### PR TITLE
ModelsParams record class

### DIFF
--- a/LLama.Examples/NewVersion/ChatSessionStripRoleName.cs
+++ b/LLama.Examples/NewVersion/ChatSessionStripRoleName.cs
@@ -10,7 +10,12 @@ namespace LLama.Examples.NewVersion
             var modelPath = Console.ReadLine();
             var prompt = File.ReadAllText("Assets/chat-with-bob.txt").Trim();
 
-            var parameters = new ModelParams(modelPath, contextSize: 1024, seed: 1337, gpuLayerCount: 5);
+            var parameters = new ModelParams(modelPath)
+            {
+                ContextSize = 1024,
+                Seed = 1337,
+                GpuLayerCount = 5
+            };
             using var model = LLamaWeights.LoadFromFile(parameters);
             using var context = model.CreateContext(parameters);
             var executor = new InteractiveExecutor(context);

--- a/LLama.Examples/NewVersion/ChatSessionWithRoleName.cs
+++ b/LLama.Examples/NewVersion/ChatSessionWithRoleName.cs
@@ -10,7 +10,12 @@ namespace LLama.Examples.NewVersion
             var modelPath = Console.ReadLine();
             var prompt = File.ReadAllText("Assets/chat-with-bob.txt").Trim();
 
-            var parameters = new ModelParams(modelPath, contextSize: 1024, seed: 1337, gpuLayerCount: 5);
+            var parameters = new ModelParams(modelPath)
+            {
+                ContextSize = 1024,
+                Seed = 1337,
+                GpuLayerCount = 5
+            };
             using var model = LLamaWeights.LoadFromFile(parameters);
             using var context = model.CreateContext(parameters);
             var executor = new InteractiveExecutor(context);

--- a/LLama.Examples/NewVersion/InstructModeExecute.cs
+++ b/LLama.Examples/NewVersion/InstructModeExecute.cs
@@ -10,7 +10,12 @@ namespace LLama.Examples.NewVersion
             var modelPath = Console.ReadLine();
             var prompt = File.ReadAllText("Assets/dan.txt").Trim();
 
-            var parameters = new ModelParams(modelPath, contextSize: 1024, seed: 1337, gpuLayerCount: 5);
+            var parameters = new ModelParams(modelPath)
+            {
+                ContextSize = 1024,
+                Seed = 1337,
+                GpuLayerCount = 5
+            };
             using var model = LLamaWeights.LoadFromFile(parameters);
             using var context = model.CreateContext(parameters);
             var executor = new InstructExecutor(context);

--- a/LLama.Examples/NewVersion/InteractiveModeExecute.cs
+++ b/LLama.Examples/NewVersion/InteractiveModeExecute.cs
@@ -10,7 +10,12 @@ namespace LLama.Examples.NewVersion
             var modelPath = Console.ReadLine();
             var prompt = (await File.ReadAllTextAsync("Assets/chat-with-bob.txt")).Trim();
 
-            var parameters = new ModelParams(modelPath, contextSize: 1024, seed: 1337, gpuLayerCount: 5);
+            var parameters = new ModelParams(modelPath)
+            {
+                ContextSize = 1024,
+                Seed = 1337,
+                GpuLayerCount = 5
+            };
             using var model = LLamaWeights.LoadFromFile(parameters);
             using var context = model.CreateContext(parameters);
             var ex = new InteractiveExecutor(context);

--- a/LLama.Examples/NewVersion/LoadAndSaveSession.cs
+++ b/LLama.Examples/NewVersion/LoadAndSaveSession.cs
@@ -10,7 +10,12 @@ namespace LLama.Examples.NewVersion
             var modelPath = Console.ReadLine();
             var prompt = File.ReadAllText("Assets/chat-with-bob.txt").Trim();
 
