### PR TITLE
CPU Feature Detection

### DIFF
--- a/LLama/Native/NativeApi.cs
+++ b/LLama/Native/NativeApi.cs
@@ -55,13 +55,13 @@ namespace LLama.Native
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // All of the Windows libraries, in order of preference
-                return TryLoad("win-cuda12/libllama.dll")
-                    ?? TryLoad("win-cuda11/libllama.dll")
+                return TryLoad("win/cu12.1.0/libllama.dll")
+                    ?? TryLoad("win/cu11.7.1/libllama.dll")
 #if NET8_0_OR_GREATER
-                    ?? TryLoad("win-avx512/libllama.dll", System.Runtime.Intrinsics.X86.Avx512.IsSupported)
+                    ?? TryLoad("win/avx512/libllama.dll", System.Runtime.Intrinsics.X86.Avx512.IsSupported)
 #endif
-                    ?? TryLoad("win-avx2/libllama.dll", System.Runtime.Intrinsics.X86.Avx2.IsSupported)
-                    ?? TryLoad("win-avx/libllama.dll", System.Runtime.Intrinsics.X86.Avx.IsSupported)
+                    ?? TryLoad("win/avx2/libllama.dll", System.Runtime.Intrinsics.X86.Avx2.IsSupported)
+                    ?? TryLoad("win/avx/libllama.dll", System.Runtime.Intrinsics.X86.Avx.IsSupported)
                     ?? IntPtr.Zero;
             }
 

--- a/LLama/Native/NativeApi.cs
+++ b/LLama/Native/NativeApi.cs
@@ -55,19 +55,27 @@ namespace LLama.Native
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // All of the Windows libraries, in order of preference
-                return TryLoad("win/cu12.1.0/libllama.dll")
-                    ?? TryLoad("win/cu11.7.1/libllama.dll")
+                return TryLoad("cu12.1.0/libllama.dll")
+                    ?? TryLoad("cu11.7.1/libllama.dll")
 #if NET8_0_OR_GREATER
-                    ?? TryLoad("win/avx512/libllama.dll", System.Runtime.Intrinsics.X86.Avx512.IsSupported)
+                    ?? TryLoad("avx512/libllama.dll", System.Runtime.Intrinsics.X86.Avx512.IsSupported)
 #endif
-                    ?? TryLoad("win/avx2/libllama.dll", System.Runtime.Intrinsics.X86.Avx2.IsSupported)
-                    ?? TryLoad("win/avx/libllama.dll", System.Runtime.Intrinsics.X86.Avx.IsSupported)
+                    ?? TryLoad("avx2/libllama.dll", System.Runtime.Intrinsics.X86.Avx2.IsSupported)
+                    ?? TryLoad("avx/libllama.dll", System.Runtime.Intrinsics.X86.Avx.IsSupported)
                     ?? IntPtr.Zero;
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                return IntPtr.Zero;
+                // All of the Linux libraries, in order of preference
+                return TryLoad("cu12.1.0/libllama.so")
+                    ?? TryLoad("cu11.7.1/libllama.so")
+#if NET8_0_OR_GREATER
+                    ?? TryLoad("avx512/libllama.so", System.Runtime.Intrinsics.X86.Avx512.IsSupported)
+#endif
+                    ?? TryLoad("avx2/libllama.so", System.Runtime.Intrinsics.X86.Avx2.IsSupported)
+                    ?? TryLoad("avx/libllama.so", System.Runtime.Intrinsics.X86.Avx.IsSupported)
+                    ?? IntPtr.Zero;
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))


### PR DESCRIPTION
### Motivation

During testing I noticed that the avx512 libllama.dll which I was using seemed to be _much_ faster than the default CPU backend.

### Proposed Change

This draft PR is a demonstration of a new way to load the native dependencies which we could use. This system performs feature detection on the CPU and then loads up the best DLL that the CPU can run. It is only written for Windows at the moment, but it could easily be extended to other platforms.

### Why Is This A Draft?

Using this would require some modification to the backend package which I don't know how to do:

Modify the `LLamaSharp.Backend.Cpu` to contain three folders:
 - `win-avx512/libllama.dll`
 - `win-avx2/libllama.dll`
 - `win-avx/libllama.dll`
 - `libllama.dll` - whatever the most basic default should be (no e.g. AVX support at all?)

Modify `LLamaSharp.Backend.Cuda11` to contain:
 - `win-cuda11/libllama.dll`

Modify `LLamaSharp.Backend.Cuda12` to contain:
 - `win-cuda12/libllama.dll`