### PR TITLE
Translating the grammar parser

### DIFF
--- a/LLama.Examples/Assets/json.gbnf
+++ b/LLama.Examples/Assets/json.gbnf
@@ -1,0 +1,27 @@
+# https://github.com/ggerganov/llama.cpp/blob/8183159cf3def112f6d1fe94815fce70e1bffa12/grammars/json.gbnf
+
+root   ::= object
+value  ::= object | array | string | number | ("true" | "false" | "null") ws
+
+object ::=
+  "{" ws (
+            string ":" ws value
+    ("," ws string ":" ws value)*
+  )? "}" ws
+
+array  ::=
+  "[" ws (
+            value
+    ("," ws value)*
+  )? "]" ws
+
+string ::=
+  "\"" (
+    [^"\\] |
+    "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]) # escapes
+  )* "\"" ws
+
+number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? ws
+
+# Optional space: by convention, applied in this grammar after literal chars when allowed
+ws ::= ([ \t\n] ws)?

--- a/LLama.Examples/LLama.Examples.csproj
+++ b/LLama.Examples/LLama.Examples.csproj
@@ -49,6 +49,9 @@
     <None Update="Assets\dan.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Assets\json.gbnf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Assets\reason-act.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/LLama.Examples/NewVersion/GrammarJsonResponse.cs
+++ b/LLama.Examples/NewVersion/GrammarJsonResponse.cs
@@ -1,0 +1,55 @@
+﻿using LLama.Common;
+using LLama.Grammar;
+using LLama.Native;
+
+namespace LLama.Examples.NewVersion
+{
+    public class GrammarJsonResponse
+    {
+        public static void Run()
+        {
+            var grammarBytes = File.ReadAllText("Assets/json.gbnf").Trim();
+            var parsedGrammar = new GrammarParser();
+
+            Console.Write("Please input your model path: ");
+            var modelPath = Console.ReadLine();
+
+            var parameters = new ModelParams(modelPath)
+            {
+                ContextSize = 1024,
+                Seed = 1337,
+                GpuLayerCount = 5
+            };
+            using var model = LLamaWeights.LoadFromFile(parameters);
+            var ex = new StatelessExecutor(model, parameters);
+            ParseState state = parsedGrammar.Parse(grammarBytes);
+            using var grammar = SafeLLamaGrammarHandle.Create(state.Rules, 0);
+
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.WriteLine("The executor has been enabled. In this example, the LLM will follow your instructions and always respond in a JSON format. For example, you can input \"Tell me the attributes of a good dish\"");
+            Console.ForegroundColor = ConsoleColor.White;
+
+            var inferenceParams = new InferenceParams() 
+            { 
+                Temperature = 0.6f, 
+                AntiPrompts = new List<string> { "Question:", "#", "Question: ", ".\n" }, 
+                MaxTokens = 50,
+                Grammar = grammar
+            };
+
+            while (true)
+            {
+                Console.Write("\nQuestion: ");
+                Console.ForegroundColor = ConsoleColor.Green;
+                var prompt = Console.ReadLine();
+                Console.ForegroundColor = ConsoleColor.White;
+                Console.Write("Answer: ");
+                prompt = $"Question: {prompt?.Trim()} Answer: ";
+                foreach (var text in ex.Infer(prompt, inferenceParams))
+                {
+                    Console.Write(text);
+                }
+            }
+        }
+    }
+}

--- a/LLama.Examples/NewVersion/TestRunner.cs
+++ b/LLama.Examples/NewVersion/TestRunner.cs
@@ -17,6 +17,7 @@
             Console.WriteLine("7: Get embeddings from LLama model.");
             Console.WriteLine("8: Quantize the model.");
             Console.WriteLine("9: Automatic conversation.");
+            Console.WriteLine("10: Constrain response to json format using grammar.");
 
             while (true)
             {
@@ -62,6 +63,10 @@
                 else if (choice == 9)
                 {
                     await TalkToYourself.Run();
+                }
+                else if (choice == 10)
+                {
+                    GrammarJsonResponse.Run();
                 }
                 else
                 {

--- a/LLama.Unittest/GrammarParserTest.cs
+++ b/LLama.Unittest/GrammarParserTest.cs
@@ -68,7 +68,7 @@ namespace LLama.Unittest
                 new LLamaGrammarElement(LLamaGrammarElementType.END, 0),
                 new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 1),
                 new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 4),
-                new LLamaGrammarElement(LLamaGrammarElementType.END, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.ALT, 0),
                 new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 1),
                 new LLamaGrammarElement(LLamaGrammarElementType.END, 0),
                 new LLamaGrammarElement(LLamaGrammarElementType.CHAR, 45),

