### PR TITLE
Add native logging output

### DIFF
--- a/LLama/Common/Logger.cs
+++ b/LLama/Common/Logger.cs
@@ -16,7 +16,7 @@ public interface ILLamaLogger
         Info = 4
     }
     /// <summary>
-    /// Write the log in cosutomized way
+    /// Write the log in customized way
     /// </summary>
     /// <param name="source">The source of the log. It may be a method name or class name.</param>
     /// <param name="message">The message.</param>
@@ -26,7 +26,7 @@ public interface ILLamaLogger
 
 /// <summary>
 /// The default logger of LLamaSharp. On default it write to console. User methods of `LLamaLogger.Default` to change the behavior.
-/// It's more recommended to inherit `ILLamaLogger` to cosutomize the behavior.
+/// It's more recommended to inherit `ILLamaLogger` to customize the behavior.
 /// </summary>
 public sealed class LLamaDefaultLogger : ILLamaLogger
 {
@@ -50,12 +50,12 @@ public sealed class LLamaDefaultLogger : ILLamaLogger
     /// </summary>
     /// <returns></returns>
     public LLamaDefaultLogger EnableNative()
-	{
-		EnableNativeLogCallback();
-		return this;
-	}
+    {
+        EnableNativeLogCallback();
+        return this;
+    }
 
-	public LLamaDefaultLogger EnableConsole()
+    public LLamaDefaultLogger EnableConsole()
     {
         _toConsole = true;
         return this;
@@ -173,18 +173,18 @@ public sealed class LLamaDefaultLogger : ILLamaLogger
     /// Register native logging callback
     /// </summary>
 	private void EnableNativeLogCallback()
-	{
+    {
         // TODO: Move to a more appropriate place once we have a intitialize method
-		NativeApi.llama_log_set(NativeLogCallback);
-	}
+        NativeApi.llama_log_set(NativeLogCallback);
+    }
 
-	/// <summary>
-	/// Callback for native logging function
-	/// </summary>
-	/// <param name="level">The log level</param>
-	/// <param name="message">The log message</param>
-	private void NativeLogCallback(LogLevel level, string message)
-	{
+    /// <summary>
+    /// Callback for native logging function
+    /// </summary>
+    /// <param name="level">The log level</param>
+    /// <param name="message">The log message</param>
+    private void NativeLogCallback(LogLevel level, string message)
+    {
         if (string.IsNullOrEmpty(message))
             return;
 
@@ -192,7 +192,7 @@ public sealed class LLamaDefaultLogger : ILLamaLogger
         // If your logging mechanism cannot handle that, check if the last character is '\n' and strip it
         // if it exists.
         // It might not exist for progress report where '.' is output repeatedly.
-		Log(default!, message.TrimEnd('\n'), level);
-	}
+        Log(default!, message.TrimEnd('\n'), level);
+    }
 
 }

--- a/LLama/Native/NativeApi.cs
+++ b/LLama/Native/NativeApi.cs
@@ -1,12 +1,16 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 using System.Text;
+using LLama.Common;
 using LLama.Exceptions;
 
 namespace LLama.Native
 {
     using llama_token = Int32;
-    public unsafe partial class NativeApi
+
+	public delegate void LLamaLogCallback(ILLamaLogger.LogLevel level, string message);
+
+	public unsafe partial class NativeApi
     {
         public static readonly int LLAMA_MAX_DEVICES = 1;
         static NativeApi()
@@ -331,5 +335,8 @@ namespace LLama.Native
 
         [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern int llama_tokenize_with_model(SafeLlamaModelHandle model, byte* text, int* tokens, int n_max_tokens, bool add_bos);
-    }
+
+		[DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern void llama_log_set(LLamaLogCallback logCallback);
+	}
 }


### PR DESCRIPTION
llama.cpp commit added output of the log to a callback 
[ea04a4c](https://github.com/ggerganov/llama.cpp/commit/ea04a4ca1940d92becc0ee26523aa2c4a18cf938)

Added native methods and a way to register though the existing Logger, although probably a temp solution

Order the current LogEnum to match to save making a duplicate. 

Edit:
Ugggggh.. I think we have different tab sizes, do we have a preference?