### PR TITLE
Low level new loading system

### DIFF
--- a/LLama/Native/LLamaContextParams.cs
+++ b/LLama/Native/LLamaContextParams.cs
@@ -13,65 +13,101 @@ namespace LLama.Native
         /// RNG seed, -1 for random
         /// </summary>
         public int seed;
+
         /// <summary>
         /// text context
         /// </summary>
         public int n_ctx;
+
         /// <summary>
         /// prompt processing batch size
         /// </summary>
         public int n_batch;
+
+        /// <summary>
+        /// grouped-query attention (TEMP - will be moved to model hparams)
+        /// </summary>
+        public int n_gqa;
+
+        /// <summary>
+        /// rms norm epsilon (TEMP - will be moved to model hparams)
+        /// </summary>
+        float rms_norm_eps;
+
         /// <summary>
         /// number of layers to store in VRAM
         /// </summary>
         public int n_gpu_layers;
+
         /// <summary>
         /// the GPU that is used for scratch and small tensors
         /// </summary>
         public int main_gpu;
+
         /// <summary>
         /// how to split layers across multiple GPUs
         /// </summary>
         public TensorSplits tensor_split;
+
+        /// <summary>
+        /// ref: https://github.com/ggerganov/llama.cpp/pull/2054
+        /// RoPE base frequency
+        /// </summary>
+        float rope_freq_base;
+
+        /// <summary>
+        /// ref: https://github.com/ggerganov/llama.cpp/pull/2054
+        /// RoPE frequency scaling factor
+        /// </summary>
+        float rope_freq_scale; 
+
         /// <summary>
         /// called with a progress value between 0 and 1, pass NULL to disable
         /// </summary>
         public IntPtr progress_callback;
+
         /// <summary>
         /// context pointer passed to the progress callback
         /// </summary>
         public IntPtr progress_callback_user_data;
+
 
         /// <summary>
         /// if true, reduce VRAM usage at the cost of performance
         /// </summary>
         [MarshalAs(UnmanagedType.I1)]
         public bool low_vram;
+
         /// <summary>
         /// use fp16 for KV cache
         /// </summary>
         [MarshalAs(UnmanagedType.I1)]
         public bool f16_kv;
+
         /// <summary>
         /// the llama_eval() call computes all logits, not just the last one
         /// </summary>
         [MarshalAs(UnmanagedType.I1)]
         public bool logits_all;
+
         /// <summary>
         /// only load the vocabulary, no weights
         /// </summary>
         [MarshalAs(UnmanagedType.I1)] 
         public bool vocab_only;
+
         /// <summary>
         /// use mmap if possible
         /// </summary>
         [MarshalAs(UnmanagedType.I1)] 
         public bool use_mmap;
+
         /// <summary>
         /// force system to keep model in RAM
         /// </summary>
         [MarshalAs(UnmanagedType.I1)] 
         public bool use_mlock;
+
         /// <summary>
         /// embedding mode only
         /// </summary>

--- a/LLama/Native/LLamaContextParams.cs
+++ b/LLama/Native/LLamaContextParams.cs
@@ -47,7 +47,6 @@ namespace LLama.Native
         /// <summary>
         /// how to split layers across multiple GPUs
         /// </summary>
-        [MarshalAs(UnmanagedType.LPArray)]
         public float[] tensor_split;
 
         /// <summary>

--- a/LLama/Native/LLamaContextParams.cs
+++ b/LLama/Native/LLamaContextParams.cs
@@ -47,6 +47,7 @@ namespace LLama.Native
         /// <summary>
         /// how to split layers across multiple GPUs
         /// </summary>
+        [MarshalAs(UnmanagedType.LPArray)]
         public float[] tensor_split;
 
         /// <summary>