--- a/LLama.Unittest/GrammarParserTest.cs
+++ b/LLama.Unittest/GrammarParserTest.cs
@@ -6,6 +6,12 @@ using Newtonsoft.Json.Linq;
 
 namespace LLama.Unittest
 {
+    /// <summary>
+    /// Source:
+    /// https://github.com/ggerganov/llama.cpp/blob/6381d4e110bd0ec02843a60bbeb8b6fc37a9ace9/tests/test-grammar-parser.cpp
+    /// 
+    /// The commit hash from URL is the actual commit hash that reflects current C# code.
+    /// </summary>
     public sealed class GrammarParserTest
     {
         [Fact]
@@ -88,6 +94,156 @@ namespace LLama.Unittest
                 new LLamaGrammarElement(LLamaGrammarElementType.CHAR, 48),
                 new LLamaGrammarElement(LLamaGrammarElementType.CHAR_RNG_UPPER, 57),
                 new LLamaGrammarElement(LLamaGrammarElementType.END, 0),
+            };
+
+            index = 0;
+            foreach (var rule in state.Rules)
+            {
+                // compare rule to expected rule
+                for (uint i = 0; i < rule.Count; i++)
+                {
+                    var element = rule[(int)i];
+                    var expectedElement = expectedRules[(int)index];
+
+                    // Pretty print error message before asserting
+                    if (expectedElement.Type != element.Type || expectedElement.Value != element.Value)
+                    {
+                        Console.Error.WriteLine($"index: {index}");
+                        Console.Error.WriteLine($"expected_element: {expectedElement.Type}, {expectedElement.Value}");
+                        Console.Error.WriteLine($"actual_element: {element.Type}, {element.Value}");
+                        Console.Error.WriteLine("expected_element != actual_element");
+                    }
+                    Assert.Equal(expectedElement.Type, element.Type);
+                    Assert.Equal(expectedElement.Value, element.Value);
+                    index++;
+                }
+            }
+            Assert.NotEmpty(state.Rules);
+        }
+
+        [Fact]
+        public void ParseExtraComplexGrammar()
+        {
+            GrammarParser parsedGrammar = new GrammarParser();
+            string grammarBytes = @"
+                root  ::= (expr ""="" ws term ""\n"")+
+                expr  ::= term ([-+*/] term)*
+                term  ::= ident | num | ""("" ws expr "")"" ws
+                ident ::= [a-z] [a-z0-9_]* ws
+                num   ::= [0-9]+ ws
+                ws    ::= [ \t\n]*
+            ";
+
+            ParseState state = parsedGrammar.Parse(grammarBytes);
+
+            List<KeyValuePair<string, uint>> expected = new List<KeyValuePair<string, uint>>
+            {
+                new KeyValuePair<string, uint>("expr", 2),
+                new KeyValuePair<string, uint>("expr_6", 6),
+                new KeyValuePair<string, uint>("expr_7", 7),
+                new KeyValuePair<string, uint>("ident", 8),
+                new KeyValuePair<string, uint>("ident_10", 10),
+                new KeyValuePair<string, uint>("num", 9),
+                new KeyValuePair<string, uint>("num_11", 11),
+                new KeyValuePair<string, uint>("root", 0),
+                new KeyValuePair<string, uint>("root_1", 1),
+                new KeyValuePair<string, uint>("root_5", 5),
+                new KeyValuePair<string, uint>("term", 4),
+                new KeyValuePair<string, uint>("ws", 3),
+                new KeyValuePair<string, uint>("ws_12", 12),
+            };
+
+            uint index = 0;
+            foreach (var it in state.SymbolIds)
+            {
+                string key = it.Key;
+                uint value = it.Value;
+                var expectedPair = expected[(int)index];
+
+                // pretty print error message before asserting
+                if (expectedPair.Key != key || expectedPair.Value != value)
+                {
+                    Console.Error.WriteLine($"expectedPair: {expectedPair.Key}, {expectedPair.Value}");
+                    Console.Error.WriteLine($"actualPair: {key}, {value}");
+                    Console.Error.WriteLine("expectedPair != actualPair");
+                }
+                Assert.Equal(expectedPair.Key, key);
+                Assert.Equal(expectedPair.Value, value);
+
+                index++;
+            }
+            Assert.NotEmpty(state.SymbolIds);
+
+
+            var expectedRules = new List<LLamaGrammarElement>
+            {
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 5),
+                new LLamaGrammarElement(LLamaGrammarElementType.END, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 2),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR, 61),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 3),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 4),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR, 10),
+                new LLamaGrammarElement(LLamaGrammarElementType.END, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 4),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 7),
+                new LLamaGrammarElement(LLamaGrammarElementType.END, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 12),
+                new LLamaGrammarElement(LLamaGrammarElementType.END, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 8),
+                new LLamaGrammarElement(LLamaGrammarElementType.ALT, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 9),
+                new LLamaGrammarElement(LLamaGrammarElementType.ALT, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR, 40),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 3),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 2),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR, 41),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 3),
+                new LLamaGrammarElement(LLamaGrammarElementType.END, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 1),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 5),
+                new LLamaGrammarElement(LLamaGrammarElementType.ALT, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 1),
+                new LLamaGrammarElement(LLamaGrammarElementType.END, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR, 45),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR_ALT, 43),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR_ALT, 42),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR_ALT, 47),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 4),
+                new LLamaGrammarElement(LLamaGrammarElementType.END, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 6),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 7),
+                new LLamaGrammarElement(LLamaGrammarElementType.ALT, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.END, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR, 97),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR_RNG_UPPER, 122),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 10),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 3),
+                new LLamaGrammarElement(LLamaGrammarElementType.END, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 11),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 3),
+                new LLamaGrammarElement(LLamaGrammarElementType.END, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR, 97),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR_RNG_UPPER, 122),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR_ALT, 48),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR_RNG_UPPER, 57),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR_ALT, 95),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 10),
+                new LLamaGrammarElement(LLamaGrammarElementType.ALT, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.END, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR, 48),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR_RNG_UPPER, 57),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 11),
+                new LLamaGrammarElement(LLamaGrammarElementType.ALT, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR, 48),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR_RNG_UPPER, 57),
+                new LLamaGrammarElement(LLamaGrammarElementType.END, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR, 32),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR_ALT, 9),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR_ALT, 10),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 12),
+                new LLamaGrammarElement(LLamaGrammarElementType.ALT, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.END, 0)
             };
 
             index = 0;

--- a/LLama.Unittest/GrammarParserTest.cs
+++ b/LLama.Unittest/GrammarParserTest.cs
@@ -1,0 +1,118 @@
+﻿using LLama.Common;
+using LLama.Native;
+using System.Diagnostics;
+using LLama.Grammar;
+using Newtonsoft.Json.Linq;
+
+namespace LLama.Unittest
+{
+    public sealed class GrammarParserTest
+    {
+        [Fact]
+        public void ParseComplexGrammar()
+        {
+            GrammarParser parsedGrammar = new GrammarParser();
+            string grammarBytes = @"root  ::= (expr ""="" term ""\n"")+
+                expr  ::= term ([-+*/] term)*
+                term  ::= [0-9]+";
+
+            ParseState state = parsedGrammar.Parse(grammarBytes);
+
+            List<KeyValuePair<string, uint>> expected = new List<KeyValuePair<string, uint>>
+            {
+                new KeyValuePair<string, uint>("expr", 2),
+                new KeyValuePair<string, uint>("expr_5", 5),
+                new KeyValuePair<string, uint>("expr_6", 6),
+                new KeyValuePair<string, uint>("root", 0),
+                new KeyValuePair<string, uint>("root_1", 1),
+                new KeyValuePair<string, uint>("root_4", 4),
+                new KeyValuePair<string, uint>("term", 3),
+                new KeyValuePair<string, uint>("term_7", 7),
+            };
+
+            uint index = 0;
+            foreach (var it in state.SymbolIds)
+            {
+                string key = it.Key;
+                uint value = it.Value;
+                var expectedPair = expected[(int)index];
+
+                // pretty print error message before asserting
+                if (expectedPair.Key != key || expectedPair.Value != value)
+                {
+                    Console.Error.WriteLine($"expectedPair: {expectedPair.Key}, {expectedPair.Value}");
+                    Console.Error.WriteLine($"actualPair: {key}, {value}");
+                    Console.Error.WriteLine("expectedPair != actualPair");
+                }
+                Assert.Equal(expectedPair.Key, key);
+                Assert.Equal(expectedPair.Value, value);
+
+                index++;
+            }
+            Assert.NotEmpty(state.SymbolIds);
+
+
+            var expectedRules = new List<LLamaGrammarElement>
+            {
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 4),
+                new LLamaGrammarElement(LLamaGrammarElementType.END, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 2),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR, 61),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 3),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR, 10),
+                new LLamaGrammarElement(LLamaGrammarElementType.END, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 3),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 6),
+                new LLamaGrammarElement(LLamaGrammarElementType.END, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 7),
+                new LLamaGrammarElement(LLamaGrammarElementType.END, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 1),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 4),
+                new LLamaGrammarElement(LLamaGrammarElementType.END, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 1),
+                new LLamaGrammarElement(LLamaGrammarElementType.END, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR, 45),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR_ALT, 43),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR_ALT, 42),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR_ALT, 47),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 3),
+                new LLamaGrammarElement(LLamaGrammarElementType.END, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 5),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 6),
+                new LLamaGrammarElement(LLamaGrammarElementType.ALT, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.END, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR, 48),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR_RNG_UPPER, 57),
+                new LLamaGrammarElement(LLamaGrammarElementType.RULE_REF, 7),
+                new LLamaGrammarElement(LLamaGrammarElementType.ALT, 0),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR, 48),
+                new LLamaGrammarElement(LLamaGrammarElementType.CHAR_RNG_UPPER, 57),
+                new LLamaGrammarElement(LLamaGrammarElementType.END, 0),
+            };
+
+            index = 0;
+            foreach (var rule in state.Rules)
+            {
+                // compare rule to expected rule
+                for (uint i = 0; i < rule.Count; i++)
+                {
+                    var element = rule[(int)i];
+                    var expectedElement = expectedRules[(int)index];
+
+                    // Pretty print error message before asserting
+                    if (expectedElement.Type != element.Type || expectedElement.Value != element.Value)
+                    {
+                        Console.Error.WriteLine($"index: {index}");
+                        Console.Error.WriteLine($"expected_element: {expectedElement.Type}, {expectedElement.Value}");
+                        Console.Error.WriteLine($"actual_element: {element.Type}, {element.Value}");
+                        Console.Error.WriteLine("expected_element != actual_element");
+                    }
+                    Assert.Equal(expectedElement.Type, element.Type);
+                    Assert.Equal(expectedElement.Value, element.Value);
+                    index++;
+                }
+            }
+            Assert.NotEmpty(state.Rules);
+        }
+    }
+}

