### PR TITLE
Changed type conversion

### DIFF
--- a/LLama/Native/LLamaContextParams.cs
+++ b/LLama/Native/LLamaContextParams.cs
@@ -77,8 +77,8 @@ namespace LLama.Native
         /// </summary>
         public bool low_vram
         {
-            get => Utils.SignedByteToBool(_low_vram);
-            set => _low_vram = Utils.BoolToSignedByte(value);
+            get => Convert.ToBoolean(_low_vram);
+            set => _low_vram = Convert.ToSByte(value);
         }
         private sbyte _low_vram;
 
@@ -87,8 +87,8 @@ namespace LLama.Native
         /// </summary>
         public bool mul_mat_q
         {
-            get => Utils.SignedByteToBool(_mul_mat_q);
-            set => _mul_mat_q = Utils.BoolToSignedByte(value);
+            get => Convert.ToBoolean(_mul_mat_q);
+            set => _mul_mat_q = Convert.ToSByte(value);
         }
         private sbyte _mul_mat_q;
 
@@ -97,8 +97,8 @@ namespace LLama.Native
         /// </summary>
         public bool f16_kv
         {
-            get => Utils.SignedByteToBool(_f16_kv);
-            set => _f16_kv = Utils.BoolToSignedByte(value);
+            get => Convert.ToBoolean(_f16_kv);
+            set => _f16_kv = Convert.ToSByte(value);
         }
         private sbyte _f16_kv;
 
@@ -107,8 +107,8 @@ namespace LLama.Native
         /// </summary>
         public bool logits_all
         {
-            get => Utils.SignedByteToBool(_logits_all);
-            set => _logits_all = Utils.BoolToSignedByte(value);
+            get => Convert.ToBoolean(_logits_all);
+            set => _logits_all = Convert.ToSByte(value);
         }
         private sbyte _logits_all;
 
@@ -117,8 +117,8 @@ namespace LLama.Native
         /// </summary>
         public bool vocab_only
         {
-            get => Utils.SignedByteToBool(_vocab_only);
-            set => _vocab_only = Utils.BoolToSignedByte(value);
+            get => Convert.ToBoolean(_vocab_only);
+            set => _vocab_only = Convert.ToSByte(value);
         }
         private sbyte _vocab_only;
 
@@ -127,8 +127,8 @@ namespace LLama.Native
         /// </summary>
         public bool use_mmap
         {
-            get => Utils.SignedByteToBool(_use_mmap);
-            set => _use_mmap = Utils.BoolToSignedByte(value);
+            get => Convert.ToBoolean(_use_mmap);
+            set => _use_mmap = Convert.ToSByte(value);
         }
         private sbyte _use_mmap;
 
@@ -137,8 +137,8 @@ namespace LLama.Native
         /// </summary>
         public bool use_mlock
         {
-            get => Utils.SignedByteToBool(_use_mlock);
-            set => _use_mlock = Utils.BoolToSignedByte(value);
+            get => Convert.ToBoolean(_use_mlock);
+            set => _use_mlock = Convert.ToSByte(value);
         }
         private sbyte _use_mlock;
 
@@ -147,8 +147,8 @@ namespace LLama.Native
         /// </summary>
         public bool embedding
         {
-            get => Utils.SignedByteToBool(_embedding);
-            set => _embedding = Utils.BoolToSignedByte(value);
+            get => Convert.ToBoolean(_embedding);
+            set => _embedding = Convert.ToSByte(value);
         }
         private sbyte _embedding;
     }

--- a/LLama/Native/LLamaModelQuantizeParams.cs
+++ b/LLama/Native/LLamaModelQuantizeParams.cs
@@ -1,4 +1,6 @@
-﻿namespace LLama.Native
+﻿using System;
+
+namespace LLama.Native
 {
     /// <summary>
     /// Quantizer parameters used in the native API
@@ -20,8 +22,8 @@
         /// </summary>
         public bool allow_requantize
         {
-            get => Utils.SignedByteToBool(_allow_requantize);
-            set => _allow_requantize = Utils.BoolToSignedByte(value);
+            get => Convert.ToBoolean(_allow_requantize);
+            set => _allow_requantize = Convert.ToSByte(value);
         }
         private sbyte _allow_requantize;
 
@@ -30,8 +32,8 @@
         /// </summary>
         public bool quantize_output_tensor
         {
-            get => Utils.SignedByteToBool(_quantize_output_tensor);
-            set => _quantize_output_tensor = Utils.BoolToSignedByte(value);
+            get => Convert.ToBoolean(_quantize_output_tensor);
+            set => _quantize_output_tensor = Convert.ToSByte(value);
         }
         private sbyte _quantize_output_tensor;
     }

--- a/LLama/Native/LLamaTokenDataArray.cs
+++ b/LLama/Native/LLamaTokenDataArray.cs
@@ -53,8 +53,8 @@ namespace LLama.Native
         /// </summary>
         public bool sorted
         {
-            get => Utils.SignedByteToBool(_sorted);
-            set => _sorted = Utils.BoolToSignedByte(value);
+            get => Convert.ToBoolean(_sorted);
+            set => _sorted = Convert.ToSByte(value);
         }
         private sbyte _sorted;
 

--- a/LLama/Utils.cs
+++ b/LLama/Utils.cs
@@ -84,26 +84,6 @@ namespace LLama
             }
 #endif
         }
-            
-        /// <summary>
-        /// Converts a bool "value" to a signed byte of "1" for true and "0" for false to be compatible with a 1 byte C-style bool.
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        public static sbyte BoolToSignedByte(bool value)
-        {
-            return value ? (sbyte)1 : (sbyte)0;
-        }
-
-        /// <summary>
-        /// Converts a sbyte "value" to a C# bool.
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        public static bool SignedByteToBool(sbyte value)
-        {
-            return value > 0;
-        }
-
+           
     }
 }


### PR DESCRIPTION
Removed the Utils methods for converting types from the [.Net Framework Fix Commit](https://github.com/SciSharp/LLamaSharp/commit/10f88ebd0e982fab8349d9816631bfaae7e179ce), on further reflection I think it makes more sense to do this where it was done before and using the System.Convert class ensures consistency, this also ensures any systems that set a negative 8bit int for true are handled correctly.