### PR TITLE
Utils Cleanup

### DIFF
--- a/LLama/LLamaEmbedder.cs
+++ b/LLama/LLamaEmbedder.cs
@@ -55,7 +55,7 @@ namespace LLama
                 text = text.Insert(0, " ");
             }
 
-            var embed_inp_array = Utils.Tokenize(_ctx, text, addBos, Encoding.GetEncoding(encoding)).ToArray();
+            var embed_inp_array = _ctx.Tokenize(text, addBos, Encoding.GetEncoding(encoding));
 
             // TODO(Rinne): deal with log of prompt
 

--- a/LLama/LLamaInstructExecutor.cs
+++ b/LLama/LLamaInstructExecutor.cs
@@ -30,8 +30,8 @@ namespace LLama
         public InstructExecutor(LLamaModel model, string instructionPrefix = "\n\n### Instruction:\n\n",
             string instructionSuffix = "\n\n### Response:\n\n") : base(model)
         {
-            _inp_pfx = _model.Tokenize(instructionPrefix, true).ToArray();
-            _inp_sfx = _model.Tokenize(instructionSuffix, false).ToArray();
+            _inp_pfx = _model.Tokenize(instructionPrefix, true);
+            _inp_sfx = _model.Tokenize(instructionSuffix, false);
             _instructionPrefix = instructionPrefix;
         }
 
@@ -133,7 +133,7 @@ namespace LLama
 
                 _embed_inps.AddRange(_inp_sfx);
 
-                args.RemainedTokens -= line_inp.Count();
+                args.RemainedTokens -= line_inp.Length;
             }
         }
         /// <inheritdoc />

--- a/LLama/LLamaInstructExecutor.cs
+++ b/LLama/LLamaInstructExecutor.cs
@@ -146,9 +146,7 @@ namespace LLama
                 {
                     string last_output = "";
                     foreach (var id in _last_n_tokens)
-                    {
-                        last_output += Utils.PtrToString(NativeApi.llama_token_to_str(_model.NativeHandle, id), _model.Encoding);
-                    }
+                        last_output += _model.NativeHandle.TokenToString(id, _model.Encoding);
 
                     foreach (var antiprompt in args.Antiprompts)
                     {

--- a/LLama/LLamaInteractExecutor.cs
+++ b/LLama/LLamaInteractExecutor.cs
@@ -133,7 +133,7 @@ namespace LLama
                     string last_output = "";
                     foreach (var id in _last_n_tokens)
                     {
-                        last_output += Utils.PtrToString(NativeApi.llama_token_to_str(_model.NativeHandle, id), _model.Encoding);
+                        last_output += _model.NativeHandle.TokenToString(id, _model.Encoding);
                     }
 
                     foreach (var antiprompt in args.Antiprompts)

--- a/LLama/LLamaInteractExecutor.cs
+++ b/LLama/LLamaInteractExecutor.cs
@@ -25,7 +25,7 @@ namespace LLama
         /// <param name="model"></param>
         public InteractiveExecutor(LLamaModel model) : base(model)
         {
-            _llama_token_newline = Utils.Tokenize(_model.NativeHandle, "\n", false, _model.Encoding).ToArray();
+            _llama_token_newline = _model.NativeHandle.Tokenize("\n", false, _model.Encoding);
         }
 
         /// <inheritdoc />
@@ -114,7 +114,7 @@ namespace LLama
                 }
                 var line_inp = _model.Tokenize(text, false);
                 _embed_inps.AddRange(line_inp);
-                args.RemainedTokens -= line_inp.Count();
+                args.RemainedTokens -= line_inp.Length;
             }
         }
 

--- a/LLama/LLamaModel.cs
+++ b/LLama/LLamaModel.cs
@@ -64,10 +64,9 @@ namespace LLama
         /// <param name="text"></param>
         /// <param name="addBos">Whether to add a bos to the text.</param>
         /// <returns></returns>
-        public IEnumerable<llama_token> Tokenize(string text, bool addBos = true)
+        public llama_token[] Tokenize(string text, bool addBos = true)
         {
-            // TODO: reconsider whether to convert to array here.
-            return Utils.Tokenize(_ctx, text, addBos, _encoding);
+            return _ctx.Tokenize(text, addBos, _encoding);
         }
 
         /// <summary>

--- a/LLama/LLamaModel.cs
+++ b/LLama/LLamaModel.cs
@@ -335,7 +335,7 @@ namespace LLama
                     n_eval = Params.BatchSize;
                 }
 