--- a/LLama/Exceptions/GrammarFormatException.cs
+++ b/LLama/Exceptions/GrammarFormatException.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace LLama.Exceptions
+{
+    public class GrammarFormatException
+        : Exception
+    {
+        public GrammarFormatException()
+        {
+
+        }
+
+        public GrammarFormatException(string message)
+            : base(message)
+        {
+
+        }
+    }
+}

--- a/LLama/Grammar/GrammarParser.cs
+++ b/LLama/Grammar/GrammarParser.cs
@@ -42,7 +42,7 @@ namespace LLama.Grammar
         private uint GetSymbolId(ParseState state, ReadOnlySpan<byte> src, int len)
         {
             uint nextId = (uint)state.SymbolIds.Count;
-            string key = Encoding.UTF8.GetString(src.Slice(0, len).ToArray());
+            string key = Encoding.UTF8.GetString(src.Slice(0, src.Length - len).ToArray());
 
             if (state.SymbolIds.TryGetValue(key, out uint existingId))
             {
@@ -344,7 +344,7 @@ namespace LLama.Grammar
             ReadOnlySpan<byte> nameEnd = ParseName(src);
             ReadOnlySpan<byte> pos = ParseSpace(nameEnd, false);
             int nameLen = src.Length - nameEnd.Length;
-            uint ruleId = GetSymbolId(state, src.Slice(0, nameLen), nameLen);
+            uint ruleId = GetSymbolId(state, src.Slice(0, nameLen), 0);
             string name = Encoding.UTF8.GetString(src.Slice(0, nameLen).ToArray());
 
             if (!(pos[0] == ':' && pos[1] == ':' && pos[2] == '='))

--- a/LLama/Grammar/GrammarParser.cs
+++ b/LLama/Grammar/GrammarParser.cs
@@ -372,25 +372,17 @@ namespace LLama.Grammar
 
         public ParseState Parse(string input)
         {
-            try
-            {
-                byte[] byteArray = Encoding.UTF8.GetBytes(input);
-                ReadOnlySpan<byte> src = new ReadOnlySpan<byte>(byteArray);
-                ParseState state = new ParseState();
-                ReadOnlySpan<byte> pos = ParseSpace(src, true);
+            byte[] byteArray = Encoding.UTF8.GetBytes(input);
+            ReadOnlySpan<byte> src = new ReadOnlySpan<byte>(byteArray);
+            ParseState state = new ParseState();
+            ReadOnlySpan<byte> pos = ParseSpace(src, true);
 
-                while (!pos.IsEmpty)
-                {
-                    pos = ParseRule(state, pos);
-                }
-
-                return state;
-            }
-            catch(Exception err)
+            while (!pos.IsEmpty)
             {
-                Console.Error.WriteLine($"{nameof(Parse)}: error parsing grammar: {err.Message}");
-                throw;
+                pos = ParseRule(state, pos);
             }
+
+            return state;
         }
     }
 }