--- a/LLama/Native/NativeApi.cs
+++ b/LLama/Native/NativeApi.cs
@@ -303,5 +303,14 @@ namespace LLama.Native
         /// <returns></returns>
         [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr llama_print_system_info();
+
+        [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int llama_n_vocab_from_model(SafeLlamaModelHandle model);
+
+        [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int llama_n_ctx_from_model(SafeLlamaModelHandle model);
+
+        [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int llama_n_embd_from_model(SafeLlamaModelHandle model);
     }
 }

--- a/LLama/Native/NativeApi.cs
+++ b/LLama/Native/NativeApi.cs
@@ -314,6 +314,9 @@ namespace LLama.Native
         public static extern int llama_n_embd_from_model(SafeLlamaModelHandle model);
 
         [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern byte* llama_token_to_str_with_model(SafeLlamaModelHandle safeLlamaModelHandle, int llamaToken);
+        public static extern byte* llama_token_to_str_with_model(SafeLlamaModelHandle model, int llamaToken);
+
+        [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int llama_tokenize_with_model(SafeLlamaModelHandle model, byte* text, int* tokens, int n_max_tokens, bool add_bos);
     }
 }

--- a/LLama/Native/NativeApi.cs
+++ b/LLama/Native/NativeApi.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
 using LLama.Exceptions;
@@ -29,7 +27,7 @@ namespace LLama.Native
         }
         private const string libraryName = "libllama";
 
-        [DllImport("libllama", EntryPoint = "llama_mmap_supported", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libraryName, EntryPoint = "llama_mmap_supported", CallingConvention = CallingConvention.Cdecl)]
         public static extern bool llama_empty_call();
 
         [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
@@ -56,7 +54,10 @@ namespace LLama.Native
         /// <param name="params_"></param>
         /// <returns></returns>
         [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr llama_init_from_file(string path_model, LLamaContextParams params_);
+        public static extern IntPtr llama_load_model_from_file(string path_model, LLamaContextParams params_);
+
+        [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr llama_new_context_with_model(SafeLlamaModelHandle model, LLamaContextParams params_);
 
         /// <summary>
         /// not great API - very likely to change. 
@@ -65,6 +66,7 @@ namespace LLama.Native
         /// </summary>
         [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern void llama_backend_init(bool numa);
+
         /// <summary>
         /// Frees all allocated memory
         /// </summary>
@@ -73,19 +75,26 @@ namespace LLama.Native
         public static extern void llama_free(IntPtr ctx);
 
         /// <summary>
+        /// Frees all allocated memory associated with a model
+        /// </summary>
+        /// <param name="model"></param>
+        [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void llama_free_model(IntPtr model);
+        
+        /// <summary>
         /// Apply a LoRA adapter to a loaded model
         /// path_base_model is the path to a higher quality model to use as a base for
         /// the layers modified by the adapter. Can be NULL to use the current loaded model.
         /// The model needs to be reloaded before applying a new adapter, otherwise the adapter
         /// will be applied on top of the previous one
         /// </summary>
-        /// <param name="ctx"></param>
+        /// <param name="model_ptr"></param>
         /// <param name="path_lora"></param>
         /// <param name="path_base_model"></param>
         /// <param name="n_threads"></param>
         /// <returns>Returns 0 on success</returns>
         [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int llama_apply_lora_from_file(SafeLLamaContextHandle ctx, string path_lora, string path_base_model, int n_threads);
+        public static extern int llama_model_apply_lora_from_file(SafeLlamaModelHandle model_ptr, string path_lora, string? path_base_model, int n_threads);
 
         /// <summary>
         /// Returns the number of tokens in the KV cache

--- a/LLama/Native/NativeApi.cs
+++ b/LLama/Native/NativeApi.cs
@@ -312,5 +312,8 @@ namespace LLama.Native
 
         [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern int llama_n_embd_from_model(SafeLlamaModelHandle model);
+
+        [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern byte* llama_token_to_str_with_model(SafeLlamaModelHandle safeLlamaModelHandle, int llamaToken);
     }
 }

--- a/LLama/Native/SafeLLamaContextHandle.cs
+++ b/LLama/Native/SafeLLamaContextHandle.cs
@@ -1,26 +1,61 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Text;
+using LLama.Exceptions;
 
 namespace LLama.Native
 {
-    public class SafeLLamaContextHandle: SafeLLamaHandleBase
+    /// <summary>
+    /// A safe wrapper around a llama_context
+    /// </summary>
+    public class SafeLLamaContextHandle
+        : SafeLLamaHandleBase
     {
-        protected SafeLLamaContextHandle()
-        {
-        }
+        /// <summary>
+        /// This field guarantees that a reference to the model is held for as long as this handle is held
+        /// </summary>
+        private SafeLlamaModelHandle? _model;
 
-        public SafeLLamaContextHandle(IntPtr handle)
+        /// <summary>
+        /// Create a new SafeLLamaContextHandle
+        /// </summary>
+        /// <param name="handle">pointer to an allocated llama_context</param>
+        /// <param name="model">the model which this context was created from</param>
+        public SafeLLamaContextHandle(IntPtr handle, SafeLlamaModelHandle model)
             : base(handle)
         {
+            // Increment the model reference count while this context exists
+            _model = model;
+            var success = false;
+            _model.DangerousAddRef(ref success);
+            if (!success)
+                throw new RuntimeError("Failed to increment model refcount");
         }
 
+        /// <inheritdoc />
         protected override bool ReleaseHandle()
         {
+            // Decrement refcount on model
+            _model?.DangerousRelease();
+            _model = null;
+
             NativeApi.llama_free(handle);
             SetHandle(IntPtr.Zero);
             return true;
+        }
+
+        /// <summary>
+        /// Create a new llama_state for the given model
+        /// </summary>
+        /// <param name="model"></param>
+        /// <param name="lparams"></param>
+        /// <returns></returns>
+        /// <exception cref="RuntimeError"></exception>
+        public static SafeLLamaContextHandle Create(SafeLlamaModelHandle model, LLamaContextParams lparams)
+        {
+            var ctx_ptr = NativeApi.llama_new_context_with_model(model, lparams);
+            if (ctx_ptr == IntPtr.Zero)
+                throw new RuntimeError("Failed to create context from model");
+
+            return new(ctx_ptr, model);
         }
     }
 }

--- a/LLama/Native/SafeLLamaHandleBase.cs
+++ b/LLama/Native/SafeLLamaHandleBase.cs
@@ -1,11 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace LLama.Native
 {
-    public abstract class SafeLLamaHandleBase: SafeHandle
+    /// <summary>
+    /// Base class for all llama handles to native resources
+    /// </summary>
+    public abstract class SafeLLamaHandleBase
+        : SafeHandle
     {
         private protected SafeLLamaHandleBase()
             : base(IntPtr.Zero, ownsHandle: true)
@@ -24,8 +26,10 @@ namespace LLama.Native
             SetHandle(handle);
         }
 
+        /// <inheritdoc />
         public override bool IsInvalid => handle == IntPtr.Zero;
 
+        /// <inheritdoc />
         public override string ToString()
             => $"0x{handle.ToString("x16")}";
     }

--- a/LLama/Native/SafeLlamaModelHandle.cs
+++ b/LLama/Native/SafeLlamaModelHandle.cs
@@ -3,10 +3,13 @@ using LLama.Exceptions;
 
 namespace LLama.Native
 {
+    /// <summary>
+    /// A reference to a set of llama model weights
+    /// </summary>
     public class SafeLlamaModelHandle
         : SafeLLamaHandleBase
     {
-        public SafeLlamaModelHandle(IntPtr handle)
+        internal SafeLlamaModelHandle(IntPtr handle)
             : base(handle)
         {
         }
@@ -19,10 +22,17 @@ namespace LLama.Native
             return true;
         }
 
+        /// <summary>
+        /// Load a model from the given file path into memory
+        /// </summary>
+        /// <param name="modelPath"></param>
+        /// <param name="lparams"></param>
+        /// <returns></returns>
+        /// <exception cref="RuntimeError"></exception>
         public static SafeLlamaModelHandle LoadFromFile(string modelPath, LLamaContextParams lparams)
         {
             var model_ptr = NativeApi.llama_load_model_from_file(modelPath, lparams);
-            if (model_ptr == null)
+            if (model_ptr == IntPtr.Zero)
                 throw new RuntimeError($"Failed to load model {modelPath}.");
 
             return new SafeLlamaModelHandle(model_ptr);

--- a/LLama/Native/SafeLlamaModelHandle.cs
+++ b/LLama/Native/SafeLlamaModelHandle.cs
@@ -15,8 +15,14 @@ namespace LLama.Native
         /// </summary>
         public int VocabCount { get; set; }
 
+        /// <summary>
+        /// Total number of tokens in the context
+        /// </summary>
         public int ContextSize { get; set; }
 
+        /// <summary>
+        /// Dimension of embedding vectors
+        /// </summary>
         public int EmbeddingCount { get; set; }
 
         internal SafeLlamaModelHandle(IntPtr handle)

--- a/LLama/Native/SafeLlamaModelHandle.cs
+++ b/LLama/Native/SafeLlamaModelHandle.cs
@@ -9,9 +9,21 @@ namespace LLama.Native
     public class SafeLlamaModelHandle
         : SafeLLamaHandleBase
     {
+        /// <summary>
+        /// Total number of tokens in vocabulary of this model
+        /// </summary>
+        public int VocabCount { get; set; }
+
+        public int ContextSize { get; set; }
+
+        public int EmbeddingCount { get; set; }
+
         internal SafeLlamaModelHandle(IntPtr handle)
             : base(handle)
         {
+            VocabCount = NativeApi.llama_n_vocab_from_model(this);
+            ContextSize = NativeApi.llama_n_ctx_from_model(this);
+            EmbeddingCount = NativeApi.llama_n_embd_from_model(this);
         }
 
         /// <inheritdoc />

--- a/LLama/Native/SafeLlamaModelHandle.cs
+++ b/LLama/Native/SafeLlamaModelHandle.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Drawing;
 using System.Text;
 using LLama.Exceptions;
 

--- a/LLama/Native/SafeLlamaModelHandle.cs
+++ b/LLama/Native/SafeLlamaModelHandle.cs
@@ -37,5 +37,26 @@ namespace LLama.Native
 
             return new SafeLlamaModelHandle(model_ptr);
         }
+
+        /// <summary>
+        /// Apply a LoRA adapter to a loaded model
+        /// </summary>
+        /// <param name="lora"></param>
+        /// <param name="modelBase">A path to a higher quality model to use as a base for the layers modified by the
+        /// adapter. Can be NULL to use the current loaded model.</param>
+        /// <param name="threads"></param>
+        /// <exception cref="RuntimeError"></exception>
+        public void ApplyLoraFromFile(string lora, string? modelBase = null, int threads = -1)
+        {
+            var err = NativeApi.llama_model_apply_lora_from_file(
+                this,
+                lora,
+                string.IsNullOrEmpty(modelBase) ? null : modelBase,
+                threads
+            );
+
+            if (err != 0)
+                throw new RuntimeError("Failed to apply lora adapter.");
+        }
     }
 }

--- a/LLama/Native/SafeLlamaModelHandle.cs
+++ b/LLama/Native/SafeLlamaModelHandle.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using LLama.Exceptions;
+
+namespace LLama.Native
+{
+    public class SafeLlamaModelHandle
+        : SafeLLamaHandleBase
+    {
+        public SafeLlamaModelHandle(IntPtr handle)
+            : base(handle)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override bool ReleaseHandle()
+        {
+            NativeApi.llama_free_model(handle);
+            SetHandle(IntPtr.Zero);
+            return true;
+        }
+
+        public static SafeLlamaModelHandle LoadFromFile(string modelPath, LLamaContextParams lparams)
+        {
+            var model_ptr = NativeApi.llama_load_model_from_file(modelPath, lparams);
+            if (model_ptr == null)
+                throw new RuntimeError($"Failed to load model {modelPath}.");
+
+            return new SafeLlamaModelHandle(model_ptr);
+        }
+    }
+}

--- a/LLama/OldVersion/Utils.cs
+++ b/LLama/OldVersion/Utils.cs
@@ -35,14 +35,8 @@ namespace LLama.OldVersion
             var ctx = SafeLLamaContextHandle.Create(model, lparams);
 
             if (!string.IsNullOrEmpty(@params.lora_adapter))
-            {
-                int err = NativeApi.llama_model_apply_lora_from_file(model, @params.lora_adapter,
-                    string.IsNullOrEmpty(@params.lora_base) ? null : @params.lora_base, @params.n_threads);
-                if (err != 0)
-                {
-                    throw new RuntimeError("Failed to apply lora adapter.");
-                }
-            }
+                model.ApplyLoraFromFile(@params.lora_adapter, @params.lora_base, @params.n_threads);
+
             return ctx;
         }
 

--- a/LLama/OldVersion/Utils.cs
+++ b/LLama/OldVersion/Utils.cs
@@ -31,18 +31,12 @@ namespace LLama.OldVersion
                 throw new FileNotFoundException($"The model file does not exist: {@params.model}");
             }
 
-            var ctx_ptr = NativeApi.llama_init_from_file(@params.model, lparams);
-
-            if (ctx_ptr == IntPtr.Zero)
-            {
-                throw new RuntimeError($"Failed to load model {@params.model}.");
-            }
-
-            SafeLLamaContextHandle ctx = new(ctx_ptr);
+            var model = SafeLlamaModelHandle.LoadFromFile(@params.model, lparams);
+            var ctx = SafeLLamaContextHandle.Create(model, lparams);
 
             if (!string.IsNullOrEmpty(@params.lora_adapter))
             {
-                int err = NativeApi.llama_apply_lora_from_file(ctx, @params.lora_adapter,
+                int err = NativeApi.llama_model_apply_lora_from_file(model, @params.lora_adapter,
                     string.IsNullOrEmpty(@params.lora_base) ? null : @params.lora_base, @params.n_threads);
                 if (err != 0)
                 {

--- a/LLama/Utils.cs
+++ b/LLama/Utils.cs
@@ -48,19 +48,8 @@ namespace LLama
             var ctx = SafeLLamaContextHandle.Create(model, lparams);
 
             if (!string.IsNullOrEmpty(@params.LoraAdapter))
-            {
-                var err = NativeApi.llama_model_apply_lora_from_file(
-                    model,
-                    @params.LoraAdapter,
-                    string.IsNullOrEmpty(@params.LoraBase) ? null : @params.LoraBase,
-                    @params.Threads
-                );
+                model.ApplyLoraFromFile(@params.LoraAdapter, @params.LoraBase, @params.Threads);
 
-                if (err != 0)
-                {
-                    throw new RuntimeError("Failed to apply lora adapter.");
-                }
-            }
             return ctx;
         }
 


### PR DESCRIPTION
Updated to use the new loading system in llama (llama_state). This new system has split model weights and contexts into two separate things, allowing one set of weights to be shared between many contexts.

This PR does **not** try to take advantage of this new capability in any way! It's just implementing the smallest change to the low level API. In future PRs I think we'll want to make quite extensive changes to the API (especially with state management).

This is built upon [llama.cpp `468ea24`](https://github.com/ggerganov/llama.cpp/releases/tag/master-468ea24), necessary DLLs are **NOT** included in this PR. I don't know how to build them all and assumed you'd rather add them yourself anyway (as a matter of security).

Edit: I've expanded the `SafeLlamaModelHandle` to include methods for all the things you can do with a `llama_model`. Most of these are not used yet, since we'll need to decide how to expose this to the higher level API.