### PR TITLE
fix: antiprompt does not work in stateless executor.

### DIFF
--- a/LLama/LLamaStatelessExecutor.cs
+++ b/LLama/LLamaStatelessExecutor.cs
@@ -87,7 +87,7 @@ namespace LLama
                     string last_output = "";
                     foreach (var token in lastTokens)
                     {
-                        last_output += Utils.PtrToString(NativeApi.llama_token_to_str(_model.NativeHandle, id), _model.Encoding);
+                        last_output += Utils.PtrToString(NativeApi.llama_token_to_str(_model.NativeHandle, token), _model.Encoding);
                     }
 
                     bool should_break = false;


### PR DESCRIPTION
Fix the error that antiprompt does not work in the stateless executor.