### PR TITLE
Memory Mapped LoadState/SaveState

### DIFF
--- a/LLama/Native/NativeApi.cs
+++ b/LLama/Native/NativeApi.cs
@@ -116,23 +116,50 @@ namespace LLama.Native
         /// <summary>
         /// Copies the state to the specified destination address.
         /// Destination needs to have allocated enough memory.
-        /// Returns the number of bytes copied
         /// </summary>
         /// <param name="ctx"></param>
         /// <param name="dest"></param>
-        /// <returns></returns>
+        /// <returns>the number of bytes copied</returns>
         [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern ulong llama_copy_state_data(SafeLLamaContextHandle ctx, byte[] dest);
+        public static extern ulong llama_copy_state_data(SafeLLamaContextHandle ctx, byte* dest);
+
+        /// <summary>
+        /// Copies the state to the specified destination address.
+        /// Destination needs to have allocated enough memory (see llama_get_state_size)
+        /// </summary>
+        /// <param name="ctx"></param>
+        /// <param name="dest"></param>
+        /// <returns>the number of bytes copied</returns>
+        public static ulong llama_copy_state_data(SafeLLamaContextHandle ctx, byte[] dest)
+        {
+            fixed (byte* dstPtr = &dest[0])
+            {
+                return llama_copy_state_data(ctx, dstPtr);
+            }
+        }
 
         /// <summary>
         /// Set the state reading from the specified address
-        /// Returns the number of bytes read
         /// </summary>
         /// <param name="ctx"></param>
         /// <param name="src"></param>
-        /// <returns></returns>
+        /// <returns>the number of bytes read</returns>
         [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern ulong llama_set_state_data(SafeLLamaContextHandle ctx, byte[] src);
+        public static extern ulong llama_set_state_data(SafeLLamaContextHandle ctx, byte* src);
+
+        /// <summary>
+        /// Set the state reading from the specified address
+        /// </summary>
+        /// <param name="ctx"></param>
+        /// <param name="src"></param>
+        /// <returns>the number of bytes read</returns>
+        public static ulong llama_set_state_data(SafeLLamaContextHandle ctx, byte[] src)
+        {
+            fixed (byte* srcPtr = &src[0])
+            {
+                return llama_set_state_data(ctx, srcPtr);
+            }
+        }
 
         /// <summary>
         /// Load session file


### PR DESCRIPTION
Replaced `SaveState` and `LoadState` implementations. These new implementations map the file into memory and then pass the pointer directly into the native API. This improves things in a few ways:
 - Most importantly it fixes a bug: A C# array cannot exceed 2,147,483,591 bytes. In my own use of LlamaSharp I encountered this limit causing a crash.
 - This saves an extra copy of the entire state data into a C# `byte[]`, so it should be faster.
 - The file is trimmed to size, so it saves disk space.

I've included wrappers which expose the old NativeApi method signatures, so this should be a completely backwards compatible change.

This does _not_ fix some other places where `GetStateData` is used. I'll look at those in a separate PR (#57)