-            var parameters = new ModelParams(modelPath, contextSize: 1024, seed: 1337, gpuLayerCount: 5);
+            var parameters = new ModelParams(modelPath)
+            {
+                ContextSize = 1024,
+                Seed = 1337,
+                GpuLayerCount = 5
+            };
             using var model = LLamaWeights.LoadFromFile(parameters);
             using var context = model.CreateContext(parameters);
             var ex = new InteractiveExecutor(context);
@@ -45,7 +50,7 @@ namespace LLama.Examples.NewVersion
                     Console.ForegroundColor = ConsoleColor.White;
 
                     ex.Context.Dispose();
-                    ex = new(new LLamaContext(new ModelParams(modelPath, contextSize: 1024, seed: 1337, gpuLayerCount: 5)));
+                    ex = new(new LLamaContext(parameters));
                     session = new ChatSession(ex);
                     session.LoadSession(statePath);
 

--- a/LLama.Examples/NewVersion/LoadAndSaveState.cs
+++ b/LLama.Examples/NewVersion/LoadAndSaveState.cs
@@ -10,7 +10,12 @@ namespace LLama.Examples.NewVersion
             var modelPath = Console.ReadLine();
             var prompt = File.ReadAllText("Assets/chat-with-bob.txt").Trim();
 
-            var parameters = new ModelParams(modelPath, contextSize: 1024, seed: 1337, gpuLayerCount: 5);
+            var parameters = new ModelParams(modelPath)
+            {
+                ContextSize = 1024,
+                Seed = 1337,
+                GpuLayerCount = 5
+            };
             using var model = LLamaWeights.LoadFromFile(parameters);
             using var context = model.CreateContext(parameters);
             var ex = new InteractiveExecutor(context);

--- a/LLama.Examples/NewVersion/StatelessModeExecute.cs
+++ b/LLama.Examples/NewVersion/StatelessModeExecute.cs
@@ -9,7 +9,12 @@ namespace LLama.Examples.NewVersion
             Console.Write("Please input your model path: ");
             var modelPath = Console.ReadLine();
 
-            var parameters = new ModelParams(modelPath, contextSize: 1024, seed: 1337, gpuLayerCount: 5);
+            var parameters = new ModelParams(modelPath)
+            {
+                ContextSize = 1024,
+                Seed = 1337,
+                GpuLayerCount = 5
+            };
             using var model = LLamaWeights.LoadFromFile(parameters);
             var ex = new StatelessExecutor(model, parameters);
 

--- a/LLama.Unittest/BasicTest.cs
+++ b/LLama.Unittest/BasicTest.cs
@@ -10,7 +10,10 @@ namespace LLama.Unittest
 
         public BasicTest()
         {
-            _params = new ModelParams("Models/llama-2-7b-chat.ggmlv3.q3_K_S.bin", contextSize: 2048);
+            _params = new ModelParams("Models/llama-2-7b-chat.ggmlv3.q3_K_S.bin")
+            {
+                ContextSize = 2048
+            };
             _model = LLamaWeights.LoadFromFile(_params);
         }
 

--- a/LLama.Unittest/GrammarTest.cs
+++ b/LLama.Unittest/GrammarTest.cs
@@ -11,7 +11,10 @@ namespace LLama.Unittest
 
         public GrammarTest()
         {
-            _params = new ModelParams("Models/llama-2-7b-chat.ggmlv3.q3_K_S.bin", contextSize: 2048);
+            _params = new ModelParams("Models/llama-2-7b-chat.ggmlv3.q3_K_S.bin")
+            {
+                ContextSize = 2048,
+            };
             _model = LLamaWeights.LoadFromFile(_params);
         }
 

--- a/LLama.Unittest/LLama.Unittest.csproj
+++ b/LLama.Unittest/LLama.Unittest.csproj
@@ -11,13 +11,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/LLama.Unittest/ModelsParamsTests.cs
+++ b/LLama.Unittest/ModelsParamsTests.cs
@@ -19,31 +19,10 @@ namespace LLama.Unittest
                 GpuLayerCount = 111
             };
 
