### PR TITLE
Larger states

### DIFF
--- a/LLama/LLamaStatelessExecutor.cs
+++ b/LLama/LLamaStatelessExecutor.cs
@@ -3,10 +3,8 @@ using LLama.Common;
 using LLama.Native;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading;
 
 namespace LLama
@@ -19,7 +17,7 @@ namespace LLama
     public class StatelessExecutor : ILLamaExecutor
     {
         private LLamaModel _model;
-        private byte[] _originalState;
+        private LLamaModel.State _originalState;
         /// <summary>
         /// The mode used by the executor when running the inference.
         /// </summary>
@@ -33,7 +31,7 @@ namespace LLama
             _model = model;
             var tokens = model.Tokenize(" ", true);
             Utils.Eval(_model.NativeHandle, tokens.ToArray(), 0, tokens.Count(), 0, _model.Params.Threads);
-            _originalState = model.GetStateData();
+            _originalState = model.GetState();
         }
 
         /// <inheritdoc />

--- a/LLama/Native/NativeApi.cs
+++ b/LLama/Native/NativeApi.cs
@@ -116,23 +116,50 @@ namespace LLama.Native
         /// <summary>
         /// Copies the state to the specified destination address.
         /// Destination needs to have allocated enough memory.
-        /// Returns the number of bytes copied
         /// </summary>
         /// <param name="ctx"></param>
         /// <param name="dest"></param>
-        /// <returns></returns>
+        /// <returns>the number of bytes copied</returns>
         [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern ulong llama_copy_state_data(SafeLLamaContextHandle ctx, byte[] dest);
+        public static extern ulong llama_copy_state_data(SafeLLamaContextHandle ctx, byte* dest);
+
+        /// <summary>
+        /// Copies the state to the specified destination address.
+        /// Destination needs to have allocated enough memory (see llama_get_state_size)
+        /// </summary>
+        /// <param name="ctx"></param>
+        /// <param name="dest"></param>
+        /// <returns>the number of bytes copied</returns>
+        public static ulong llama_copy_state_data(SafeLLamaContextHandle ctx, byte[] dest)
+        {
+            fixed (byte* dstPtr = &dest[0])
+            {
+                return llama_copy_state_data(ctx, dstPtr);
+            }
+        }
 
         /// <summary>
         /// Set the state reading from the specified address
-        /// Returns the number of bytes read
         /// </summary>
         /// <param name="ctx"></param>
         /// <param name="src"></param>
-        /// <returns></returns>
+        /// <returns>the number of bytes read</returns>
         [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern ulong llama_set_state_data(SafeLLamaContextHandle ctx, byte[] src);
+        public static extern ulong llama_set_state_data(SafeLLamaContextHandle ctx, byte* src);
+
+        /// <summary>
+        /// Set the state reading from the specified address
+        /// </summary>
+        /// <param name="ctx"></param>
+        /// <param name="src"></param>
+        /// <returns>the number of bytes read</returns>
+        public static ulong llama_set_state_data(SafeLLamaContextHandle ctx, byte[] src)
+        {
+            fixed (byte* srcPtr = &src[0])
+            {
+                return llama_set_state_data(ctx, srcPtr);
+            }
+        }
 
         /// <summary>
         /// Load session file

--- a/LLama/ResettableLLamaModel.cs
+++ b/LLama/ResettableLLamaModel.cs
@@ -13,7 +13,7 @@ namespace LLama
         /// <summary>
         /// The initial state of the model
         /// </summary>
-        public byte[] OriginalState { get; set; }
+        public State OriginalState { get; set; }
         /// <summary>
         /// 
         /// </summary>
@@ -21,7 +21,7 @@ namespace LLama
         /// <param name="encoding"></param>
         public ResettableLLamaModel(ModelParams Params, string encoding = "UTF-8") : base(Params, encoding)
         {
-            OriginalState = GetStateData();
+            OriginalState = GetState();
         }
 
         /// <summary>
@@ -30,6 +30,14 @@ namespace LLama
         public void Reset()
         {
             LoadState(OriginalState);
+        }
+
+        /// <inheritdoc />
+        public override void Dispose()
+        {
+            OriginalState.Dispose();
+
+            base.Dispose();
         }
     }
 }


### PR DESCRIPTION
This builds on my previous PR #56, review that first!

Implemented a new LlamaModel.State handle which internally stores the state as natively allocated memory. This allows it to exceed the 2GB limit on C# arrays.