--- a/LLama/Grammar/GrammarParser.cs
+++ b/LLama/Grammar/GrammarParser.cs
@@ -1,0 +1,328 @@
+﻿using LLama.Native;
+using System;
+using System.Collections.Generic;
+
+namespace LLama.Grammar
+{
+    /// <summary>
+    /// Source:
+    /// https://github.com/ggerganov/llama.cpp/blob/6381d4e110bd0ec02843a60bbeb8b6fc37a9ace9/common/grammar-parser.cpp
+    /// 
+    /// The commit hash from URL is the actual commit hash that reflects current C# code.
+    /// </summary>
+    internal class GrammarParser
+    {
+        // NOTE: assumes valid utf8 (but checks for overrun)
+        // copied from llama.cpp
+        public Tuple<uint, ReadOnlyMemory<char>> DecodeUTF8(ReadOnlyMemory<char> src)
+        {
+            ReadOnlySpan<char> span = src.Span;
+            int[] lookup = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 3, 4 };
+
+            byte firstByte = (byte)span[0];
+            byte highbits = (byte)(firstByte >> 4);
+            int len = lookup[highbits];
+            byte mask = (byte)((1 << (8 - len)) - 1);
+            uint value = (uint)(firstByte & mask);
+
+            int end = len;
+            int pos = 1;
+
+            for (; pos < end && pos < src.Length; pos++)
+            {
+                value = (uint)((value << 6) + ((byte)span[pos] & 0x3F));
+            }
+
+            ReadOnlyMemory<char> nextSpan = src.Slice(pos);
+
+            return new Tuple<uint, ReadOnlyMemory<char>>(value, nextSpan);
+        }
+
+        public uint GetSymbolId(ParseState state, ReadOnlySpan<char> src, int len)
+        {
+            uint nextId = (uint)state.SymbolIds.Count;
+            string key = src.Slice(0, len).ToString();
+
+            if (state.SymbolIds.TryGetValue(key, out uint existingId))
+            {
+                return existingId;
+            }
+            else
+            {
+                state.SymbolIds[key] = nextId;
+                return nextId;
+            }
+        }
+
+        public uint GenerateSymbolId(ParseState state, string baseName)
+        {
+            uint nextId = (uint)state.SymbolIds.Count;
+            string key = $"{baseName}_{nextId}";
+            state.SymbolIds[key] = nextId;
+            return nextId;
+        }
+
+        public void AddRule(ParseState state, uint ruleId, List<LLamaGrammarElement> rule)
+        {
+            while (state.Rules.Count <= ruleId)
+            {
+                state.Rules.Add(new List<LLamaGrammarElement>());
+            }
+
+            state.Rules[(int)ruleId] = rule;
+        }
+
+        public bool IsWordChar(char c)
+        {
+            return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || c == '-' || ('0' <= c && c <= '9');
+        }
+
+        public Tuple<uint, ReadOnlyMemory<char>> ParseHex(ReadOnlyMemory<char> src, int size)
+        {
+            int pos = 0;
+            int end = size;
+            uint value = 0;
+
+            ReadOnlySpan<char> srcSpan = src.Span;
+
+            for (; pos < end && pos < src.Length; pos++)
+            {
+                value <<= 4;
+                char c = srcSpan[pos];
+                if ('a' <= c && c <= 'f')
+                {
+                    value += (uint)(c - 'a' + 10);
+                }
+                else if ('A' <= c && c <= 'F')
+                {
+                    value += (uint)(c - 'A' + 10);
+                }
+                else if ('0' <= c && c <= '9')
+                {
+                    value += (uint)(c - '0');
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            if (pos != end)
+            {
+                throw new InvalidOperationException($"Expecting {size} hex chars at {src.ToString()}");
+            }
+
+            return new Tuple<uint, ReadOnlyMemory<char>>(value, src.Slice(pos));
+        }
+
+        public ReadOnlySpan<char> ParseSpace(ReadOnlySpan<char> src, bool newlineOk)
+        {
+            int pos = 0;
+            while (pos < src.Length &&
+                   (src[pos] == ' ' || src[pos] == '\t' || src[pos] == '#' ||
+                    (newlineOk && (src[pos] == '\r' || src[pos] == '\n'))))
+            {
+                if (src[pos] == '#')
+                {
+                    while (pos < src.Length && src[pos] != '\r' && src[pos] != '\n')
+                    {
+                        pos++;
+                    }
+                }
+                else
+                {
+                    pos++;
+                }
+            }
+            return src.Slice(pos);
+        }
+
+        public ReadOnlySpan<char> ParseName(ReadOnlySpan<char> src)
+        {
+            int pos = 0;
+            while (pos < src.Length && IsWordChar(src[pos]))
+            {
+                pos++;
+            }
+            if (pos == 0)
+            {
+                throw new InvalidOperationException($"Expecting name at {src.ToString()}");
+            }
+            return src.Slice(pos);
+        }
+
+        public Tuple<uint, ReadOnlyMemory<char>> ParseChar(ReadOnlyMemory<char> src)
+        {
+            ReadOnlySpan<char> span = src.Span;
+
+            if (span[0] == '\\')
+            {
+                switch (span[1])
+                {
+                    case 'x':
+                        return ParseHex(src.Slice(2), 2);
+                    case 'u':
+                        return ParseHex(src.Slice(2), 4);
+                    case 'U':
+                        return ParseHex(src.Slice(2), 8);
+                    case 't':
+                        return new Tuple<uint, ReadOnlyMemory<char>>('\t', src.Slice(2));
+                    case 'r':
+                        return new Tuple<uint, ReadOnlyMemory<char>>('\r', src.Slice(2));
+                    case 'n':
+                        return new Tuple<uint, ReadOnlyMemory<char>>('\n', src.Slice(2));
+                    case '\\':
+                    case '"':
+                    case '[':
+                    case ']':
+                        return new Tuple<uint, ReadOnlyMemory<char>>(span[1], src.Slice(2));
+                    default:
+                        throw new Exception("Unknown escape at " + src.ToString());
+                }
+            }
+            else if (!span.IsEmpty)
+            {
+                return DecodeUTF8(src);
+            }
+
+            throw new Exception("Unexpected end of input");
+        }
+
+        public ReadOnlySpan<char> ParseSequence(
+            ref ParseState state,
+            ReadOnlyMemory<char> src,
+            string ruleName,
+            List<LLamaGrammarElement> outElements,
+            bool isNested)
+        {
+            int lastSymStart = outElements.Count;
+            var pos = src.Span;
+
+            while (!pos.IsEmpty)
+            {
+                if (pos[0] == '"')  // literal string
+                {
+                    pos = pos.Slice(1);
+                    lastSymStart = outElements.Count;
+
+                    while (pos[0] != '"')
+                    {
+                        var charPair = ParseChar(src);
+                        pos = charPair.Item2.Span;
+                        outElements.Add(new LLamaGrammarElement { Type = LLamaGrammarElementType.CHAR, Value = charPair.Item1 });
+                    }
+                    pos = ParseSpace(pos.Slice(1), isNested);
+                }
+                else if (pos[0] == '[')  // char range(s)
+                {
+                    pos = pos.Slice(1);
+                    var startType = LLamaGrammarElementType.CHAR;
+
+                    if (pos[0] == '^')
+                    {
+                        pos = pos.Slice(1);
+                        startType = LLamaGrammarElementType.CHAR_NOT;
+                    }
+
+                    lastSymStart = outElements.Count;
+
+                    while (pos[0] != ']')
+                    {
+                        var charPair = ParseChar(src);
+                        pos = charPair.Item2.Span;
+                        var type = lastSymStart < outElements.Count ? LLamaGrammarElementType.CHAR_ALT : startType;
+
+                        outElements.Add(new LLamaGrammarElement { Type = type, Value = charPair.Item1 });
+
+                        if (pos[0] == '-' && pos[1] != ']')
+                        {
+                            var endCharPair = ParseChar(src.Slice(1));
+                            pos = endCharPair.Item2.Span;
+                            outElements.Add(new LLamaGrammarElement { Type = LLamaGrammarElementType.CHAR_RNG_UPPER, Value = endCharPair.Item1 });
+                        }
+                    }
+                    pos = ParseSpace(pos.Slice(1), isNested);
+                }
+                else if (IsWordChar(pos[0]))  // rule reference
+                {
+                    var nameEnd = ParseName(pos);
+                    uint refRuleId = GetSymbolId(state, pos, nameEnd.Length);
+                    pos = ParseSpace(nameEnd, isNested);
+                    lastSymStart = outElements.Count;
+                    outElements.Add(new LLamaGrammarElement { Type = LLamaGrammarElementType.RULE_REF, Value = refRuleId });
+                }
+                else if (pos[0] == '(')  // grouping
+                {
+                    // parse nested alternates into synthesized rule
+                    pos = ParseSpace(pos.Slice(1), true);
+                    uint subRuleId = GenerateSymbolId(state, ruleName);
+                    pos = ParseAlternates(state, pos, ruleName, subRuleId, true);
+                    lastSymStart = outElements.Count;
+                    // output reference to synthesized rule
+                    outElements.Add(new LLamaGrammarElement { Type = LLamaGrammarElementType.RULE_REF, Value = subRuleId });
+                    if (pos[0] != ')')
+                    {
+                        throw new Exception($"Expecting ')' at {new string(pos.ToArray())}");
+                    }
+                    pos = ParseSpace(pos.Slice(1), isNested);
+                }
+                else if (pos[0] == '*' || pos[0] == '+' || pos[0] == '?') // repetition operator
+                {
+                    if (lastSymStart == outElements.Count)
+                    {
+                        throw new Exception($"Expecting preceding item to */+/? at {new string(pos.ToArray())}");
+                    }
+
+                    // apply transformation to previous symbol (lastSymStart to end) according to
+                    // rewrite rules:
+                    // S* --> S' ::= S S' |
+                    // S+ --> S' ::= S S' | S
+                    // S? --> S' ::= S |
+                    uint subRuleId = GenerateSymbolId(state, ruleName);
+
+                    List<LLamaGrammarElement> subRule = new List<LLamaGrammarElement>();
+
+                    // add preceding symbol to generated rule
+                    subRule.AddRange(outElements.GetRange(lastSymStart, outElements.Count - lastSymStart));
+
+                    if (pos[0] == '*' || pos[0] == '+')
+                    {
+                        // cause generated rule to recurse
+                        subRule.Add(new LLamaGrammarElement { Type = LLamaGrammarElementType.RULE_REF, Value = subRuleId });
+                    }
+
+                    // mark start of alternate def
+                    subRule.Add(new LLamaGrammarElement { Type = LLamaGrammarElementType.ALT, Value = 0 });
+
+                    if (pos[0] == '+')
+                    {
+                        // add preceding symbol as alternate only for '+' (otherwise empty)
+                        subRule.AddRange(outElements.GetRange(lastSymStart, outElements.Count - lastSymStart));
+                    }
+
+                    subRule.Add(new LLamaGrammarElement { Type = LLamaGrammarElementType.END, Value = 0 });
+
+                    AddRule(state, subRuleId, subRule);
+
+                    // in original rule, replace previous symbol with reference to generated rule
+                    outElements.RemoveRange(lastSymStart, outElements.Count - lastSymStart);
+                    outElements.Add(new LLamaGrammarElement { Type = LLamaGrammarElementType.RULE_REF, Value = subRuleId });
+
+                    pos = ParseSpace(pos.Slice(1), isNested);
+
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            return pos;
+        }
+
+        public ReadOnlySpan<char> ParseAlternates(ParseState state, ReadOnlySpan<char> pos, string ruleName, uint subRuleId, bool v)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/LLama/Grammar/GrammarParser.cs
+++ b/LLama/Grammar/GrammarParser.cs
@@ -1,7 +1,7 @@
-﻿using LLama.Native;
+﻿using LLama.Exceptions;
+using LLama.Native;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Text;
 
 namespace LLama.Grammar
@@ -108,7 +108,7 @@ namespace LLama.Grammar
 
             if (pos != end)
             {
-                throw new InvalidOperationException($"Expecting {size} hex chars at {Encoding.UTF8.GetString(src.ToArray())}");
+                throw new GrammarFormatException($"Expecting {size} hex chars at {Encoding.UTF8.GetString(src.ToArray())}");
             }
             src = src.Slice(pos);
             return value;
@@ -145,7 +145,7 @@ namespace LLama.Grammar
             }
             if (pos == 0)
             {
-                throw new InvalidOperationException($"Expecting name at {Encoding.UTF8.GetString(src.ToArray())}");
+                throw new GrammarFormatException($"Expecting name at {Encoding.UTF8.GetString(src.ToArray())}");
             }
             return src.Slice(pos);
         }
@@ -176,7 +176,7 @@ namespace LLama.Grammar
                     case (byte)']':
                         return chr;
                     default:
-                        throw new Exception("Unknown escape at " + Encoding.UTF8.GetString(src.ToArray()));
+                        throw new GrammarFormatException("Unknown escape at " + Encoding.UTF8.GetString(src.ToArray()));
                 }
             }
             else if (!src.IsEmpty)
@@ -184,7 +184,7 @@ namespace LLama.Grammar
                 return DecodeUTF8(ref src);
             }
 