-                if(Utils.Eval(_ctx, tokens, i, n_eval, pastTokensCount, Params.Threads) != 0)
+                if (!_ctx.Eval(tokens.AsMemory(i, n_eval), pastTokensCount, Params.Threads))
                 {
                     _logger?.Log(nameof(LLamaModel), "Failed to eval.", ILLamaLogger.LogLevel.Error);
                     throw new RuntimeError("Failed to eval.");

--- a/LLama/LLamaModel.cs
+++ b/LLama/LLamaModel.cs
@@ -78,9 +78,7 @@ namespace LLama
         {
             StringBuilder sb = new();
             foreach(var token in tokens)
-            {
-                sb.Append(Utils.PtrToString(NativeApi.llama_token_to_str(_ctx, token), _encoding));
-            }
+                sb.Append(_ctx.TokenToString(token, _encoding));
             return sb.ToString();
         }
 
@@ -352,9 +350,7 @@ namespace LLama
         internal IEnumerable<string> GenerateResult(IEnumerable<llama_token> ids)
         {
             foreach(var id in ids)
-            {
-                yield return Utils.TokenToString(id, _ctx, _encoding);
-            }
+                yield return _ctx.TokenToString(id, _encoding);
         }
 
         /// <inheritdoc />

--- a/LLama/LLamaModel.cs
+++ b/LLama/LLamaModel.cs
@@ -284,8 +284,8 @@ namespace LLama
             int repeatLastTokensCount = 64, float repeatPenalty = 1.1f, float alphaFrequency = .0f, float alphaPresence = .0f, 
             bool penalizeNL = true)
         {
-            var n_vocab = NativeApi.llama_n_vocab(_ctx);
-            var logits = Utils.GetLogits(_ctx, n_vocab);
+            var n_vocab = _ctx.VocabCount;
+            var logits = _ctx.GetLogits();
 
             // Apply params.logit_bias map
             if(logitBias is not null)

--- a/LLama/LLamaStatelessExecutor.cs
+++ b/LLama/LLamaStatelessExecutor.cs
@@ -31,7 +31,7 @@ namespace LLama
             _model = model;
             
             var tokens = model.Tokenize(" ", true).ToArray();
-            Utils.Eval(_model.NativeHandle, tokens, 0, tokens.Length, 0, _model.Params.Threads);
+            _model.NativeHandle.Eval(tokens.AsMemory(0, tokens.Length), 0, _model.Params.Threads);
             _originalState = model.GetState();
         }
 
@@ -52,7 +52,7 @@ namespace LLama
             List<llama_token> tokens = _model.Tokenize(text, true).ToList();
             int n_prompt_tokens = tokens.Count;
 
-            Utils.Eval(_model.NativeHandle, tokens.ToArray(), 0, n_prompt_tokens, n_past, _model.Params.Threads);
+            _model.NativeHandle.Eval(tokens.ToArray().AsMemory(0, n_prompt_tokens), n_past, _model.Params.Threads);
 
             lastTokens.AddRange(tokens);
             n_past += n_prompt_tokens;

--- a/LLama/LLamaStatelessExecutor.cs
+++ b/LLama/LLamaStatelessExecutor.cs
@@ -76,7 +76,7 @@ namespace LLama
 
                 lastTokens.Add(id);
 
-                string response = Utils.TokenToString(id, _model.NativeHandle, _model.Encoding);
+                string response = _model.NativeHandle.TokenToString(id, _model.Encoding);
                 yield return response;
 
                 tokens.Clear();

--- a/LLama/LLamaStatelessExecutor.cs
+++ b/LLama/LLamaStatelessExecutor.cs
@@ -87,7 +87,7 @@ namespace LLama
                     string last_output = "";
                     foreach (var token in lastTokens)
                     {
-                        last_output += Utils.PtrToString(NativeApi.llama_token_to_str(_model.NativeHandle, id), _model.Encoding);
+                        last_output += _model.NativeHandle.TokenToString(id, _model.Encoding);
                     }
 
                     bool should_break = false;

--- a/LLama/LLamaStatelessExecutor.cs
+++ b/LLama/LLamaStatelessExecutor.cs
@@ -87,7 +87,7 @@ namespace LLama
                     string last_output = "";
                     foreach (var token in lastTokens)
                     {
-                        last_output += _model.NativeHandle.TokenToString(id, _model.Encoding);
+                        last_output += _model.NativeHandle.TokenToString(token, _model.Encoding);
                     }
 
                     bool should_break = false;

--- a/LLama/Native/NativeApi.cs
+++ b/LLama/Native/NativeApi.cs
@@ -257,8 +257,8 @@ namespace LLama.Native
         /// <summary>
         /// Token logits obtained from the last call to llama_eval()
         /// The logits for the last token are stored in the last row
-        /// Can be mutated in order to change the probabilities of the next token
-        /// Rows: n_tokens
+        /// Can be mutated in order to change the probabilities of the next token.<br />
+        /// Rows: n_tokens<br />
         /// Cols: n_vocab
         /// </summary>
         /// <param name="ctx"></param>

