### PR TITLE
Stateless Executor Fix

### DIFF
--- a/LLama.Examples/NewVersion/ChatSessionStripRoleName.cs
+++ b/LLama.Examples/NewVersion/ChatSessionStripRoleName.cs
@@ -13,7 +13,7 @@ namespace LLama.Examples.NewVersion
 
             var parameters = new ModelParams(modelPath, contextSize: 1024, seed: 1337, gpuLayerCount: 5);
             using var model = LLamaWeights.LoadFromFile(parameters);
-            using var context = model.CreateContext(parameters, Encoding.UTF8);
+            using var context = model.CreateContext(parameters);
             var executor = new InteractiveExecutor(context);
 
             var session = new ChatSession(executor).WithOutputTransform(new LLamaTransforms.KeywordTextOutputStreamTransform(new string[] { "User:", "Bob:" }, redundancyLength: 8));

--- a/LLama.Examples/NewVersion/ChatSessionWithRoleName.cs
+++ b/LLama.Examples/NewVersion/ChatSessionWithRoleName.cs
@@ -13,7 +13,7 @@ namespace LLama.Examples.NewVersion
 
             var parameters = new ModelParams(modelPath, contextSize: 1024, seed: 1337, gpuLayerCount: 5);
             using var model = LLamaWeights.LoadFromFile(parameters);
-            using var context = model.CreateContext(parameters, Encoding.UTF8);
+            using var context = model.CreateContext(parameters);
             var executor = new InteractiveExecutor(context);
 
             var session = new ChatSession(executor);

--- a/LLama.Examples/NewVersion/InstructModeExecute.cs
+++ b/LLama.Examples/NewVersion/InstructModeExecute.cs
@@ -13,7 +13,7 @@ namespace LLama.Examples.NewVersion
 
             var parameters = new ModelParams(modelPath, contextSize: 1024, seed: 1337, gpuLayerCount: 5);
             using var model = LLamaWeights.LoadFromFile(parameters);
-            using var context = model.CreateContext(parameters, Encoding.UTF8);
+            using var context = model.CreateContext(parameters);
             var executor = new InstructExecutor(context);
 
             Console.ForegroundColor = ConsoleColor.Yellow;

--- a/LLama.Examples/NewVersion/InteractiveModeExecute.cs
+++ b/LLama.Examples/NewVersion/InteractiveModeExecute.cs
@@ -13,7 +13,7 @@ namespace LLama.Examples.NewVersion
 
             var parameters = new ModelParams(modelPath, contextSize: 1024, seed: 1337, gpuLayerCount: 5);
             using var model = LLamaWeights.LoadFromFile(parameters);
-            using var context = model.CreateContext(parameters, Encoding.UTF8);
+            using var context = model.CreateContext(parameters);
             var ex = new InteractiveExecutor(context);
 
             Console.ForegroundColor = ConsoleColor.Yellow;

--- a/LLama.Examples/NewVersion/LoadAndSaveSession.cs
+++ b/LLama.Examples/NewVersion/LoadAndSaveSession.cs
@@ -13,7 +13,7 @@ namespace LLama.Examples.NewVersion
 
             var parameters = new ModelParams(modelPath, contextSize: 1024, seed: 1337, gpuLayerCount: 5);
             using var model = LLamaWeights.LoadFromFile(parameters);
-            using var context = model.CreateContext(parameters, Encoding.UTF8);
+            using var context = model.CreateContext(parameters);
             var ex = new InteractiveExecutor(context);
 
             var session = new ChatSession(ex);

--- a/LLama.Examples/NewVersion/LoadAndSaveState.cs
+++ b/LLama.Examples/NewVersion/LoadAndSaveState.cs
@@ -13,7 +13,7 @@ namespace LLama.Examples.NewVersion
 
             var parameters = new ModelParams(modelPath, contextSize: 1024, seed: 1337, gpuLayerCount: 5);
             using var model = LLamaWeights.LoadFromFile(parameters);
-            using var context = model.CreateContext(parameters, Encoding.UTF8);
+            using var context = model.CreateContext(parameters);
             var ex = new InteractiveExecutor(context);
 
             Console.ForegroundColor = ConsoleColor.Yellow;

--- a/LLama.Examples/NewVersion/StatelessModeExecute.cs
+++ b/LLama.Examples/NewVersion/StatelessModeExecute.cs
@@ -29,7 +29,7 @@ namespace LLama.Examples.NewVersion
                 Console.Write("\nQuestion: ");
                 Console.ForegroundColor = ConsoleColor.Green;
                 string prompt = Console.ReadLine();