-            var options = new System.Text.Json.JsonSerializerOptions();
-            options.Converters.Add(new SystemTextJsonEncodingConverter());
-
-            var json = System.Text.Json.JsonSerializer.Serialize(expected, options);
-            var actual = System.Text.Json.JsonSerializer.Deserialize<ModelParams>(json, options);
+            var json = System.Text.Json.JsonSerializer.Serialize(expected);
+            var actual = System.Text.Json.JsonSerializer.Deserialize<ModelParams>(json);
 
             Assert.Equal(expected, actual);
-        }
-
-        private class SystemTextJsonEncodingConverter
-            : System.Text.Json.Serialization.JsonConverter<Encoding>
-
-        {
-            public override Encoding? Read(ref System.Text.Json.Utf8JsonReader reader, Type typeToConvert, System.Text.Json.JsonSerializerOptions options)
-            {
-                var name = reader.GetString();
-                if (name == null)
-                    return null;
-                return Encoding.GetEncoding(name);
-            }
-
-            public override void Write(System.Text.Json.Utf8JsonWriter writer, Encoding value, System.Text.Json.JsonSerializerOptions options)
-            {
-                writer.WriteStringValue(value.WebName);
-            }
         }
 
         [Fact]

--- a/LLama.Unittest/ModelsParamsTests.cs
+++ b/LLama.Unittest/ModelsParamsTests.cs
@@ -1,0 +1,45 @@
+﻿using LLama.Common;
+
+namespace LLama.Unittest
+{
+    public class ModelsParamsTests
+    {
+        [Fact]
+        public void SerializeRoundTripSystemTextJson()
+        {
+            var expected = new ModelParams("abc/123")
+            {
+                BatchSize = 17,
+                ContextSize = 42,
+                LoraAdapter = "adapter",
+                GroupedQueryAttention = 7,
+                Seed = 42,
+                GpuLayerCount = 111
+            };
+
+            var json = System.Text.Json.JsonSerializer.Serialize(expected);
+            var actual = System.Text.Json.JsonSerializer.Deserialize<ModelParams>(json);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void SerializeRoundTripNewtonsoft()
+        {
+            var expected = new ModelParams("abc/123")
+            {
+                BatchSize = 17,
+                ContextSize = 42,
+                LoraAdapter = "adapter",
+                GroupedQueryAttention = 7,
+                Seed = 42,
+                GpuLayerCount = 111
+            };
+
+            var json = Newtonsoft.Json.JsonConvert.SerializeObject(expected);
+            var actual = Newtonsoft.Json.JsonConvert.DeserializeObject<ModelParams>(json);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/LLama.Unittest/ModelsParamsTests.cs
+++ b/LLama.Unittest/ModelsParamsTests.cs
@@ -1,4 +1,6 @@
-﻿using LLama.Common;
+﻿using System.Text;
+using LLama.Common;
+using Newtonsoft.Json;
 
 namespace LLama.Unittest
 {
@@ -17,10 +19,31 @@ namespace LLama.Unittest
                 GpuLayerCount = 111
             };
 
-            var json = System.Text.Json.JsonSerializer.Serialize(expected);
-            var actual = System.Text.Json.JsonSerializer.Deserialize<ModelParams>(json);
+            var options = new System.Text.Json.JsonSerializerOptions();
+            options.Converters.Add(new SystemTextJsonEncodingConverter());
+
+            var json = System.Text.Json.JsonSerializer.Serialize(expected, options);
+            var actual = System.Text.Json.JsonSerializer.Deserialize<ModelParams>(json, options);
 
             Assert.Equal(expected, actual);
+        }
+
+        private class SystemTextJsonEncodingConverter
+            : System.Text.Json.Serialization.JsonConverter<Encoding>
+
+        {
+            public override Encoding? Read(ref System.Text.Json.Utf8JsonReader reader, Type typeToConvert, System.Text.Json.JsonSerializerOptions options)
+            {
+                var name = reader.GetString();
+                if (name == null)
+                    return null;
+                return Encoding.GetEncoding(name);
+            }
+
+            public override void Write(System.Text.Json.Utf8JsonWriter writer, Encoding value, System.Text.Json.JsonSerializerOptions options)
+            {
+                writer.WriteStringValue(value.WebName);
+            }
         }
 
         [Fact]
@@ -36,10 +59,30 @@ namespace LLama.Unittest
                 GpuLayerCount = 111
             };
 
-            var json = Newtonsoft.Json.JsonConvert.SerializeObject(expected);
-            var actual = Newtonsoft.Json.JsonConvert.DeserializeObject<ModelParams>(json);
+            var settings = new Newtonsoft.Json.JsonSerializerSettings();
+            settings.Converters.Add(new NewtsonsoftEncodingConverter());
+
+            var json = Newtonsoft.Json.JsonConvert.SerializeObject(expected, settings);
+            var actual = Newtonsoft.Json.JsonConvert.DeserializeObject<ModelParams>(json, settings);
 
             Assert.Equal(expected, actual);
+        }
+
+        private class NewtsonsoftEncodingConverter
+            : Newtonsoft.Json.JsonConverter<Encoding>
+        {
+            public override void WriteJson(JsonWriter writer, Encoding? value, JsonSerializer serializer)
+            {
+                writer.WriteValue((string?)value?.WebName);
+            }
+
+            public override Encoding? ReadJson(JsonReader reader, Type objectType, Encoding? existingValue, bool hasExistingValue, JsonSerializer serializer)
+            {
+                var name = (string?)reader.Value;
+                if (name == null)
+                    return null;
+                return Encoding.GetEncoding(name);
+            }
         }
     }
 }

