### PR TITLE
Better Antiprompt Testing

### DIFF
--- a/LLama.Unittest/TokenTests.cs
+++ b/LLama.Unittest/TokenTests.cs
@@ -4,7 +4,7 @@ using LLama.Extensions;
 
 namespace LLama.Unittest;
 
-public class TokenTests
+public sealed class TokenTests
     : IDisposable
 {
     private readonly ModelParams _params;

--- a/LLama.Unittest/TokenTests.cs
+++ b/LLama.Unittest/TokenTests.cs
@@ -29,13 +29,13 @@ public class TokenTests
     {
         var tokens = _model.NativeHandle.Tokenize("The cat sat on the edge of the mat", false, Encoding.UTF8);
 
-        var resultTrue = tokens.TokensEndsWithAnyString(new[]
+        var result = tokens.TokensEndsWithAnyString(new[]
         {
             "a fish",
             "the mat",
             "this is an improbably long query to be using for this method"
         }, _model.NativeHandle, Encoding.UTF8);
-        Assert.True(resultTrue);
+        Assert.True(result);
     }
 
     [Fact]
@@ -43,11 +43,11 @@ public class TokenTests
     {
         var tokens = _model.NativeHandle.Tokenize("The cat sat on the edge of the mat", false, Encoding.UTF8);
 
-        var resultTrue = tokens.TokensEndsWithAnyString(new[]
+        var result = tokens.TokensEndsWithAnyString(new[]
         {
             "at",
         }, _model.NativeHandle, Encoding.UTF8);
-        Assert.True(resultTrue);
+        Assert.True(result);
     }
 
     [Fact]
@@ -55,13 +55,13 @@ public class TokenTests
     {
         var tokens = _model.NativeHandle.Tokenize("The cat sat on the edge of the mat", false, Encoding.UTF8);
 
-        var resultTrue = tokens.TokensEndsWithAnyString(new[]
+        var result = tokens.TokensEndsWithAnyString(new[]
         {
             "a fish",
             "The cat sat on the edge of the ma",
             "this is an improbably long query to be using for this method"
         }, _model.NativeHandle, Encoding.UTF8);
-        Assert.False(resultTrue);
+        Assert.False(result);
     }
 
     [Fact]
@@ -69,7 +69,7 @@ public class TokenTests
     {
         var tokens = _model.NativeHandle.Tokenize("The cat sat on the edge of the mat", false, Encoding.UTF8);
 
-        var resultTrue = tokens.TokensEndsWithAnyString(Array.Empty<string>(), _model.NativeHandle, Encoding.UTF8);
-        Assert.False(resultTrue);
+        var result = tokens.TokensEndsWithAnyString(Array.Empty<string>(), _model.NativeHandle, Encoding.UTF8);
+        Assert.False(result);
     }
 }

--- a/LLama.Unittest/TokenTests.cs
+++ b/LLama.Unittest/TokenTests.cs
@@ -1,0 +1,75 @@
+﻿using System.Text;
+using LLama.Common;
+using LLama.Extensions;
+
+namespace LLama.Unittest;
+
+public class TokenTests
+    : IDisposable
+{
+    private readonly ModelParams _params;
+    private readonly LLamaWeights _model;
+
+    public TokenTests()
+    {
+        _params = new ModelParams(Constants.ModelPath)
+        {
+            ContextSize = 2048
+        };
+        _model = LLamaWeights.LoadFromFile(_params);
+    }
+
+    public void Dispose()
+    {
+        _model.Dispose();
+    }
+
+    [Fact]
+    public void TokensEndWith()
+    {
+        var tokens = _model.NativeHandle.Tokenize("The cat sat on the edge of the mat", false, Encoding.UTF8);
+
+        var resultTrue = tokens.TokensEndsWithAnyString(new[]
+        {
+            "a fish",
+            "the mat",
+            "this is an improbably long query to be using for this method"
+        }, _model.NativeHandle, Encoding.UTF8);
+        Assert.True(resultTrue);
+    }
+
+    [Fact]
+    public void TokensEndSubstring()
+    {
+        var tokens = _model.NativeHandle.Tokenize("The cat sat on the edge of the mat", false, Encoding.UTF8);
+
+        var resultTrue = tokens.TokensEndsWithAnyString(new[]
+        {
+            "at",
+        }, _model.NativeHandle, Encoding.UTF8);
+        Assert.True(resultTrue);
+    }
+
+    [Fact]
+    public void TokensNotEndWith()
+    {
+        var tokens = _model.NativeHandle.Tokenize("The cat sat on the edge of the mat", false, Encoding.UTF8);
+
+        var resultTrue = tokens.TokensEndsWithAnyString(new[]
+        {
+            "a fish",
+            "The cat sat on the edge of the ma",
+            "this is an improbably long query to be using for this method"
+        }, _model.NativeHandle, Encoding.UTF8);
+        Assert.False(resultTrue);
+    }
+
+    [Fact]
+    public void TokensNotEndWithNothing()
+    {
+        var tokens = _model.NativeHandle.Tokenize("The cat sat on the edge of the mat", false, Encoding.UTF8);
+
+        var resultTrue = tokens.TokensEndsWithAnyString(Array.Empty<string>(), _model.NativeHandle, Encoding.UTF8);
+        Assert.False(resultTrue);
+    }
+}

--- a/LLama/Extensions/EncodingExtensions.cs
+++ b/LLama/Extensions/EncodingExtensions.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace LLama.Extensions;
+
+internal static class EncodingExtensions
+{
+#if NETSTANDARD2_0
+    public static int GetChars(this Encoding encoding, ReadOnlySpan<byte> bytes, Span<char> output)
+    {
+        unsafe
+        {
+            fixed (byte* bytePtr = bytes)
+            fixed (char* charPtr = output)
+            {
+                return encoding.GetChars(bytePtr, bytes.Length, charPtr, output.Length);
+            }
+        }
+    }
+
+    public static int GetCharCount(this Encoding encoding, ReadOnlySpan<byte> bytes)
+    {
+        unsafe
+        {
+            fixed (byte* bytePtr = bytes)
+            {
+                return encoding.GetCharCount(bytePtr, bytes.Length);
+            }
+        }
+    }
+#endif
+}

--- a/LLama/Extensions/IReadOnlyListExtensions.cs
+++ b/LLama/Extensions/IReadOnlyListExtensions.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Buffers;
 using System.Collections.Generic;
+using System.Text;
+using LLama.Native;
 
 namespace LLama.Extensions
 {
@@ -15,6 +18,45 @@ namespace LLama.Extensions
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Check if the given set of tokens ends with any of the given strings
+        /// </summary>
+        /// <param name="tokens">Tokens to check</param>
+        /// <param name="queries">Strings to search for</param>
+        /// <param name="model">Model to use to convert tokens into bytes</param>
+        /// <param name="encoding">Encoding to use to convert bytes into characters</param>
+        /// <returns></returns>
+        internal static bool TokensEndsWithAnyString<TList>(this TList tokens, IReadOnlyList<string> queries, SafeLlamaModelHandle model, Encoding encoding)
+            where TList : IReadOnlyList<int>
+        {
+            if (queries.Count == 0 || tokens.Count == 0)
+                return false;
+
+            // Find the length of the longest query
+            var longest = 0;
+            foreach (var candidate in queries)
+                longest = Math.Max(longest, candidate.Length);
+
+            // Rent an array to detokenize into
+            var builderArray = ArrayPool<char>.Shared.Rent(longest);
+            try
+            {
+                // Convert as many tokens as possible into the builderArray
+                var characters = model.TokensToSpan(tokens, builderArray.AsSpan(0, longest), encoding);
+
+                // Check every query to see if it's present
+                foreach (var query in queries)
+                    if (characters.EndsWith(query.AsSpan()))
+                        return true;
+
+                return false;
+            }
+            finally
+            {
+                ArrayPool<char>.Shared.Return(builderArray);
+            }
         }
     }
 }

--- a/LLama/LLamaStatelessExecutor.cs
+++ b/LLama/LLamaStatelessExecutor.cs
@@ -1,11 +1,13 @@
 ﻿using LLama.Abstractions;
 using LLama.Common;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
+using LLama.Extensions;
 
 namespace LLama
 {
@@ -138,22 +140,7 @@ namespace LLama
         /// <returns></returns>
         private bool EndsWithAntiprompt(IReadOnlyList<llama_token> tokens, IReadOnlyList<string> antiprompts)
         {
-            if (antiprompts.Count == 0 || tokens.Count == 0)
-                return false;
-
-            var builder = new StringBuilder();
-            foreach (var token in tokens)
-                builder.Append(Context.TokenToString(token));
-
-            var last_output = builder.ToString();
-
-            foreach (var antiprompt in antiprompts)
-            {
-                if (last_output.EndsWith(antiprompt))
-                    return true;
-            }
-
-            return false;
+            return tokens.TokensEndsWithAnyString(antiprompts, Context.NativeHandle.ModelHandle, Context.Encoding);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Added a better system for checking antiprompts which does much less work per-token, does not allocate anything and has test coverage.

- `TokensEndsWithAnyString` extension for `IReadOnlyList<int>` which efficiently checks if a set of tokens ends with one of a set of strings.
   - Minimal amount of characters converted
   - Allocation free
 - Added `TokensToSpan` to `SafeLlamaModelHandle` which converts as many tokens as possible into a character span
   - Allocation free