--- a/LLama/Native/NativeApi.cs
+++ b/LLama/Native/NativeApi.cs
@@ -207,6 +207,17 @@ namespace LLama.Native
         [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern int llama_eval(SafeLLamaContextHandle ctx, llama_token[] tokens, int n_tokens, int n_past, int n_threads);
 
+        /// <summary>
+        /// Run the llama inference to obtain the logits and probabilities for the next token.
+        /// tokens + n_tokens is the provided batch of new tokens to process
+        /// n_past is the number of tokens to use from previous eval calls
+        /// </summary>
+        /// <param name="ctx"></param>
+        /// <param name="tokens"></param>
+        /// <param name="n_tokens"></param>
+        /// <param name="n_past"></param>
+        /// <param name="n_threads"></param>
+        /// <returns>Returns 0 on success</returns>
         [DllImport(libraryName, EntryPoint = "llama_eval", CallingConvention = CallingConvention.Cdecl)]
         public static extern int llama_eval_with_pointer(SafeLLamaContextHandle ctx, llama_token* tokens, int n_tokens, int n_past, int n_threads);
 

--- a/LLama/Native/NativeApi.cs
+++ b/LLama/Native/NativeApi.cs
@@ -218,6 +218,7 @@ namespace LLama.Native
         /// </summary>
         /// <param name="ctx"></param>
         /// <param name="text"></param>
+        /// <param name="encoding"></param>
         /// <param name="tokens"></param>
         /// <param name="n_max_tokens"></param>
         /// <param name="add_bos"></param>

--- a/LLama/Native/SafeLLamaContextHandle.cs
+++ b/LLama/Native/SafeLLamaContextHandle.cs
@@ -169,5 +169,21 @@ namespace LLama.Native
         {
             return ThrowIfDisposed().TokenToSpan(token);
         }
+
+        /// <summary>
+        /// Run the llama inference to obtain the logits and probabilities for the next token.
+        /// </summary>
+        /// <param name="tokens">The provided batch of new tokens to process</param>
+        /// <param name="n_past">the number of tokens to use from previous eval calls</param>
+        /// <param name="n_threads"></param>
+        /// <returns>Returns true on success</returns>
+        public bool Eval(Memory<int> tokens, int n_past, int n_threads)
+        {
+            using var pin = tokens.Pin();
+            unsafe
+            {
+                return NativeApi.llama_eval_with_pointer(this, (int*)pin.Pointer, tokens.Length, n_past, n_threads) == 0;
+            }
+        }
     }
 }

--- a/LLama/Native/SafeLLamaContextHandle.cs
+++ b/LLama/Native/SafeLLamaContextHandle.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Buffers;
+using System.Text;
 using LLama.Exceptions;
 
 namespace LLama.Native
@@ -56,6 +58,44 @@ namespace LLama.Native
                 throw new RuntimeError("Failed to create context from model");
 
             return new(ctx_ptr, model);
+        }
+
+        /// <summary>
+        /// Convert the given text into tokens
+        /// </summary>
+        /// <param name="text">The text to tokenize</param>
+        /// <param name="add_bos">Whether the "BOS" token should be added</param>
+        /// <param name="encoding">Encoding to use for the text</param>
+        /// <returns></returns>
+        /// <exception cref="RuntimeError"></exception>
+        public int[] Tokenize(string text, bool add_bos, Encoding encoding)
+        {
+            // Calculate number of bytes in string, this is a pessimistic estimate of token count. It can't
+            // possibly be more than this.
+            var count = encoding.GetByteCount(text) + (add_bos ? 1 : 0);
+
+            // "Rent" an array to write results into (avoiding an allocation of a large array)
+            var temporaryArray = ArrayPool<int>.Shared.Rent(count);
+            try
+            {
+                // Do the actual conversion
+                var n = NativeApi.llama_tokenize(this, text, encoding, temporaryArray, count, add_bos);
+                if (n < 0)
+                {
+                    throw new RuntimeError("Error happened during tokenization. It's possibly caused by wrong encoding. Please try to " +
+                                           "specify the encoding.");
+                }
+
+                // Copy the results from the rented into an array which is exactly the right size
+                var result = new int[n];
+                Array.ConstrainedCopy(temporaryArray, 0, result, 0, n);
+
+                return result;
+            }
+            finally
+            {
+                ArrayPool<int>.Shared.Return(temporaryArray);
+            }
         }
     }
 }

--- a/LLama/Native/SafeLLamaContextHandle.cs
+++ b/LLama/Native/SafeLLamaContextHandle.cs
@@ -148,5 +148,26 @@ namespace LLama.Native
                 return new Span<float>(logits, model.VocabCount);
             }
         }