--- a/LLama.Web/Common/ModelOptions.cs
+++ b/LLama.Web/Common/ModelOptions.cs
@@ -1,4 +1,5 @@
-﻿using LLama.Abstractions;
+﻿using System.Text;
+using LLama.Abstractions;
 
 namespace LLama.Web.Common
 {
@@ -115,6 +116,6 @@ namespace LLama.Web.Common
         /// <summary>
         /// The encoding to use for models
         /// </summary>
-        public string Encoding { get; set; } = "UTF-8";
+        public Encoding Encoding { get; set; } = Encoding.UTF8;
     }
 }

--- a/LLama.WebAPI/Services/StatefulChatService.cs
+++ b/LLama.WebAPI/Services/StatefulChatService.cs
@@ -16,7 +16,10 @@ public class StatefulChatService : IDisposable
 
     public StatefulChatService(IConfiguration configuration)
     {
-        _context = new LLamaContext(new Common.ModelParams(configuration["ModelPath"], contextSize: 512));
+        _context = new LLamaContext(new Common.ModelParams(configuration["ModelPath"])
+        {
+            ContextSize = 512
+        });
         _session = new ChatSession(new InteractiveExecutor(_context));
     }
 

--- a/LLama.WebAPI/Services/StatelessChatService.cs
+++ b/LLama.WebAPI/Services/StatelessChatService.cs
@@ -12,7 +12,10 @@ namespace LLama.WebAPI.Services
 
         public StatelessChatService(IConfiguration configuration)
         {
-            _context = new LLamaContext(new ModelParams(configuration["ModelPath"], contextSize: 512));
+            _context = new LLamaContext(new ModelParams(configuration["ModelPath"])
+            {
+                ContextSize = 512,
+            });
             // TODO: replace with a stateless executor
             _session = new ChatSession(new InteractiveExecutor(_context))
                         .WithOutputTransform(new LLamaTransforms.KeywordTextOutputStreamTransform(new string[] { "User:", "Assistant:" }, redundancyLength: 8))

--- a/LLama/Abstractions/IModelParams.cs
+++ b/LLama/Abstractions/IModelParams.cs
@@ -1,4 +1,6 @@
-﻿namespace LLama.Abstractions
+﻿using System.Text;
+
+namespace LLama.Abstractions
 {
     public interface IModelParams
     {
@@ -121,6 +123,6 @@
         /// <summary>
         /// The encoding to use for models
         /// </summary>
-        string Encoding { get; set; }
+        Encoding Encoding { get; set; }
     }
 }

--- a/LLama/Common/ModelParams.cs
+++ b/LLama/Common/ModelParams.cs
@@ -6,7 +6,7 @@ namespace LLama.Common
     /// <summary>
     /// The parameters for initializing a LLama model.
     /// </summary>
-    public class ModelParams
+    public record ModelParams
         : IModelParams
     {
         /// <summary>
@@ -120,6 +120,22 @@ namespace LLama.Common
         /// 
         /// </summary>
         /// <param name="modelPath">The model path.</param>
+        [System.Text.Json.Serialization.JsonConstructor]
+        public ModelParams(string modelPath)
+        {
+            ModelPath = modelPath;
+        }
+
+        private ModelParams()
+        {
+            // This constructor (default parameterless constructor) is used by Newtonsoft to deserialize!
+            ModelPath = "";
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="modelPath">The model path.</param>
         /// <param name="contextSize">Model context size (n_ctx)</param>
         /// <param name="gpuLayerCount">Number of layers to run in VRAM / GPU memory (n_gpu_layers)</param>
         /// <param name="seed">Seed for the random number generator (seed)</param>
@@ -139,6 +155,7 @@ namespace LLama.Common
         /// <param name="ropeFrequencyScale">RoPE frequency scaling factor</param>
         /// <param name="mulMatQ">Use experimental mul_mat_q kernels</param>
         /// <param name="encoding">The encoding to use to convert text for the model</param>
+        [Obsolete("Use object initializer to set all optional parameters")]
         public ModelParams(string modelPath, int contextSize = 512, int gpuLayerCount = 20,
                            int seed = 1337, bool useFp16Memory = true,
                            bool useMemorymap = true, bool useMemoryLock = false, bool perplexity = false,
@@ -161,10 +178,10 @@ namespace LLama.Common
             BatchSize = batchSize;
             ConvertEosToNewLine = convertEosToNewLine;
             EmbeddingMode = embeddingMode;
-            GroupedQueryAttention  = groupedQueryAttention;
+            GroupedQueryAttention = groupedQueryAttention;
             RmsNormEpsilon = rmsNormEpsilon;
-            RopeFrequencyBase  = ropeFrequencyBase;
-            RopeFrequencyScale  = ropeFrequencyScale;
+            RopeFrequencyBase = ropeFrequencyBase;
+            RopeFrequencyScale = ropeFrequencyScale;
             MulMatQ = mulMatQ;
             Encoding = encoding;
         }

--- a/LLama/Common/ModelParams.cs
+++ b/LLama/Common/ModelParams.cs
@@ -1,6 +1,7 @@
 ﻿using LLama.Abstractions;
 using System;
 using System.Text;
+using System.Text.Json.Serialization;
 
 namespace LLama.Common
 {
@@ -121,7 +122,7 @@ namespace LLama.Common
         /// 
         /// </summary>
         /// <param name="modelPath">The model path.</param>
-        [System.Text.Json.Serialization.JsonConstructor]
+        [JsonConstructor]
         public ModelParams(string modelPath)
         {
             ModelPath = modelPath;

--- a/LLama/Common/ModelParams.cs
+++ b/LLama/Common/ModelParams.cs
@@ -1,6 +1,7 @@
 ﻿using LLama.Abstractions;
 using System;
 using System.Text;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace LLama.Common
@@ -116,6 +117,7 @@ namespace LLama.Common
         /// <summary>
         /// The encoding to use to convert text for the model
         /// </summary>
+        [JsonConverter(typeof(EncodingConverter))]
         public Encoding Encoding { get; set; } = Encoding.UTF8;
 
         /// <summary>
@@ -186,6 +188,23 @@ namespace LLama.Common
             RopeFrequencyScale = ropeFrequencyScale;
             MulMatQ = mulMatQ;
             Encoding = Encoding.GetEncoding(encoding);
+        }
+    }
+
+    internal class EncodingConverter
+        : JsonConverter<Encoding>
+    {
+        public override Encoding? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var name = reader.GetString();
+            if (name == null)
+                return null;
+            return Encoding.GetEncoding(name);
+        }
+
+        public override void Write(Utf8JsonWriter writer, Encoding value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.WebName);
         }
     }
 }