-                Console.ForegroundColor = ConsoleColor.White; 
+                Console.ForegroundColor = ConsoleColor.White;
                 Console.Write("Answer: ");
                 prompt = $"Question: {prompt.Trim()} Answer: ";
                 foreach (var text in ex.Infer(prompt, inferenceParams))

--- a/LLama.Examples/NewVersion/StatelessModeExecute.cs
+++ b/LLama.Examples/NewVersion/StatelessModeExecute.cs
@@ -1,5 +1,4 @@
 ﻿using LLama.Common;
-using System.Text;
 
 namespace LLama.Examples.NewVersion
 {
@@ -12,8 +11,7 @@ namespace LLama.Examples.NewVersion
 
             var parameters = new ModelParams(modelPath, contextSize: 1024, seed: 1337, gpuLayerCount: 5);
             using var model = LLamaWeights.LoadFromFile(parameters);
-            using var context = model.CreateContext(parameters, Encoding.UTF8);
-            var ex = new StatelessExecutor(context);
+            var ex = new StatelessExecutor(model, parameters);
 
             Console.ForegroundColor = ConsoleColor.Yellow;
             Console.WriteLine("The executor has been enabled. In this example, the inference is an one-time job. That says, the previous input and response has " +
@@ -28,10 +26,10 @@ namespace LLama.Examples.NewVersion
             {
                 Console.Write("\nQuestion: ");
                 Console.ForegroundColor = ConsoleColor.Green;
-                string prompt = Console.ReadLine();
+                var prompt = Console.ReadLine();
                 Console.ForegroundColor = ConsoleColor.White;
                 Console.Write("Answer: ");
-                prompt = $"Question: {prompt.Trim()} Answer: ";
+                prompt = $"Question: {prompt?.Trim()} Answer: ";
                 foreach (var text in ex.Infer(prompt, inferenceParams))
                 {
                     Console.Write(text);

--- a/LLama.Examples/NewVersion/TalkToYourself.cs
+++ b/LLama.Examples/NewVersion/TalkToYourself.cs
@@ -20,9 +20,9 @@ namespace LLama.Examples.NewVersion
             using var weights = LLamaWeights.LoadFromFile(@params);
 
             // Create 2 contexts sharing the same weights
-            using var aliceCtx = weights.CreateContext(@params, Encoding.UTF8);
+            using var aliceCtx = weights.CreateContext(@params);
             var alice = new InteractiveExecutor(aliceCtx);
-            using var bobCtx = weights.CreateContext(@params, Encoding.UTF8);
+            using var bobCtx = weights.CreateContext(@params);
             var bob = new InteractiveExecutor(bobCtx);
 
             // Initial alice prompt

--- a/LLama.Unittest/LLamaContextTests.cs
+++ b/LLama.Unittest/LLamaContextTests.cs
@@ -16,7 +16,7 @@ namespace LLama.Unittest
                 ContextSize = 768,
             };
             _weights = LLamaWeights.LoadFromFile(@params);
-            _context = _weights.CreateContext(@params, Encoding.UTF8);
+            _context = _weights.CreateContext(@params);
         }
 
         public void Dispose()

--- a/LLama.Unittest/StatelessExecutorTest.cs
+++ b/LLama.Unittest/StatelessExecutorTest.cs
@@ -13,7 +13,7 @@ namespace LLama.Unittest
         {
             _params = new ModelParams("Models/llama-2-7b-chat.ggmlv3.q3_K_S.bin")
             {
-                ContextSize = 40,
+                ContextSize = 60,
                 Seed = 1754
             };
             _weights = LLamaWeights.LoadFromFile(_params);
@@ -47,12 +47,18 @@ namespace LLama.Unittest
         {
             var executor = new StatelessExecutor(_weights.CreateContext(_params, Encoding.UTF8));
 
-            const string question = "Question. why is a cat the best pet?\nAnswer: ";
-            const string answer = "";
+            const string question = " Question. why is a cat the best pet?\nAnswer: ";
+            const string answer = " there are many reasons why cats make excellent pets! here are just a few of them:\n" +
+                                  "1)Loyalty: Cats are known for their loyalty to their owners, and they will often follow " +
+                                  "you around the house if you call them. They will always come running when called, and they’ll " +
+                                  "nuzzle and purr with delight when you walk into the room! they adore being close to their human " +
+                                  "family members and can form very close bonds.\n";
 
+            // The context size is set to 60. Generate more than that, forcing it to generate a coherent response
+            // with a modified context
             var @params = new InferenceParams()
             {
-                MaxTokens = 50,
+                MaxTokens = 100,
                 TokensKeep = question.Length,
             };
 

--- a/LLama.Unittest/StatelessExecutorTest.cs
+++ b/LLama.Unittest/StatelessExecutorTest.cs
@@ -1,0 +1,59 @@
+using LLama.Common;
+using System.Text;
+
+namespace LLama.Unittest
+{
+    public class StatelessExecutorTest
+        : IDisposable
+    {
+        private readonly LLamaWeights _weights;
+        private readonly ModelParams _params;
+
+        public StatelessExecutorTest()
+        {
+            _params = new ModelParams("Models/llama-2-7b-chat.ggmlv3.q3_K_S.bin")
+            {
+                ContextSize = 64,
+                Seed = 1754
+            };
+            _weights = LLamaWeights.LoadFromFile(_params);
+        }
+
+        public void Dispose()
+        {
+            _weights.Dispose();
+        }
+
+        [Fact]
+        public void Stateless()
+        {
+            var executor = new StatelessExecutor(_weights.CreateContext(_params, Encoding.UTF8));
+
+            const string question = "Question. what is a cat?\nAnswer: ";
+            const string expected = " a domestic or wild animal that is typically small to medium-sized, has fur, four legs, and sharp retractable claws.";
+            var @params = new InferenceParams { MaxTokens = 32, AntiPrompts = new[] { "." } };
+
+            var result1 = string.Join("", executor.Infer(question, @params));
+            Assert.Equal(expected, result1);
+
+            var result2 = string.Join("", executor.Infer(question, @params));
+            Assert.Equal(expected, result2);
+
+            Assert.Equal(result1, result2);
+        }
+
+        [Fact]
+        public void OutOfContext()
+        {
+            var executor = new StatelessExecutor(_weights.CreateContext(_params, Encoding.UTF8));
+
+            const string question = "Question. why is a cat the best pet?\nAnswer: ";
+            var @params = new InferenceParams()
+            {
+                MaxTokens = 128,
+            };
+
+            var result1 = string.Join("", executor.Infer(question, @params));
+        }
+    }
+}

--- a/LLama.Unittest/StatelessExecutorTest.cs
+++ b/LLama.Unittest/StatelessExecutorTest.cs
@@ -1,16 +1,19 @@
 using LLama.Common;
 using System.Text;
+using Xunit.Abstractions;
 
 namespace LLama.Unittest
 {
     public class StatelessExecutorTest
         : IDisposable
     {
+        private readonly ITestOutputHelper _testOutputHelper;
         private readonly LLamaWeights _weights;
         private readonly ModelParams _params;
 
-        public StatelessExecutorTest()
+        public StatelessExecutorTest(ITestOutputHelper testOutputHelper)
         {
+            _testOutputHelper = testOutputHelper;
             _params = new ModelParams("Models/llama-2-7b-chat.ggmlv3.q3_K_S.bin")
             {
                 ContextSize = 60,
@@ -35,6 +38,8 @@ namespace LLama.Unittest
             var result1 = string.Join("", executor.Infer(question, @params));
             var result2 = string.Join("", executor.Infer(question, @params));
 
+            _testOutputHelper.WriteLine(result1);
+
             // Check that it produced the exact same result both times
             Assert.Equal(result1, result2);
         }
@@ -45,11 +50,6 @@ namespace LLama.Unittest
             var executor = new StatelessExecutor(_weights.CreateContext(_params, Encoding.UTF8));
 
             const string question = " Question. why is a cat the best pet?\nAnswer: ";
-            const string answer = " there are many reasons why cats make excellent pets! here are just a few of them:\n" +
-                                  "1)Loyalty: Cats are known for their loyalty to their owners, and they will often follow " +
-                                  "you around the house if you call them. They will always come running when called, and they’ll " +
-                                  "nuzzle and purr with delight when you walk into the room! they adore being close to their human " +
-                                  "family members and can form very close bonds.\n";
 
             // The context size is set to 60. Generate more than that, forcing it to generate a coherent response
             // with a modified context
@@ -59,9 +59,13 @@ namespace LLama.Unittest
                 TokensKeep = question.Length,
             };
 
-            var result = string.Join("", executor.Infer(question, @params));
+            var result1 = string.Join("", executor.Infer(question, @params));
+            var result2 = string.Join("", executor.Infer(question, @params));
 
-            Assert.Equal(answer, result);
+            _testOutputHelper.WriteLine(result1);
+
+            // Check that it produced the exact same result both times
+            Assert.Equal(result1, result2);
         }
     }
 }

--- a/LLama.Unittest/StatelessExecutorTest.cs
+++ b/LLama.Unittest/StatelessExecutorTest.cs
@@ -30,15 +30,12 @@ namespace LLama.Unittest
             var executor = new StatelessExecutor(_weights.CreateContext(_params, Encoding.UTF8));
 
             const string question = "Question. what is a cat?\nAnswer: ";
-            const string expected = " a domestic or wild animal that is typically small to medium-sized, has fur, four legs, and sharp retractable claws.";
             var @params = new InferenceParams { MaxTokens = 32, AntiPrompts = new[] { "." } };
 
             var result1 = string.Join("", executor.Infer(question, @params));
-            Assert.Equal(expected, result1);
-
             var result2 = string.Join("", executor.Infer(question, @params));
-            Assert.Equal(expected, result2);
 
+            // Check that it produced the exact same result both times
             Assert.Equal(result1, result2);
         }
 

--- a/LLama.Unittest/StatelessExecutorTest.cs
+++ b/LLama.Unittest/StatelessExecutorTest.cs
@@ -13,7 +13,7 @@ namespace LLama.Unittest
         {
             _params = new ModelParams("Models/llama-2-7b-chat.ggmlv3.q3_K_S.bin")
             {
-                ContextSize = 64,
+                ContextSize = 40,
                 Seed = 1754
             };
             _weights = LLamaWeights.LoadFromFile(_params);
@@ -48,12 +48,17 @@ namespace LLama.Unittest
             var executor = new StatelessExecutor(_weights.CreateContext(_params, Encoding.UTF8));
 
             const string question = "Question. why is a cat the best pet?\nAnswer: ";
+            const string answer = "";
+
             var @params = new InferenceParams()
             {
-                MaxTokens = 128,
+                MaxTokens = 50,
+                TokensKeep = question.Length,
             };
 
-            var result1 = string.Join("", executor.Infer(question, @params));
+            var result = string.Join("", executor.Infer(question, @params));
+
+            Assert.Equal(answer, result);
         }
     }
 }