+
+        /// <summary>
+        /// Convert a token into a string
+        /// </summary>
+        /// <param name="token"></param>
+        /// <param name="encoding"></param>
+        /// <returns></returns>
+        public string TokenToString(int token, Encoding encoding)
+        {
+            return ThrowIfDisposed().TokenToString(token, encoding);
+        }
+
+        /// <summary>
+        /// Convert a token into a span of bytes that could be decoded into a string
+        /// </summary>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        public ReadOnlySpan<byte> TokenToSpan(int token)
+        {
+            return ThrowIfDisposed().TokenToSpan(token);
+        }
     }
 }

--- a/LLama/Native/SafeLlamaModelHandle.cs
+++ b/LLama/Native/SafeLlamaModelHandle.cs
@@ -13,17 +13,17 @@ namespace LLama.Native
         /// <summary>
         /// Total number of tokens in vocabulary of this model
         /// </summary>
-        public int VocabCount { get; set; }
+        public int VocabCount { get; }
 
         /// <summary>
         /// Total number of tokens in the context
         /// </summary>
-        public int ContextSize { get; set; }
+        public int ContextSize { get; }
 
         /// <summary>
         /// Dimension of embedding vectors
         /// </summary>
-        public int EmbeddingCount { get; set; }
+        public int EmbeddingCount { get; }
 
         internal SafeLlamaModelHandle(IntPtr handle)
             : base(handle)

--- a/LLama/Utils.cs
+++ b/LLama/Utils.cs
@@ -33,10 +33,13 @@ namespace LLama
             return ctx.Tokenize(text, add_bos, encoding);
         }
 
-        public static unsafe Span<float> GetLogits(SafeLLamaContextHandle ctx, int length)
+        [Obsolete("Use SafeLLamaContextHandle GetLogits method instead")]
+        public static Span<float> GetLogits(SafeLLamaContextHandle ctx, int length)
         {
-            var logits = NativeApi.llama_get_logits(ctx);
-            return new Span<float>(logits, length);
+            if (length != ctx.VocabCount)
+                throw new ArgumentException("length must be the VocabSize");
+
+            return ctx.GetLogits();
         }
 
         public static unsafe int Eval(SafeLLamaContextHandle ctx, llama_token[] tokens, int startIndex, int n_tokens, int n_past, int n_threads)

--- a/LLama/Utils.cs
+++ b/LLama/Utils.cs
@@ -43,14 +43,11 @@ namespace LLama
             return ctx.GetLogits();
         }
 
-        public static unsafe int Eval(SafeLLamaContextHandle ctx, llama_token[] tokens, int startIndex, int n_tokens, int n_past, int n_threads)
+        [Obsolete("Use SafeLLamaContextHandle Eval method instead")]
+        public static int Eval(SafeLLamaContextHandle ctx, llama_token[] tokens, int startIndex, int n_tokens, int n_past, int n_threads)
         {
-            int result;
-            fixed(llama_token* p = tokens)
-            {
-                result = NativeApi.llama_eval_with_pointer(ctx, p + startIndex, n_tokens, n_past, n_threads);
-            }
-            return result;
+            var slice = tokens.AsMemory().Slice(startIndex, n_tokens);
+            return ctx.Eval(slice, n_past, n_threads) ? 0 : 1;
         }
 
         [Obsolete("Use SafeLLamaContextHandle TokenToString method instead")]

--- a/LLama/Utils.cs
+++ b/LLama/Utils.cs
@@ -27,17 +27,10 @@ namespace LLama
             }
         }
 
+        [Obsolete("Use SafeLLamaContextHandle Tokenize method instead")]
         public static IEnumerable<llama_token> Tokenize(SafeLLamaContextHandle ctx, string text, bool add_bos, Encoding encoding)
         {
-            var cnt = encoding.GetByteCount(text);
-            llama_token[] res = new llama_token[cnt + (add_bos ? 1 : 0)];
-            int n = NativeApi.llama_tokenize(ctx, text, encoding, res, res.Length, add_bos);
-            if (n < 0)
-            {
-                throw new RuntimeError("Error happened during tokenization. It's possibly caused by wrong encoding. Please try to " +
-                    "specify the encoding.");
-            }
-            return res.Take(n);
+            return ctx.Tokenize(text, add_bos, encoding);
         }
 
         public static unsafe Span<float> GetLogits(SafeLLamaContextHandle ctx, int length)


### PR DESCRIPTION
"Utils" is a collection of random things that could all be better placed elsewhere. This PRs moves them all out to new places (but leaves the original methods in place, marked with `Obsolete`).

While moving tokenization stuff out of Utils I also refactored it to return an `int[]` instead of an `IEnumerable<int>`. Hopefully solving (most of) the "multiple enumeration" problems at the source!