--- a/LLama/Common/ModelParams.cs
+++ b/LLama/Common/ModelParams.cs
@@ -1,5 +1,6 @@
 ﻿using LLama.Abstractions;
 using System;
+using System.Text;
 
 namespace LLama.Common
 {
@@ -114,7 +115,7 @@ namespace LLama.Common
         /// <summary>
         /// The encoding to use to convert text for the model
         /// </summary>
-        public string Encoding { get; set; } = "UTF-8";
+        public Encoding Encoding { get; set; } = Encoding.UTF8;
 
         /// <summary>
         /// 
@@ -183,7 +184,7 @@ namespace LLama.Common
             RopeFrequencyBase = ropeFrequencyBase;
             RopeFrequencyScale = ropeFrequencyScale;
             MulMatQ = mulMatQ;
-            Encoding = encoding;
+            Encoding = Encoding.GetEncoding(encoding);
         }
     }
 }

--- a/LLama/LLamaContext.cs
+++ b/LLama/LLamaContext.cs
@@ -68,7 +68,7 @@ namespace LLama
             Params = @params;
 
             _logger = logger;
-            _encoding = Encoding.GetEncoding(@params.Encoding);
+            _encoding = @params.Encoding;
 
             _logger?.Log(nameof(LLamaContext), $"Initializing LLama model with params: {this.Params}", ILLamaLogger.LogLevel.Info);
             _ctx = Utils.InitLLamaContextFromModelParams(Params);