-            throw new Exception("Unexpected end of input");
+            throw new GrammarFormatException("Unexpected end of input");
         }
 
         private ReadOnlySpan<byte> ParseSequence(
@@ -258,7 +258,7 @@ namespace LLama.Grammar
                     outElements.Add(new LLamaGrammarElement { Type = LLamaGrammarElementType.RULE_REF, Value = subRuleId });
                     if (pos[0] != ')')
                     {
-                        throw new Exception($"Expecting ')' at {Encoding.UTF8.GetString(pos.ToArray())}");
+                        throw new GrammarFormatException($"Expecting ')' at {Encoding.UTF8.GetString(pos.ToArray())}");
                     }
                     pos = ParseSpace(pos.Slice(1), isNested);
                 }
@@ -266,7 +266,7 @@ namespace LLama.Grammar
                 {
                     if (lastSymStart == outElements.Count)
                     {
-                        throw new Exception($"Expecting preceding item to */+/? at {Encoding.UTF8.GetString(pos.ToArray())}");
+                        throw new GrammarFormatException($"Expecting preceding item to */+/? at {Encoding.UTF8.GetString(pos.ToArray())}");
                     }
 
                     // apply transformation to previous symbol (lastSymStart to end) according to
@@ -349,7 +349,7 @@ namespace LLama.Grammar
 
             if (!(pos[0] == ':' && pos[1] == ':' && pos[2] == '='))
             {
-                throw new Exception($"Expecting ::= at {Encoding.UTF8.GetString(pos.ToArray())}");
+                throw new GrammarFormatException($"Expecting ::= at {Encoding.UTF8.GetString(pos.ToArray())}");
             }
             pos = ParseSpace(pos.Slice(3), true);
 
@@ -365,7 +365,7 @@ namespace LLama.Grammar
             }
             else if (!pos.IsEmpty)
             {
-                throw new Exception($"Expecting newline or end at {Encoding.UTF8.GetString(pos.ToArray())}");
+                throw new GrammarFormatException($"Expecting newline or end at {Encoding.UTF8.GetString(pos.ToArray())}");
             }
             return ParseSpace(pos, true);
         }
@@ -386,163 +386,10 @@ namespace LLama.Grammar
 
                 return state;
             }
