### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,26 +17,32 @@ jobs:
           - build: linux-debug
             os: ubuntu-latest
             config: debug
+            dotnet: 6.0.x
           - build: linux-release
             os: ubuntu-latest
             config: release
+            dotnet: 6.0.x
           - build: macos-debug
             os: macos-latest
             config: debug
+            dotnet: 6.0.x
           - build: macos-release
             os: macos-latest
             config: release
+            dotnet: 6.0.x
           - build: windows-debug
             os: windows-2019
             config: debug
+            dotnet: 6.0.x
           - build: windows-release
             os: windows-2019
             config: release
+            dotnet: 6.0.x
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '7.0.x'
+        dotnet-version: ${{ matrix.dotnet }}
     #  workaround for actions/setup-dotnet#155
     - name: Clear package cache
       run: dotnet clean LLamaSharp.sln && dotnet nuget locals all --clear

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,11 +35,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 7.0.x
+        with:
+            dotnet-version: | 
+                6.0.x
+                7.0.x
     #  workaround for actions/setup-dotnet#155
     - name: Clear package cache
       run: dotnet clean LLamaSharp.sln && dotnet nuget locals all --clear

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,48 @@
+name: CI
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [linux-debug, linux-release, macos-debug, macos-release, windows-debug, windows-release]
+        include:
+          - build: linux-debug
+            os: ubuntu-latest
+            config: debug
+          - build: linux-release
+            os: ubuntu-latest
+            config: release
+          - build: macos-debug
+            os: macos-latest
+            config: debug
+          - build: macos-release
+            os: macos-latest
+            config: release
+          - build: windows-debug
+            os: windows-2019
+            config: debug
+          - build: windows-release
+            os: windows-2019
+            config: release
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '7.0.x'
+    #  workaround for actions/setup-dotnet#155
+    - name: Clear package cache
+      run: dotnet clean LlamaSharp.sln && dotnet nuget locals all --clear
+    - name: Restore packages
+      run: dotnet restore LlamaSharp.sln
+    - name: Build
+      run: dotnet build LlamaSharp.sln -c ${{ matrix.config }} --no-restore
+    - name: Test
+      run: dotnet test LlamaSharp.sln -c ${{ matrix.config }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,32 +17,29 @@ jobs:
           - build: linux-debug
             os: ubuntu-latest
             config: debug
-            dotnet: 6.0.x
           - build: linux-release
             os: ubuntu-latest
             config: release
-            dotnet: 6.0.x
           - build: macos-debug
             os: macos-latest
             config: debug
-            dotnet: 6.0.x
           - build: macos-release
             os: macos-latest
             config: release
-            dotnet: 6.0.x
           - build: windows-debug
             os: windows-2019
             config: debug
-            dotnet: 6.0.x
           - build: windows-release
             os: windows-2019
             config: release
-            dotnet: 6.0.x
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: ${{ matrix.dotnet }}
+        dotnet-version: 6.0.x
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 7.0.x
     #  workaround for actions/setup-dotnet#155
     - name: Clear package cache
       run: dotnet clean LLamaSharp.sln && dotnet nuget locals all --clear

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,10 +39,10 @@ jobs:
         dotnet-version: '7.0.x'
     #  workaround for actions/setup-dotnet#155
     - name: Clear package cache
-      run: dotnet clean LlamaSharp.sln && dotnet nuget locals all --clear
+      run: dotnet clean LLamaSharp.sln && dotnet nuget locals all --clear
     - name: Restore packages
-      run: dotnet restore LlamaSharp.sln
+      run: dotnet restore LLamaSharp.sln
     - name: Build
-      run: dotnet build LlamaSharp.sln -c ${{ matrix.config }} --no-restore
+      run: dotnet build LLamaSharp.sln -c ${{ matrix.config }} --no-restore
     - name: Test
-      run: dotnet test LlamaSharp.sln -c ${{ matrix.config }}
+      run: dotnet test LLamaSharp.sln -c ${{ matrix.config }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,11 @@ jobs:
         dotnet-version: | 
           6.0.x
           7.0.x
+    - name: Cache Gradle packages
+      uses: actions/cache@v3
+      with:
+        key: "unit_test_models"
+        path: LLama.Unittest/Models
     #  workaround for actions/setup-dotnet#155
     - name: Clear package cache
       run: dotnet clean LLamaSharp.sln && dotnet nuget locals all --clear

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,10 +35,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-dotnet@v1
-        with:
-            dotnet-version: | 
-                6.0.x
-                7.0.x
+      with:
+        dotnet-version: | 
+          6.0.x
+          7.0.x
     #  workaround for actions/setup-dotnet#155
     - name: Clear package cache
       run: dotnet clean LLamaSharp.sln && dotnet nuget locals all --clear

--- a/.gitignore
+++ b/.gitignore
@@ -342,3 +342,4 @@ test/TensorFlowNET.Examples/mnist
 
 # docs
 site/
+/LLama.Unittest/Models/*.bin

--- a/LLama.Unittest/BasicTest.cs
+++ b/LLama.Unittest/BasicTest.cs
@@ -1,11 +1,14 @@
+using LLama.Common;
+
 namespace LLama.Unittest
 {
     public class BasicTest
     {
         [Fact]
-        public void SimpleQA()
+        public void LoadModel()
         {
-            
+            var model = new LLamaModel(new ModelParams("Models/llama-2-7b-chat.ggmlv3.q3_K_S.bin", contextSize: 256));
+            model.Dispose();
         }
     }
 }

--- a/LLama.Unittest/LLama.Unittest.csproj
+++ b/LLama.Unittest/LLama.Unittest.csproj
@@ -23,8 +23,23 @@
     </PackageReference>
   </ItemGroup>
 
+  <Target Name="DownloadContentFiles" BeforeTargets="Build">
+      <DownloadFile SourceUrl="https://huggingface.co/TheBloke/Llama-2-7B-Chat-GGML/resolve/main/llama-2-7b-chat.ggmlv3.q3_K_S.bin" DestinationFolder="Models" DestinationFileName="llama-2-7b-chat.ggmlv3.q3_K_S.bin" SkipUnchangedFiles="true">
+    </DownloadFile>
+  </Target>
+
   <ItemGroup>
     <ProjectReference Include="..\LLama\LLamaSharp.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Models\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Models\llama-2-7b-chat.ggmlv3.q3_K_S.bin">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/LLama/Common/FixedSizeQueue.cs
+++ b/LLama/Common/FixedSizeQueue.cs
@@ -30,9 +30,11 @@ namespace LLama.Common
         /// <param name="data"></param>
         public FixedSizeQueue(int size, IEnumerable<T> data)
         {
+#if NETCOREAPP3_0_OR_GREATER
             // Try an early check on the amount of data supplied (if possible)
             if (data.TryGetNonEnumeratedCount(out var count) && count > size)
                 throw new ArgumentException($"The max size set for the quene is {size}, but got {count} initial values.");
+#endif
 
             // Size of "data" is unknown, copy it all into a list
             _maxSize = size;
@@ -40,7 +42,7 @@ namespace LLama.Common
 
             // Now check if that list is a valid size
             if (_storage.Count > _maxSize)
-                throw new ArgumentException($"The max size set for the quene is {size}, but got {count} initial values.");
+                throw new ArgumentException($"The max size set for the quene is {size}, but got {_storage.Count} initial values.");
         }
 
         /// <summary>


### PR DESCRIPTION
Added some simple CI which builds the project and runs tests in debug and release mode on Linux, Windows and MacOS.

I've added an action to download a model into the test project as part of the build. This file is **not** comitted to the repo, but it's cached in the CI so it should be fast after the first time.

This also incorporates a fix to the netstandard2.0 build (formerly #73) so that the CI doesn't immediately fail!