@@ -79,7 +79,7 @@ namespace LLama
             Params = @params;
 
             _logger = logger;
-            _encoding = Encoding.GetEncoding(@params.Encoding);
+            _encoding = @params.Encoding;
             _ctx = nativeContext;
         }
 
@@ -98,7 +98,7 @@ namespace LLama
             Params = @params;
 
             _logger = logger;
-            _encoding = Encoding.GetEncoding(@params.Encoding);
+            _encoding = @params.Encoding;
 
             using var pin = @params.ToLlamaContextParams(out var lparams);
             _ctx = SafeLLamaContextHandle.Create(model.NativeHandle, lparams);

--- a/LLama/LLamaStatelessExecutor.cs
+++ b/LLama/LLamaStatelessExecutor.cs
@@ -47,7 +47,7 @@ namespace LLama
         [Obsolete("Use the constructor which automatically creates contexts using the LLamaWeights")]
         public StatelessExecutor(LLamaContext context)
         {
-            _weights = new LLamaWeights(context.NativeHandle.ModelHandle, Encoding.GetEncoding(context.Params.Encoding));
+            _weights = new LLamaWeights(context.NativeHandle.ModelHandle, context.Params.Encoding);
             _params = context.Params;
 
             Context = _weights.CreateContext(_params);

--- a/LLama/LLamaWeights.cs
+++ b/LLama/LLamaWeights.cs
@@ -59,7 +59,7 @@ namespace LLama
             if (!string.IsNullOrEmpty(@params.LoraAdapter))
                 weights.ApplyLoraFromFile(@params.LoraAdapter, @params.LoraBase, @params.Threads);
 
-            return new LLamaWeights(weights, Encoding.GetEncoding(@params.Encoding));
+            return new LLamaWeights(weights, @params.Encoding);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Converted ModelParams into a `record` class. This has several advantanges:
 - Equality, hashing etc all implemented automatically
 - Default values are defined in just one place (the properties) instead of the constructor as well
 - Added test to ensure that serialization works properly

Also added tests to ensure the ModelParams class can be round tripped through JSON using both System.Text.Json and Newtonsoft.