-            catch (Exception err)
+            catch(Exception err)
             {
                 Console.Error.WriteLine($"{nameof(Parse)}: error parsing grammar: {err.Message}");
-                return new ParseState();
-            }
-        }
-
-        private void PrintGrammarChar(StreamWriter file, uint c)
-        {
-            if (c >= 0x20 && c <= 0x7F)
-            {
-                file.Write((char)c);
-            }
-            else
-            {
-                // cop out of encoding UTF-8
-                file.Write($"<U+{c:X4}>");
-            }
-        }
-
-        private bool IsCharElement(LLamaGrammarElement elem)
-        {
-            switch (elem.Type)
-            {
-                case LLamaGrammarElementType.CHAR:
-                case LLamaGrammarElementType.CHAR_NOT:
-                case LLamaGrammarElementType.CHAR_ALT:
-                case LLamaGrammarElementType.CHAR_RNG_UPPER:
-                    return true;
-                default:
-                    return false;
-            }
-        }
-
-        public void PrintRuleBinary(StreamWriter file, List<LLamaGrammarElement> rule)
-        {
-            foreach (var elem in rule)
-            {
-                switch (elem.Type)
-                {
-                    case LLamaGrammarElementType.END: file.Write("END"); break;
-                    case LLamaGrammarElementType.ALT: file.Write("ALT"); break;
-                    case LLamaGrammarElementType.RULE_REF: file.Write("RULE_REF"); break;
-                    case LLamaGrammarElementType.CHAR: file.Write("CHAR"); break;
-                    case LLamaGrammarElementType.CHAR_NOT: file.Write("CHAR_NOT"); break;
-                    case LLamaGrammarElementType.CHAR_RNG_UPPER: file.Write("CHAR_RNG_UPPER"); break;
-                    case LLamaGrammarElementType.CHAR_ALT: file.Write("CHAR_ALT"); break;
-                }
-                switch (elem.Type)
-                {
-                    case LLamaGrammarElementType.END:
-                    case LLamaGrammarElementType.ALT:
-                    case LLamaGrammarElementType.RULE_REF:
-                        file.Write($"({elem.Value}) ");
-                        break;
-                    case LLamaGrammarElementType.CHAR:
-                    case LLamaGrammarElementType.CHAR_NOT:
-                    case LLamaGrammarElementType.CHAR_RNG_UPPER:
-                    case LLamaGrammarElementType.CHAR_ALT:
-                        file.Write("(\"");
-                        PrintGrammarChar(file, elem.Value);
-                        file.Write("\") ");
-                        break;
-                }
-            }
-            file.WriteLine();
-        }
-
-        private void PrintRule(
-            StreamWriter file,
-            uint ruleId,
-            List<LLamaGrammarElement> rule,
-            Dictionary<uint, string> symbolIdNames)
-        {
-            if (rule.Count == 0 || rule[rule.Count - 1].Type != LLamaGrammarElementType.END)
-            {
-                throw new InvalidOperationException(
-                    $"Malformed rule, does not end with LLamaGrammarElementType.END: {ruleId}");
-            }
-
-            file.Write($"{symbolIdNames[ruleId]} ::= ");
-
-            for (int i = 0, end = rule.Count - 1; i < end; i++)
-            {
-                var elem = rule[i];
-                switch (elem.Type)
-                {
-                    case LLamaGrammarElementType.END:
-                        throw new InvalidOperationException(
-                            $"Unexpected end of rule: {ruleId}, {i}");
-                    case LLamaGrammarElementType.ALT:
-                        file.Write("| ");
-                        break;
-                    case LLamaGrammarElementType.RULE_REF:
-                        file.Write($"{symbolIdNames[elem.Value]} ");
-                        break;
-                    case LLamaGrammarElementType.CHAR:
-                        file.Write("[");
-                        PrintGrammarChar(file, elem.Value);
-                        break;
-                    case LLamaGrammarElementType.CHAR_NOT:
-                        file.Write("[^");
-                        PrintGrammarChar(file, elem.Value);
-                        break;
-                    case LLamaGrammarElementType.CHAR_RNG_UPPER:
-                        if (i == 0 || !IsCharElement(rule[i - 1]))
-                        {
-                            throw new InvalidOperationException(
-                                $"LLamaGrammarElementType.CHAR_RNG_UPPER without preceding char: {ruleId},{i}");
-                        }
-                        file.Write("-");
-                        PrintGrammarChar(file, elem.Value);
-                        break;
-                    case LLamaGrammarElementType.CHAR_ALT:
-                        if (i == 0 || !IsCharElement(rule[i - 1]))
-                        {
-                            throw new InvalidOperationException(
-                                $"LLamaGrammarElementType.CHAR_ALT without preceding char: {ruleId},{i}");
-                        }
-                        PrintGrammarChar(file, elem.Value);
-                        break;
-
-                }
-
-                if (IsCharElement(elem))
-                {
-                    switch (rule[i + 1].Type)
-                    {
-                        case LLamaGrammarElementType.CHAR_ALT:
-                        case LLamaGrammarElementType.CHAR_RNG_UPPER:
-                            break;
-                        default:
-                            file.Write("] ");
-                            break;
-                    }
-                }
-            }
-            file.WriteLine();
-        }
-
-        public void PrintGrammar(StreamWriter file, ParseState state)
-        {
-            try
-            {
-                Dictionary<uint, string> symbolIdNames = new Dictionary<uint, string>();
-                foreach (var kv in state.SymbolIds)
-                {
-                    symbolIdNames[kv.Value] = kv.Key;
-                }
-                for (int i = 0, end = state.Rules.Count; i < end; i++)
-                {
-                    PrintRule(file, (uint)i, state.Rules[i], symbolIdNames);
-                }
-            }
-            catch (Exception err)
-            {
-                Console.Error.WriteLine($"\nError printing grammar: {err.Message}");
+                throw;
             }
         }
     }

--- a/LLama/Grammar/GrammarParser.cs
+++ b/LLama/Grammar/GrammarParser.cs
@@ -1,6 +1,7 @@
 ﻿using LLama.Native;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 
 namespace LLama.Grammar
@@ -335,6 +336,211 @@ namespace LLama.Grammar
             AddRule(state, ruleId, rule);
 
             return pos;