--- a/LLama.Unittest/StatelessExecutorTest.cs
+++ b/LLama.Unittest/StatelessExecutorTest.cs
@@ -1,5 +1,4 @@
 using LLama.Common;
-using System.Text;
 using Xunit.Abstractions;
 
 namespace LLama.Unittest
@@ -30,7 +29,7 @@ namespace LLama.Unittest
         [Fact]
         public void Stateless()
         {
-            var executor = new StatelessExecutor(_weights.CreateContext(_params, Encoding.UTF8));
+            var executor = new StatelessExecutor(_weights, _params);
 
             const string question = "Question. what is a cat?\nAnswer: ";
             var @params = new InferenceParams { MaxTokens = 32, AntiPrompts = new[] { "." } };
@@ -47,7 +46,7 @@ namespace LLama.Unittest
         [Fact]
         public void OutOfContext()
         {
-            var executor = new StatelessExecutor(_weights.CreateContext(_params, Encoding.UTF8));
+            var executor = new StatelessExecutor(_weights, _params);
 
             const string question = " Question. why is a cat the best pet?\nAnswer: ";
 

--- a/LLama.Web/Common/ModelOptions.cs
+++ b/LLama.Web/Common/ModelOptions.cs
@@ -2,7 +2,8 @@
 
 namespace LLama.Web.Common
 {
-    public class ModelOptions : IModelParams
+    public class ModelOptions
+        : IModelParams
     {
       
         public string Name { get; set; }
@@ -111,5 +112,9 @@ namespace LLama.Web.Common
 		/// </summary>
 		public bool MulMatQ { get; set; }
 
-	}
+        /// <summary>
+        /// The encoding to use for models
+        /// </summary>
+        public string Encoding { get; set; } = "UTF-8";
+    }
 }

--- a/LLama/Abstractions/IModelParams.cs
+++ b/LLama/Abstractions/IModelParams.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace LLama.Abstractions
+﻿namespace LLama.Abstractions
 {
     public interface IModelParams
     {
@@ -119,5 +117,10 @@ namespace LLama.Abstractions
         /// Use experimental mul_mat_q kernels
         /// </summary>
         bool MulMatQ { get; set; }
+
+        /// <summary>
+        /// The encoding to use for models
+        /// </summary>
+        string Encoding { get; set; }
     }
 }

--- a/LLama/Common/ModelParams.cs
+++ b/LLama/Common/ModelParams.cs
@@ -1,5 +1,6 @@
 ﻿using LLama.Abstractions;
 using System;
+using System.Text;
 
 namespace LLama.Common
 {
@@ -111,34 +112,41 @@ namespace LLama.Common
 		/// </summary>
 		public bool MulMatQ { get; set; }
 
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <param name="modelPath">The model path.</param>
-		/// <param name="contextSize">Model context size (n_ctx)</param>
-		/// <param name="gpuLayerCount">Number of layers to run in VRAM / GPU memory (n_gpu_layers)</param>
-		/// <param name="seed">Seed for the random number generator (seed)</param>
-		/// <param name="useFp16Memory">Whether to use f16 instead of f32 for memory kv (memory_f16)</param>
-		/// <param name="useMemorymap">Whether to use mmap for faster loads (use_mmap)</param>
-		/// <param name="useMemoryLock">Whether to use mlock to keep model in memory (use_mlock)</param>
-		/// <param name="perplexity">Thether to compute perplexity over the prompt (perplexity)</param>
-		/// <param name="loraAdapter">Lora adapter path (lora_adapter)</param>
-		/// <param name="loraBase">Base model path for the lora adapter (lora_base)</param>
-		/// <param name="threads">Number of threads (-1 = autodetect) (n_threads)</param>
-		/// <param name="batchSize">Batch size for prompt processing (must be >=32 to use BLAS) (n_batch)</param>
-		/// <param name="convertEosToNewLine">Whether to convert eos to newline during the inference.</param>
-		/// <param name="embeddingMode">Whether to use embedding mode. (embedding) Note that if this is set to true, The LLamaModel won't produce text response anymore.</param>
-		/// <param name="groupedQueryAttention">Grouped-Query Attention</param>
-		/// <param name="rmsNormEpsilon">RMS Norm Epsilon</param>
-		/// <param name="ropeFrequencyBase">RoPE base frequency.</param>
-		/// <param name="ropeFrequencyScale">RoPE frequency scaling factor</param>
-		/// <param name="mulMatQ">Use experimental mul_mat_q kernels</param>
-		public ModelParams(string modelPath, int contextSize = 512, int gpuLayerCount = 20,
-                   int seed = 1337, bool useFp16Memory = true,
-                   bool useMemorymap = true, bool useMemoryLock = false, bool perplexity = false,
-                   string loraAdapter = "", string loraBase = "", int threads = -1, int batchSize = 512,
-                   bool convertEosToNewLine = false, bool embeddingMode = false,
-                   int groupedQueryAttention = 1, float rmsNormEpsilon = 5e-6f, float ropeFrequencyBase = 10000.0f, float ropeFrequencyScale = 1f, bool mulMatQ = false)
+        /// <summary>
+        /// The encoding to use to convert text for the model
+        /// </summary>
+        public string Encoding { get; set; } = "UTF-8";
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="modelPath">The model path.</param>
+        /// <param name="contextSize">Model context size (n_ctx)</param>
+        /// <param name="gpuLayerCount">Number of layers to run in VRAM / GPU memory (n_gpu_layers)</param>
+        /// <param name="seed">Seed for the random number generator (seed)</param>
+        /// <param name="useFp16Memory">Whether to use f16 instead of f32 for memory kv (memory_f16)</param>
+        /// <param name="useMemorymap">Whether to use mmap for faster loads (use_mmap)</param>
+        /// <param name="useMemoryLock">Whether to use mlock to keep model in memory (use_mlock)</param>
+        /// <param name="perplexity">Thether to compute perplexity over the prompt (perplexity)</param>
+        /// <param name="loraAdapter">Lora adapter path (lora_adapter)</param>
+        /// <param name="loraBase">Base model path for the lora adapter (lora_base)</param>
+        /// <param name="threads">Number of threads (-1 = autodetect) (n_threads)</param>
+        /// <param name="batchSize">Batch size for prompt processing (must be >=32 to use BLAS) (n_batch)</param>
+        /// <param name="convertEosToNewLine">Whether to convert eos to newline during the inference.</param>
+        /// <param name="embeddingMode">Whether to use embedding mode. (embedding) Note that if this is set to true, The LLamaModel won't produce text response anymore.</param>
+        /// <param name="groupedQueryAttention">Grouped-Query Attention</param>
+        /// <param name="rmsNormEps">RMS Norm Epsilon</param>
+        /// <param name="ropeFreqBase">RoPE base frequency.</param>
+        /// <param name="ropeFreqScale">RoPE frequency scaling factor</param>
+        /// <param name="muMatQ">Use experimental mul_mat_q kernels</param>
+        /// <param name="encoding">The encoding to use to convert text for the model</param>
+        public ModelParams(string modelPath, int contextSize = 512, int gpuLayerCount = 20,
+                           int seed = 1337, bool useFp16Memory = true,
+                           bool useMemorymap = true, bool useMemoryLock = false, bool perplexity = false,
+                           string loraAdapter = "", string loraBase = "", int threads = -1, int batchSize = 512,
+                           bool convertEosToNewLine = false, bool embeddingMode = false,
+                           int groupedQueryAttention = 1, float rmsNormEps = 5e-6f, float ropeFreqBase = 10000.0f, float ropeFreqScale = 1f, bool muMatQ = false,
+                           string encoding = "UTF-8")
         {
             ContextSize = contextSize;
             GpuLayerCount = gpuLayerCount;
@@ -155,10 +163,11 @@ namespace LLama.Common
             ConvertEosToNewLine = convertEosToNewLine;
             EmbeddingMode = embeddingMode;
             GroupedQueryAttention  = groupedQueryAttention;
-            RmsNormEpsilon = rmsNormEpsilon;
-            RopeFrequencyBase  = ropeFrequencyBase;
-            RopeFrequencyScale  = ropeFrequencyScale;
-            MulMatQ = mulMatQ;
-	    }
+            RmsNormEpsilon = rmsNormEps;
+            RopeFrequencyBase  = ropeFreqBase;
+            RopeFrequencyScale  = ropeFreqScale;
+            MulMatQ = muMatQ;
+            Encoding = encoding;
+        }
     }
 }

