### PR TITLE
Async Stateless Executor

### DIFF
--- a/LLama.Examples/Extensions/IAsyncEnumerableExtensions.cs
+++ b/LLama.Examples/Extensions/IAsyncEnumerableExtensions.cs
@@ -1,0 +1,43 @@
+﻿namespace LLama.Examples.Extensions
+{
+    public static class IAsyncEnumerableExtensions
+    {
+        /// <summary>
+        /// Show a console spinner while waiting for the next result
+        /// </summary>
+        /// <param name="source"></param>
+        /// <returns></returns>
+        public static async IAsyncEnumerable<string> Spinner(this IAsyncEnumerable<string> source)
+        {
+            var enumerator = source.GetAsyncEnumerator();
+
+            var characters = new[] { '|', '/', '-', '\\' };
+
+            while (true)
+            {
+                var next = enumerator.MoveNextAsync();
+
+                var (Left, Top) = Console.GetCursorPosition();
+
+                // Keep showing the next spinner character while waiting for "MoveNextAsync" to finish
+                var count = 0;
+                while (!next.IsCompleted)
+                {
+                    count = (count + 1) % characters.Length;
+                    Console.SetCursorPosition(Left, Top);
+                    Console.Write(characters[count]);
+                    await Task.Delay(75);
+                }
+
+                // Clear the spinner character
+                Console.SetCursorPosition(Left, Top);
+                Console.Write(" ");
+                Console.SetCursorPosition(Left, Top);
+
+                if (!next.Result)
+                    break;
+                yield return enumerator.Current;
+            }
+        }
+    }
+}

--- a/LLama.Examples/NewVersion/StatelessModeExecute.cs
+++ b/LLama.Examples/NewVersion/StatelessModeExecute.cs
@@ -1,4 +1,5 @@
 ﻿using LLama.Common;
+using LLama.Examples.Extensions;
 
 namespace LLama.Examples.NewVersion
 {
@@ -35,48 +36,10 @@ namespace LLama.Examples.NewVersion
                 Console.ForegroundColor = ConsoleColor.White;
                 Console.Write("Answer: ");
                 prompt = $"Question: {prompt?.Trim()} Answer: ";
-                await foreach (var text in Spinner(ex.InferAsync(prompt, inferenceParams)))
+                await foreach (var text in ex.InferAsync(prompt, inferenceParams).Spinner())
                 {
                     Console.Write(text);
                 }
-            }
-        }
-
-        /// <summary>
-        /// Show a spinner while waiting for the next result
-        /// </summary>
-        /// <param name="source"></param>
-        /// <returns></returns>
-        private static async IAsyncEnumerable<string> Spinner(IAsyncEnumerable<string> source)
-        {
-            var enumerator = source.GetAsyncEnumerator();
-
-            var characters = new[] { '|', '/', '-', '\\' };
-
-            while (true)
-            {
-                var next = enumerator.MoveNextAsync();
-
-                var (Left, Top) = Console.GetCursorPosition();
-
-                // Keep showing the next spinner character while waiting for "MoveNextAsync" to finish
-                var count = 0;
-                while (!next.IsCompleted)
-                {
-                    count = (count + 1) % characters.Length;
-                    Console.SetCursorPosition(Left, Top);
-                    Console.Write(characters[count]);
-                    await Task.Delay(75);
-                }
-
-                // Clear the spinner character
-                Console.SetCursorPosition(Left, Top);
-                Console.Write(" ");
-                Console.SetCursorPosition(Left, Top);
-
-                if (!next.Result)
-                    break;
-                yield return enumerator.Current;
             }
         }
     }

--- a/LLama/Extensions/IReadOnlyListExtensions.cs
+++ b/LLama/Extensions/IReadOnlyListExtensions.cs
@@ -68,6 +68,13 @@ namespace LLama.Extensions
             }
         }
 
+        internal static bool TokensEndsWithAnyString<TTokens, TQueries>(this TTokens tokens, TQueries? queries, LLamaContext context)
+            where TTokens : IReadOnlyList<int>
+            where TQueries : IReadOnlyList<string>
+        {
+            return TokensEndsWithAnyString(tokens, queries, context.NativeHandle.ModelHandle, context.Encoding);
+        }
+
         /// <summary>
         /// Check if the given set of tokens ends with any of the given strings
         /// </summary>

--- a/LLama/LLamaContext.cs
+++ b/LLama/LLamaContext.cs
@@ -406,7 +406,7 @@ namespace LLama
         /// <param name="pastTokensCount"></param>
         /// <returns>The updated `pastTokensCount`.</returns>
         /// <exception cref="RuntimeError"></exception>
-        public int Eval(llama_token[] tokens, llama_token pastTokensCount)
+        public int Eval(llama_token[] tokens, int pastTokensCount)
         {
             return Eval(tokens.AsSpan(), pastTokensCount);
         }
@@ -418,7 +418,7 @@ namespace LLama
         /// <param name="pastTokensCount"></param>
         /// <returns>The updated `pastTokensCount`.</returns>
         /// <exception cref="RuntimeError"></exception>
-        public int Eval(List<llama_token> tokens, llama_token pastTokensCount)
+        public int Eval(List<llama_token> tokens, int pastTokensCount)
         {
 #if NET5_0_OR_GREATER
             var span = CollectionsMarshal.AsSpan(tokens);
@@ -448,7 +448,7 @@ namespace LLama
         /// <param name="pastTokensCount"></param>
         /// <returns>The updated `pastTokensCount`.</returns>
         /// <exception cref="RuntimeError"></exception>
-        public int Eval(ReadOnlyMemory<llama_token> tokens, llama_token pastTokensCount)
+        public int Eval(ReadOnlyMemory<llama_token> tokens, int pastTokensCount)
         {
             return Eval(tokens.Span, pastTokensCount);
         }
@@ -460,7 +460,7 @@ namespace LLama
         /// <param name="pastTokensCount"></param>
         /// <returns>The updated `pastTokensCount`.</returns>
         /// <exception cref="RuntimeError"></exception>
-        public int Eval(ReadOnlySpan<llama_token> tokens, llama_token pastTokensCount)
+        public int Eval(ReadOnlySpan<llama_token> tokens, int pastTokensCount)
         {
             var total = tokens.Length;
             for(var i = 0; i < total; i += Params.BatchSize)

--- a/LLama/LLamaStatelessExecutor.cs
+++ b/LLama/LLamaStatelessExecutor.cs
@@ -104,15 +104,13 @@ namespace LLama
                     inferenceParams.MirostatEta, inferenceParams.TopK, inferenceParams.TopP, inferenceParams.TfsZ, inferenceParams.TypicalP, inferenceParams.Grammar);
 
                 lastTokens.Add(id);
-
-                var response = Context.TokenToString(id);
-                yield return response;
+                yield return Context.TokenToString(id);
 
                 tokens.Clear();
                 tokens.Add(id);
 
                 // Check if any of the antiprompts have been generated
-                if (tokens.TokensEndsWithAnyString(antiprompts, Context))
+                if (lastTokens.TokensEndsWithAnyString(antiprompts, Context))
                     break;
 
                 // when run out of context


### PR DESCRIPTION
 - Converted LLamaStatelessExecutor to run `Exec` calls inside an awaited task. This unblocks async callers while the model is being evaluated.
 - Added a "spinner" to the `StatelessModeExecute` demo, which spins while waiting for the next token (demonstrating that it's not blocked).