+        }
+
+        public ReadOnlySpan<byte> ParseRule(ParseState state, ReadOnlySpan<byte> src)
+        {
+            ReadOnlySpan<byte> nameEnd = ParseName(src);
+            ReadOnlySpan<byte> pos = ParseSpace(nameEnd, false);
+            int nameLen = nameEnd.Length - src.Length;
+            uint ruleId = GetSymbolId(state, src.Slice(0, nameLen), nameLen);
+            string name = Encoding.UTF8.GetString(src.Slice(0, nameLen).ToArray());
+
+            if (!(pos[0] == ':' && pos[1] == ':' && pos[2] == '='))
+            {
+                throw new Exception($"Expecting ::= at {Encoding.UTF8.GetString(pos.ToArray())}");
+            }
+            pos = ParseSpace(pos.Slice(3), true);
+
+            pos = ParseAlternates(state, pos, name, ruleId, false);
+
+            if (pos[0] == '\r')
+            {
+                pos = pos.Slice(pos[1] == '\n' ? 2 : 1);
+            }
+            else if (pos[0] == '\n')
+            {
+                pos = pos.Slice(1);
+            }
+            else if (pos.Length > 0)
+            {
+                throw new Exception($"Expecting newline or end at {Encoding.UTF8.GetString(pos.ToArray())}");
+            }
+            return ParseSpace(pos, true);
+        }
+
+        public ParseState Parse(ReadOnlySpan<byte> src)
+        {
+            try
+            {
+                ParseState state = new ParseState();
+                ReadOnlySpan<byte> pos = ParseSpace(src, true);
+
+                while (!pos.IsEmpty)
+                {
+                    pos = ParseRule(state, pos);
+                }
+
+                return state;
+            }
+            catch (Exception err)
+            {
+                Console.Error.WriteLine($"{nameof(Parse)}: error parsing grammar: {err.Message}");
+                return new ParseState();
+            }
+        }
+
+        public void PrintGrammarChar(StreamWriter file, uint c)
+        {
+            if (c >= 0x20 && c <= 0x7F)
+            {
+                file.Write((char)c);
+            }
+            else
+            {
+                // cop out of encoding UTF-8
+                file.Write($"<U+{c:X4}>");
+            }
+        }
+
+        public bool IsCharElement(LLamaGrammarElement elem)
+        {
+            switch (elem.Type)
+            {
+                case LLamaGrammarElementType.CHAR:
+                case LLamaGrammarElementType.CHAR_NOT:
+                case LLamaGrammarElementType.CHAR_ALT:
+                case LLamaGrammarElementType.CHAR_RNG_UPPER:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        public void PrintRuleBinary(StreamWriter file, List<LLamaGrammarElement> rule)
+        {
+            foreach (var elem in rule)
+            {
+                switch (elem.Type)
+                {
+                    case LLamaGrammarElementType.END: file.Write("END"); break;
+                    case LLamaGrammarElementType.ALT: file.Write("ALT"); break;
+                    case LLamaGrammarElementType.RULE_REF: file.Write("RULE_REF"); break;
+                    case LLamaGrammarElementType.CHAR: file.Write("CHAR"); break;
+                    case LLamaGrammarElementType.CHAR_NOT: file.Write("CHAR_NOT"); break;
+                    case LLamaGrammarElementType.CHAR_RNG_UPPER: file.Write("CHAR_RNG_UPPER"); break;
+                    case LLamaGrammarElementType.CHAR_ALT: file.Write("CHAR_ALT"); break;
+                }
+                switch (elem.Type)
+                {
+                    case LLamaGrammarElementType.END:
+                    case LLamaGrammarElementType.ALT:
+                    case LLamaGrammarElementType.RULE_REF:
+                        file.Write($"({elem.Value}) ");
+                        break;
+                    case LLamaGrammarElementType.CHAR:
+                    case LLamaGrammarElementType.CHAR_NOT:
+                    case LLamaGrammarElementType.CHAR_RNG_UPPER:
+                    case LLamaGrammarElementType.CHAR_ALT:
+                        file.Write("(\"");
+                        PrintGrammarChar(file, elem.Value);
+                        file.Write("\") ");
+                        break;
+                }
+            }
+            file.WriteLine();
+        }
+
+        public void PrintRule(
+            StreamWriter file,
+            uint ruleId,
+            List<LLamaGrammarElement> rule,
+            Dictionary<uint, string> symbolIdNames)
+        {
+            if (rule.Count == 0 || rule[rule.Count - 1].Type != LLamaGrammarElementType.END)
+            {
+                throw new InvalidOperationException(
+                    $"Malformed rule, does not end with LLamaGrammarElementType.END: {ruleId}");
+            }
+
+            file.Write($"{symbolIdNames[ruleId]} ::= ");
+
+            for (int i = 0, end = rule.Count - 1; i < end; i++)
+            {
+                var elem = rule[i];
+                switch (elem.Type)
+                {
+                    case LLamaGrammarElementType.END:
+                        throw new InvalidOperationException(
+                            $"Unexpected end of rule: {ruleId}, {i}");
+                    case LLamaGrammarElementType.ALT:
+                        file.Write("| ");
+                        break;
+                    case LLamaGrammarElementType.RULE_REF:
+                        file.Write($"{symbolIdNames[elem.Value]} ");
+                        break;
+                    case LLamaGrammarElementType.CHAR:
+                        file.Write("[");
+                        PrintGrammarChar(file, elem.Value);
+                        break;
+                    case LLamaGrammarElementType.CHAR_NOT:
+                        file.Write("[^");
+                        PrintGrammarChar(file, elem.Value);
+                        break;
+                    case LLamaGrammarElementType.CHAR_RNG_UPPER:
+                        if (i == 0 || !IsCharElement(rule[i - 1]))
+                        {
+                            throw new InvalidOperationException(
+                                $"LLamaGrammarElementType.CHAR_RNG_UPPER without preceding char: {ruleId},{i}");
+                        }
+                        file.Write("-");
+                        PrintGrammarChar(file, elem.Value);
+                        break;
+                    case LLamaGrammarElementType.CHAR_ALT:
+                        if (i == 0 || !IsCharElement(rule[i - 1]))
+                        {
+                            throw new InvalidOperationException(
+                                $"LLamaGrammarElementType.CHAR_ALT without preceding char: {ruleId},{i}");
+                        }
+                        PrintGrammarChar(file, elem.Value);
+                        break;
+
+                }
+
+                if (IsCharElement(elem))
+                {
+                    switch (rule[i + 1].Type)
+                    {
+                        case LLamaGrammarElementType.CHAR_ALT:
+                        case LLamaGrammarElementType.CHAR_RNG_UPPER:
+                            break;
+                        default:
+                            file.Write("] ");
+                            break;
+                    }
+                }
+            }
+            file.WriteLine();
+        }
+
+        public void PrintGrammar(StreamWriter file, ParseState state)
+        {
+            try
+            {
+                Dictionary<uint, string> symbolIdNames = new Dictionary<uint, string>();
+                foreach (var kv in state.SymbolIds)
+                {
+                    symbolIdNames[kv.Value] = kv.Key;
+                }
+                for (int i = 0, end = state.Rules.Count; i < end; i++)
+                {
+                    PrintRule(file, (uint)i, state.Rules[i], symbolIdNames);
+                }
+            }
+            catch (Exception err)
+            {
+                Console.Error.WriteLine($"\nError printing grammar: {err.Message}");
+            }
         }
     }
 }