--- a/LLama/Extensions/ListExtensions.cs
+++ b/LLama/Extensions/ListExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace LLama.Extensions
+{
+    internal static class ListExtensions
+    {
+        public static void AddRangeSpan<T>(this List<T> list, ReadOnlySpan<T> span)
+        {
+            for (var i = 0; i < span.Length; i++)
+                list.Add(span[i]);
+        }
+    }
+}

--- a/LLama/LLamaContext.cs
+++ b/LLama/LLamaContext.cs
@@ -411,7 +411,7 @@ namespace LLama
             var span = CollectionsMarshal.AsSpan(tokens);
             return Eval(span, pastTokensCount);
 #else
-            // on netstandard2.0 we can't use collections marshal to get directly at the internal memory of
+            // on netstandard2.0 we can't use CollectionsMarshal to get directly at the internal memory of
             // the list. Instead rent an array and copy the data into it. This avoids an allocation, but can't
             // avoid the copying.
 
@@ -449,11 +449,11 @@ namespace LLama
         /// <exception cref="RuntimeError"></exception>
         public int Eval(ReadOnlySpan<llama_token> tokens, llama_token pastTokensCount)
         {
-            int total = tokens.Length;
-            for(int i = 0; i < total; i += Params.BatchSize)
+            var total = tokens.Length;
+            for(var i = 0; i < total; i += Params.BatchSize)
             {
-                int n_eval = total - i;
-                if(n_eval > Params.BatchSize)
+                var n_eval = total - i;
+                if (n_eval > Params.BatchSize)
                 {
                     n_eval = Params.BatchSize;
                 }

--- a/LLama/LLamaInstructExecutor.cs
+++ b/LLama/LLamaInstructExecutor.cs
@@ -189,7 +189,7 @@ namespace LLama
                 }
 
                 TryReuseMathingPrefix();
-                _pastTokensCount = Context.Eval(_embeds.ToArray(), _pastTokensCount);
+                _pastTokensCount = Context.Eval(_embeds, _pastTokensCount);
 
                 if (_embeds.Count > 0 && !string.IsNullOrEmpty(_pathSession))
                 {

--- a/LLama/LLamaInteractExecutor.cs
+++ b/LLama/LLamaInteractExecutor.cs
@@ -178,7 +178,7 @@ namespace LLama
                 }
 
                 TryReuseMathingPrefix();
-                _pastTokensCount = Context.Eval(_embeds.ToArray(), _pastTokensCount);
+                _pastTokensCount = Context.Eval(_embeds, _pastTokensCount);
 
                 if (_embeds.Count > 0 && !string.IsNullOrEmpty(_pathSession))
                 {

--- a/LLama/LLamaStatelessExecutor.cs
+++ b/LLama/LLamaStatelessExecutor.cs
@@ -1,10 +1,10 @@
 ﻿using LLama.Abstractions;
 using LLama.Common;
-using LLama.Native;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading;
 
 namespace LLama
@@ -16,12 +16,14 @@ namespace LLama
     /// </summary>
     public class StatelessExecutor : ILLamaExecutor
     {
-        private LLamaContext _context;
-        private LLamaContext.State _originalState;
+        private readonly LLamaContext _context;
+        private readonly LLamaContext.State _originalState;
+
         /// <summary>
         /// The context used by the executor when running the inference.
         /// </summary>
         public LLamaContext Context => _context;
+
         /// <summary>
         /// 
         /// </summary>
@@ -31,7 +33,7 @@ namespace LLama
             _context = context;
             
             var tokens = context.Tokenize(" ", true).ToArray();
-            _context.NativeHandle.Eval(tokens.AsMemory(0, tokens.Length), 0, _context.Params.Threads);
+            _context.NativeHandle.Eval(tokens.AsSpan(0, tokens.Length), 0, _context.Params.Threads);
             _originalState = context.GetState();
         }
 
@@ -39,27 +41,26 @@ namespace LLama
         public IEnumerable<string> Infer(string text, IInferenceParams? inferenceParams = null, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            int n_past = 1;
-            if(inferenceParams is null)
-            {
-                inferenceParams = new InferenceParams();
-            }
-            List<llama_token> lastTokens = new(inferenceParams.RepeatLastTokensCount);
-            for(int i = 0; i < lastTokens.Count; i++)
-            {
-                lastTokens[i] = 0;
-            }
-            List<llama_token> tokens = _context.Tokenize(text, true).ToList();
-            int n_prompt_tokens = tokens.Count;
 
-            _context.NativeHandle.Eval(tokens.ToArray().AsMemory(0, n_prompt_tokens), n_past, _context.Params.Threads);
+            var antiprompts = inferenceParams?.AntiPrompts.ToArray() ?? Array.Empty<string>();
+            var n_past = 1;
+            inferenceParams ??= new InferenceParams();
+
+            var lastTokens = new List<llama_token>(inferenceParams.RepeatLastTokensCount);
+            for (var i = 0; i < inferenceParams.RepeatLastTokensCount; i++)
+                lastTokens.Add(0);
+
+            var tokens = _context.Tokenize(text).ToList();
+            var n_prompt_tokens = tokens.Count;
+
+            _context.Eval(tokens, n_past);
 
             lastTokens.AddRange(tokens);
             n_past += n_prompt_tokens;
 
             var mu = (float?)null;
-            int max_tokens = inferenceParams.MaxTokens < 0 ? int.MaxValue : inferenceParams.MaxTokens;
-            for(int i = 0; i < max_tokens; i++)
+            var max_tokens = inferenceParams.MaxTokens < 0 ? int.MaxValue : inferenceParams.MaxTokens;
+            for(var i = 0; i < max_tokens; i++)
             {
                 if (cancellationToken.IsCancellationRequested)
                 {
@@ -76,35 +77,17 @@ namespace LLama
 
                 lastTokens.Add(id);
 
-                string response = _context.NativeHandle.TokenToString(id, _context.Encoding);
+                var response = _context.TokenToString(id);
                 yield return response;
 
                 tokens.Clear();
                 tokens.Add(id);
 
-                if (inferenceParams.AntiPrompts is not null && inferenceParams.AntiPrompts.Count() > 0)
-                {
-                    string last_output = "";
-                    foreach (var token in lastTokens)
-                    {
-                        last_output += _context.NativeHandle.TokenToString(token, _context.Encoding);
-                    }
+                if (EndsWithAntiprompt(lastTokens, antiprompts))
+                    break;
 
-                    bool should_break = false;
-                    foreach (var antiprompt in inferenceParams.AntiPrompts)
-                    {
-                        if (last_output.EndsWith(antiprompt))
-                        {
-                            should_break = true;
-                            break;
-                        }
-                    }
-                    if (should_break)
-                    {
-                        break;
-                    }
-                }
-
+                // todo: this seems to be based on this logic: https://github.com/ggerganov/llama.cpp/blob/master/examples/main/main.cpp#L433
+                // todo: but it's broken!
                 // when run out of context
                 if (n_past + tokens.Count > _context.ContextSize)
                 {
@@ -116,10 +99,36 @@ namespace LLama
                     tokens.InsertRange(0, lastTokens.Take(lastTokens.Count - tokens.Count).Skip(_context.ContextSize - n_left / 2 - tokens.Count));
                 }
 
-                n_past = _context.Eval(tokens.ToArray(), n_past);
+                n_past = _context.Eval(tokens, n_past);
             }
 
             _context.LoadState(_originalState);
+        }
+
+        /// <summary>
+        /// Check if the given tokens list ends with any of the antiprompts
+        /// </summary>
+        /// <param name="tokens"></param>
+        /// <param name="antiprompts"></param>
+        /// <returns></returns>
+        private bool EndsWithAntiprompt(IReadOnlyList<llama_token> tokens, IReadOnlyList<string> antiprompts)
+        {
+            if (antiprompts.Count == 0 || tokens.Count == 0)
+                return false;
+
+            var builder = new StringBuilder();
+            foreach (var token in tokens)
+                builder.Append(_context.TokenToString(token));
+
+            var last_output = builder.ToString();
+
+            foreach (var antiprompt in antiprompts)
+            {
+                if (last_output.EndsWith(antiprompt))
+                    return true;
+            }
+
+            return false;
         }
 
         /// <inheritdoc />

--- a/LLama/LLamaWeights.cs
+++ b/LLama/LLamaWeights.cs
@@ -20,9 +20,15 @@ namespace LLama
         /// <remarks>Be careful how you use this!</remarks>
         public SafeLlamaModelHandle NativeHandle => _weights;
 
-        private LLamaWeights(SafeLlamaModelHandle weights)
+        /// <summary>
+        /// Encoding to use to convert text into bytes for the model
+        /// </summary>
+        public Encoding Encoding { get; }
+
+        internal LLamaWeights(SafeLlamaModelHandle weights, Encoding encoding)
         {
             _weights = weights;
+            Encoding = encoding;
         }
 
         /// <summary>
@@ -38,7 +44,7 @@ namespace LLama
             if (!string.IsNullOrEmpty(@params.LoraAdapter))
                 weights.ApplyLoraFromFile(@params.LoraAdapter, @params.LoraBase, @params.Threads);
 
-            return new LLamaWeights(weights);
+            return new LLamaWeights(weights, Encoding.GetEncoding(@params.Encoding));
         }
 
         /// <inheritdoc />
@@ -51,11 +57,10 @@ namespace LLama
         /// Create a llama_context using this model
         /// </summary>
         /// <param name="params"></param>
-        /// <param name="encoding"></param>
         /// <returns></returns>
-        public LLamaContext CreateContext(IModelParams @params, Encoding encoding)
+        public LLamaContext CreateContext(IModelParams @params)
         {
-            return new LLamaContext(this, @params, encoding);
+            return new LLamaContext(this, @params);
         }
     }
 }

