### PR TITLE
Removed `GenerateResult`

### DIFF
--- a/LLama/LLamaContext.cs
+++ b/LLama/LLamaContext.cs
@@ -482,12 +482,6 @@ namespace LLama
         }
 #endregion
 
-        internal IEnumerable<string> GenerateResult(IEnumerable<llama_token> ids)
-        {
-            foreach(var id in ids)
-                yield return _ctx.TokenToString(id, _encoding);
-        }
-
         /// <summary>
         /// Convert a token into a string
         /// </summary>

--- a/LLama/LLamaExecutorBase.cs
+++ b/LLama/LLamaExecutorBase.cs
@@ -288,10 +288,8 @@ namespace LLama
 
                 if (args.ReturnValue)
                 {
-                    foreach (var item in Context.GenerateResult(_embeds))
-                    {
-                        yield return item;
-                    }
+                    foreach (var id in _embeds)
+                        yield return Context.TokenToString(id);
                 }
 
                 var breakGeneration = PostProcess(inferenceParams, args, out var extraOutputs);


### PR DESCRIPTION
Removed `GenerateResult` method that was only used in one place