### PR TITLE
Access to IModelParamsExtensions

### DIFF
--- a/LLama/Extensions/IModelParamsExtensions.cs
+++ b/LLama/Extensions/IModelParamsExtensions.cs
@@ -6,7 +6,7 @@ using LLama.Native;
 
 namespace LLama.Extensions
 {
-    internal static class IModelParamsExtensions
+    public static class IModelParamsExtensions
     {
         /// <summary>
         /// Convert the given `IModelParams` into a `LLamaContextParams`


### PR DESCRIPTION
Can we set this class as public, need access to this method for building multiple contexts outside LLamaSharp

I stood up a wee demo of the web UI too :)
https://llamaweb.chainstack.nz/