--- a/LLama/Native/SafeLLamaContextHandle.cs
+++ b/LLama/Native/SafeLLamaContextHandle.cs
@@ -179,12 +179,14 @@ namespace LLama.Native
         /// <param name="n_past">the number of tokens to use from previous eval calls</param>
         /// <param name="n_threads"></param>
         /// <returns>Returns true on success</returns>
-        public bool Eval(Memory<int> tokens, int n_past, int n_threads)
+        public bool Eval(ReadOnlySpan<int> tokens, int n_past, int n_threads)
         {
-            using var pin = tokens.Pin();
             unsafe
             {
-                return NativeApi.llama_eval_with_pointer(this, (int*)pin.Pointer, tokens.Length, n_past, n_threads) == 0;
+                fixed (int* pinned = tokens)
+                {
+                    return NativeApi.llama_eval_with_pointer(this, pinned, tokens.Length, n_past, n_threads) == 0;
+                }
             }
         }
     }

--- a/LLama/Native/SafeLLamaContextHandle.cs
+++ b/LLama/Native/SafeLLamaContextHandle.cs
@@ -138,7 +138,6 @@ namespace LLama.Native
         /// Rows: n_tokens<br />
         /// Cols: n_vocab
         /// </summary>
-        /// <param name="ctx"></param>
         /// <returns></returns>
         public Span<float> GetLogits()
         {

--- a/LLama/Utils.cs
+++ b/LLama/Utils.cs
@@ -37,7 +37,7 @@ namespace LLama
         [Obsolete("Use SafeLLamaContextHandle Eval method instead")]
         public static int Eval(SafeLLamaContextHandle ctx, llama_token[] tokens, int startIndex, int n_tokens, int n_past, int n_threads)
         {
-            var slice = tokens.AsMemory().Slice(startIndex, n_tokens);
+            var slice = tokens.AsSpan().Slice(startIndex, n_tokens);
             return ctx.Eval(slice, n_past, n_threads) ? 0 : 1;
         }
 


### PR DESCRIPTION
Added a unit test to the stateless executor (`OutOfContext`) which _fails_ with the current master branch, it looks like the stateless executor has never properly handled running out of context. Fixed this.

Other assorted changes:
 - Updated `StatelessModeExecute` demo to use the new model/context loading
 - Added some more `Eval` overloads which accept various different types (Span, Memory, List etc). These overloads avoid allocating/copying, and also mean call sites don't have to call `.ToArray()` to often.

Additional big changes:
 - The StatelessExecutor creates a new context when inference starts and disposes it when complete. This means that zero memory is used when not inferring!
 - Added `encoding` to parameters. This means it no longer has to be passed everywhere.