### PR TITLE
Fixed `ToLlamaContextParams` using the wrong parameter for `use_mmap`

### DIFF
--- a/LLama/Extensions/IModelParamsExtensions.cs
+++ b/LLama/Extensions/IModelParamsExtensions.cs
@@ -6,6 +6,9 @@ using LLama.Native;
 
 namespace LLama.Extensions
 {
+    /// <summary>
+    /// Extention methods to the IModelParams interface
+    /// </summary>
     public static class IModelParamsExtensions
     {
         /// <summary>

--- a/LLama/Extensions/IModelParamsExtensions.cs
+++ b/LLama/Extensions/IModelParamsExtensions.cs
@@ -31,7 +31,7 @@ namespace LLama.Extensions
             result.n_gpu_layers = @params.GpuLayerCount;
             result.seed = @params.Seed;
             result.f16_kv = @params.UseFp16Memory;
-            result.use_mmap = @params.UseMemoryLock;
+            result.use_mmap = @params.UseMemorymap;
             result.use_mlock = @params.UseMemoryLock;
             result.logits_all = @params.Perplexity;
             result.embedding = @params.EmbeddingMode;

--- a/LLama/Utils.cs
+++ b/LLama/Utils.cs
@@ -2,11 +2,8 @@
 using LLama.Native;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
-using LLama.Exceptions;
 using LLama.Extensions;
 
 namespace LLama


### PR DESCRIPTION
At some point the `use_mmap` was taking the value of `UseMemoryLock` instead of `UseMemorymap`. Fixed that.