--- a/LLama/Grammar/ParseState.cs
+++ b/LLama/Grammar/ParseState.cs
@@ -12,7 +12,7 @@ namespace LLama.Grammar
     /// </summary>
     public class ParseState
     {
-        public Dictionary<string, uint> SymbolIds { get; } = new Dictionary<string, uint>();
+        public SortedDictionary<string, uint> SymbolIds { get; } = new SortedDictionary<string, uint>();
         public List<List<LLamaGrammarElement>> Rules { get; } = new List<List<LLamaGrammarElement>>();
 
         public IEnumerable<List<LLamaGrammarElement>> CRules()

--- a/LLama/Grammar/ParseState.cs
+++ b/LLama/Grammar/ParseState.cs
@@ -1,0 +1,26 @@
+﻿using LLama.Native;
+using System;
+using System.Collections.Generic;
+
+namespace LLama.Grammar
+{
+    /// <summary>
+    /// Source:
+    /// https://github.com/ggerganov/llama.cpp/blob/6381d4e110bd0ec02843a60bbeb8b6fc37a9ace9/common/grammar-parser.h
+    /// 
+    /// The commit hash from URL is the actual commit hash that reflects current C# code.
+    /// </summary>
+    internal class ParseState
+    {
+        public Dictionary<string, uint> SymbolIds { get; } = new Dictionary<string, uint>();
+        public List<List<LLamaGrammarElement>> Rules { get; } = new List<List<LLamaGrammarElement>>();
+
+        public IEnumerable<List<LLamaGrammarElement>> CRules()
+        {
+            foreach (var rule in Rules)
+            {
+                yield return rule;
+            }
+        }
+    }
+}

--- a/LLama/Grammar/ParseState.cs
+++ b/LLama/Grammar/ParseState.cs
@@ -10,7 +10,7 @@ namespace LLama.Grammar
     /// 
     /// The commit hash from URL is the actual commit hash that reflects current C# code.
     /// </summary>
-    internal class ParseState
+    public class ParseState
     {
         public Dictionary<string, uint> SymbolIds { get; } = new Dictionary<string, uint>();
         public List<List<LLamaGrammarElement>> Rules { get; } = new List<List<LLamaGrammarElement>>();

--- a/LLama/Grammar/ParseState.cs
+++ b/LLama/Grammar/ParseState.cs
@@ -1,6 +1,8 @@
-﻿using LLama.Native;
+﻿using LLama.Exceptions;
+using LLama.Native;
 using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace LLama.Grammar
 {
@@ -20,6 +22,159 @@ namespace LLama.Grammar
             foreach (var rule in Rules)
             {
                 yield return rule;
+            }
+        }
+
+        public void PrintGrammar(StreamWriter file, ParseState state)
+        {
+            try
+            {
+                Dictionary<uint, string> symbolIdNames = new Dictionary<uint, string>();
+                foreach (var kv in state.SymbolIds)
+                {
+                    symbolIdNames[kv.Value] = kv.Key;
+                }
+                for (int i = 0, end = state.Rules.Count; i < end; i++)
+                {
+                    PrintRule(file, (uint)i, state.Rules[i], symbolIdNames);
+                }
+            }
+            catch(Exception err)
+            {
+                Console.Error.WriteLine($"\nError printing grammar: {err.Message}");
+            }
+        }
+
+        public void PrintRuleBinary(StreamWriter file, List<LLamaGrammarElement> rule)
+        {
+            foreach (var elem in rule)
+            {
+                switch (elem.Type)
+                {
+                    case LLamaGrammarElementType.END: file.Write("END"); break;
+                    case LLamaGrammarElementType.ALT: file.Write("ALT"); break;
+                    case LLamaGrammarElementType.RULE_REF: file.Write("RULE_REF"); break;
+                    case LLamaGrammarElementType.CHAR: file.Write("CHAR"); break;
+                    case LLamaGrammarElementType.CHAR_NOT: file.Write("CHAR_NOT"); break;
+                    case LLamaGrammarElementType.CHAR_RNG_UPPER: file.Write("CHAR_RNG_UPPER"); break;
+                    case LLamaGrammarElementType.CHAR_ALT: file.Write("CHAR_ALT"); break;
+                }
+                switch (elem.Type)
+                {
+                    case LLamaGrammarElementType.END:
+                    case LLamaGrammarElementType.ALT:
+                    case LLamaGrammarElementType.RULE_REF:
+                        file.Write($"({elem.Value}) ");
+                        break;
+                    case LLamaGrammarElementType.CHAR:
+                    case LLamaGrammarElementType.CHAR_NOT:
+                    case LLamaGrammarElementType.CHAR_RNG_UPPER:
+                    case LLamaGrammarElementType.CHAR_ALT:
+                        file.Write("(\"");
+                        PrintGrammarChar(file, elem.Value);
+                        file.Write("\") ");
+                        break;
+                }
+            }
+            file.WriteLine();
+        }
+
+        private void PrintRule(
+            StreamWriter file,
+            uint ruleId,
+            List<LLamaGrammarElement> rule,
+            Dictionary<uint, string> symbolIdNames)
+        {
+            if (rule.Count == 0 || rule[rule.Count - 1].Type != LLamaGrammarElementType.END)
+            {
+                throw new GrammarFormatException(
+                    $"Malformed rule, does not end with LLamaGrammarElementType.END: {ruleId}");
+            }
+
+            file.Write($"{symbolIdNames[ruleId]} ::= ");
+
+            for (int i = 0, end = rule.Count - 1; i < end; i++)
+            {
+                var elem = rule[i];
+                switch (elem.Type)
+                {
+                    case LLamaGrammarElementType.END:
+                        throw new GrammarFormatException(
+                            $"Unexpected end of rule: {ruleId}, {i}");
+                    case LLamaGrammarElementType.ALT:
+                        file.Write("| ");
+                        break;
+                    case LLamaGrammarElementType.RULE_REF:
+                        file.Write($"{symbolIdNames[elem.Value]} ");
+                        break;
+                    case LLamaGrammarElementType.CHAR:
+                        file.Write("[");
+                        PrintGrammarChar(file, elem.Value);
+                        break;
+                    case LLamaGrammarElementType.CHAR_NOT:
+                        file.Write("[^");
+                        PrintGrammarChar(file, elem.Value);
+                        break;
+                    case LLamaGrammarElementType.CHAR_RNG_UPPER:
+                        if (i == 0 || !IsCharElement(rule[i - 1]))
+                        {
+                            throw new GrammarFormatException(
+                                $"LLamaGrammarElementType.CHAR_RNG_UPPER without preceding char: {ruleId},{i}");
+                        }
+                        file.Write("-");
+                        PrintGrammarChar(file, elem.Value);
+                        break;
+                    case LLamaGrammarElementType.CHAR_ALT:
+                        if (i == 0 || !IsCharElement(rule[i - 1]))
+                        {
+                            throw new GrammarFormatException(
+                                $"LLamaGrammarElementType.CHAR_ALT without preceding char: {ruleId},{i}");
+                        }
+                        PrintGrammarChar(file, elem.Value);
+                        break;
+
+                }
+
+                if (IsCharElement(elem))
+                {
+                    switch (rule[i + 1].Type)
+                    {
+                        case LLamaGrammarElementType.CHAR_ALT:
+                        case LLamaGrammarElementType.CHAR_RNG_UPPER:
+                            break;
+                        default:
+                            file.Write("] ");
+                            break;
+                    }
+                }
+            }
+            file.WriteLine();
+        }
+
+        private void PrintGrammarChar(StreamWriter file, uint c)
+        {
+            if (c >= 0x20 && c <= 0x7F)
+            {
+                file.Write((char)c);
+            }
+            else
+            {
+                // cop out of encoding UTF-8
+                file.Write($"<U+{c:X4}>");
+            }
+        }
+
+        private bool IsCharElement(LLamaGrammarElement elem)
+        {
+            switch (elem.Type)
+            {
+                case LLamaGrammarElementType.CHAR:
+                case LLamaGrammarElementType.CHAR_NOT:
+                case LLamaGrammarElementType.CHAR_ALT:
+                case LLamaGrammarElementType.CHAR_RNG_UPPER:
+                    return true;
+                default:
+                    return false;
             }
         }
     }

--- a/LLama/Native/LLamaGrammarElement.cs
+++ b/LLama/Native/LLamaGrammarElement.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace LLama.Native
 {
@@ -49,6 +50,7 @@ namespace LLama.Native
     /// An element of a grammar
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
+    [DebuggerDisplay("{Type} {Value}")]
     public struct LLamaGrammarElement
     {
         /// <summary>


### PR DESCRIPTION
Translation of llama.cpp's grammar parser as of the [current latest commit ](https://github.com/ggerganov/llama.cpp/blob/6381d4e110bd0ec02843a60bbeb8b6fc37a9ace9/common/grammar-parser.cpp) of the file (I'm mentioning this for ease of diff in the future).

- [x] Finish adaptation of grammar-parser.cpp
- [x] Translate all tests for grammar-parser
- [x] Add example(s) in Llama.Examples