### PR TITLE
Cleanup

### DIFF
--- a/LLama.Examples/NewVersion/GetEmbeddings.cs
+++ b/LLama.Examples/NewVersion/GetEmbeddings.cs
@@ -8,7 +8,10 @@ namespace LLama.Examples.NewVersion
         {
             Console.Write("Please input your model path: ");
             var modelPath = Console.ReadLine();
-            var embedder = new LLamaEmbedder(new ModelParams(modelPath));
+
+            var @params = new ModelParams(modelPath);
+            using var weights = LLamaWeights.LoadFromFile(@params);
+            var embedder = new LLamaEmbedder(weights, @params);
 
             while (true)
             {

--- a/LLama.Examples/NewVersion/LoadAndSaveState.cs
+++ b/LLama.Examples/NewVersion/LoadAndSaveState.cs
@@ -8,7 +8,7 @@ namespace LLama.Examples.NewVersion
         {
             Console.Write("Please input your model path: ");
             var modelPath = Console.ReadLine();
-            var prompt = File.ReadAllText("Assets/chat-with-bob.txt").Trim();
+            var prompt = (await File.ReadAllTextAsync("Assets/chat-with-bob.txt")).Trim();
 
             var parameters = new ModelParams(modelPath)
             {
@@ -44,7 +44,7 @@ namespace LLama.Examples.NewVersion
 
                     Console.Write("Your path to save executor state: ");
                     var executorStatePath = Console.ReadLine();
-                    ex.SaveState(executorStatePath);
+                    await ex.SaveState(executorStatePath);
 
                     Console.ForegroundColor = ConsoleColor.Yellow;
                     Console.WriteLine("All states saved!");
@@ -53,7 +53,7 @@ namespace LLama.Examples.NewVersion
                     var ctx = ex.Context;
                     ctx.LoadState(modelStatePath);
                     ex = new InteractiveExecutor(ctx);
-                    ex.LoadState(executorStatePath);
+                    await ex.LoadState(executorStatePath);
                     Console.ForegroundColor = ConsoleColor.Yellow;
                     Console.WriteLine("Loaded state!");
                     Console.ForegroundColor = ConsoleColor.White;

--- a/LLama.Unittest/LLamaEmbedderTests.cs
+++ b/LLama.Unittest/LLamaEmbedderTests.cs
@@ -5,7 +5,14 @@ namespace LLama.Unittest;
 public class LLamaEmbedderTests
     : IDisposable
 {
-    private readonly LLamaEmbedder _embedder = new(new ModelParams(Constants.ModelPath));
+    private readonly LLamaEmbedder _embedder;
+
+    public LLamaEmbedderTests()
+    {
+        var @params = new ModelParams(Constants.ModelPath);
+        using var weights = LLamaWeights.LoadFromFile(@params);
+        _embedder = new(weights, @params);
+    }
 
     public void Dispose()
     {

--- a/LLama.Unittest/ModelsParamsTests.cs
+++ b/LLama.Unittest/ModelsParamsTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Text;
-using LLama.Common;
-using Newtonsoft.Json;
+﻿using LLama.Common;
 
 namespace LLama.Unittest
 {
@@ -40,34 +38,11 @@ namespace LLama.Unittest
             };
 
             var settings = new Newtonsoft.Json.JsonSerializerSettings();
-            settings.Converters.Add(new NewtsonsoftEncodingConverter());
 
             var json = Newtonsoft.Json.JsonConvert.SerializeObject(expected, settings);
             var actual = Newtonsoft.Json.JsonConvert.DeserializeObject<ModelParams>(json, settings);
 
             Assert.Equal(expected, actual);
         }
-
-
-
-        public class NewtsonsoftEncodingConverter : JsonConverter
-        {
-            public override bool CanConvert(Type objectType)
-            {
-                return typeof(Encoding).IsAssignableFrom(objectType);
-            }
-
-            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-            {
-                writer.WriteValue(((Encoding)value).WebName);
-            }
-
-            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-            {
-                return Encoding.GetEncoding((string)reader.Value);
-            }
-        }
-
-
     }
 }

--- a/LLama/Abstractions/IModelParams.cs
+++ b/LLama/Abstractions/IModelParams.cs
@@ -35,11 +35,6 @@ namespace LLama.Abstractions
         string ModelPath { get; set; }
 
         /// <summary>
-        /// Number of threads (-1 = autodetect) (n_threads)
-        /// </summary>
-        uint? Threads { get; set; }
-
-        /// <summary>
         /// how split tensors should be distributed across GPUs
         /// </summary>
         float[]? TensorSplits { get; set; }

--- a/LLama/Common/FixedSizeQueue.cs
+++ b/LLama/Common/FixedSizeQueue.cs
@@ -12,7 +12,6 @@ namespace LLama.Common
     public class FixedSizeQueue<T>
         : IEnumerable<T>
     {
-        private readonly int _maxSize;
         private readonly List<T> _storage;
 
         internal IReadOnlyList<T> Items => _storage;
@@ -25,7 +24,7 @@ namespace LLama.Common
         /// <summary>
         /// Maximum number of items allowed in this queue
         /// </summary>
-        public int Capacity => _maxSize;
+        public int Capacity { get; }
 
         /// <summary>
         /// Create a new queue
@@ -33,7 +32,7 @@ namespace LLama.Common
         /// <param name="size">the maximum number of items to store in this queue</param>
         public FixedSizeQueue(int size)
         {
-            _maxSize = size;
+            Capacity = size;
             _storage = new();
         }
 
@@ -52,11 +51,11 @@ namespace LLama.Common
 #endif
 
             // Size of "data" is unknown, copy it all into a list
-            _maxSize = size;
+            Capacity = size;
             _storage = new List<T>(data);
 
             // Now check if that list is a valid size.
-            if (_storage.Count > _maxSize)
+            if (_storage.Count > Capacity)
                 throw new ArgumentException($"The max size set for the quene is {size}, but got {_storage.Count} initial values.");
         }
 
@@ -81,7 +80,7 @@ namespace LLama.Common
         public void Enqueue(T item)
         {
             _storage.Add(item);
-            if(_storage.Count >= _maxSize)
+            if(_storage.Count >= Capacity)
             {
                 _storage.RemoveAt(0);
             }

--- a/LLama/Common/ModelParams.cs
+++ b/LLama/Common/ModelParams.cs
@@ -40,11 +40,11 @@ namespace LLama.Common
         /// <summary>
         /// Use mlock to keep model in memory (use_mlock)
         /// </summary>
-        public bool UseMemoryLock { get; set; } = false;
+        public bool UseMemoryLock { get; set; }
         /// <summary>
         /// Compute perplexity over the prompt (perplexity)
         /// </summary>
-        public bool Perplexity { get; set; } = false;
+        public bool Perplexity { get; set; }
         /// <summary>
         /// Model path (model)
         /// </summary>
@@ -79,7 +79,7 @@ namespace LLama.Common
         /// Whether to use embedding mode. (embedding) Note that if this is set to true, 
         /// The LLamaModel won't produce text response anymore.
         /// </summary>
-        public bool EmbeddingMode { get; set; } = false;
+        public bool EmbeddingMode { get; set; }
 
         /// <summary>
         /// how split tensors should be distributed across GPUs

--- a/LLama/Exceptions/GrammarFormatExceptions.cs
+++ b/LLama/Exceptions/GrammarFormatExceptions.cs
@@ -58,7 +58,7 @@ public class GrammarUnexpectedEndOfInput
     : GrammarFormatException
 {
     internal GrammarUnexpectedEndOfInput()
-        : base($"Unexpected end of input")
+        : base("Unexpected end of input")
     {
     }
 }

--- a/LLama/Exceptions/RuntimeError.cs
+++ b/LLama/Exceptions/RuntimeError.cs
@@ -1,19 +1,20 @@
 ﻿using System;
 
-namespace LLama.Exceptions
+namespace LLama.Exceptions;
+
+/// <summary>
+/// Base class for LLamaSharp runtime errors (i.e. errors produced by llama.cpp, converted into exceptions)
+/// </summary>
+public class RuntimeError
+    : Exception
 {
-    public class RuntimeError
-        : Exception
+    /// <summary>
+    /// Create a new RuntimeError
+    /// </summary>
+    /// <param name="message"></param>
+    public RuntimeError(string message)
+        : base(message)
     {
-        public RuntimeError()
-        {
 
-        }
-
-        public RuntimeError(string message)
-            : base(message)
-        {
-
-        }
     }
 }

--- a/LLama/Extensions/EncodingExtensions.cs
+++ b/LLama/Extensions/EncodingExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Text;
 
 namespace LLama.Extensions;

--- a/LLama/Extensions/KeyValuePairExtensions.cs
+++ b/LLama/Extensions/KeyValuePairExtensions.cs
@@ -1,26 +1,23 @@
-﻿using System.Collections.Generic;
+﻿namespace LLama.Extensions;
 
-namespace LLama.Extensions
+/// <summary>
+/// Extensions to the KeyValuePair struct
+/// </summary>
+internal static class KeyValuePairExtensions
 {
-    /// <summary>
-    /// Extensions to the KeyValuePair struct
-    /// </summary>
-    internal static class KeyValuePairExtensions
-    {
 #if NETSTANDARD2_0
-        /// <summary>
-        /// Deconstruct a KeyValuePair into it's constituent parts.
-        /// </summary>
-        /// <param name="pair">The KeyValuePair to deconstruct</param>
-        /// <param name="first">First element, the Key</param>
-        /// <param name="second">Second element, the Value</param>
-        /// <typeparam name="TKey">Type of the Key</typeparam>
-        /// <typeparam name="TValue">Type of the Value</typeparam>
-        public static void Deconstruct<TKey, TValue>(this KeyValuePair<TKey, TValue> pair, out TKey first, out TValue second)
-        {
-            first = pair.Key;
-            second = pair.Value;
-        }
-#endif
+    /// <summary>
+    /// Deconstruct a KeyValuePair into it's constituent parts.
+    /// </summary>
+    /// <param name="pair">The KeyValuePair to deconstruct</param>
+    /// <param name="first">First element, the Key</param>
+    /// <param name="second">Second element, the Value</param>
+    /// <typeparam name="TKey">Type of the Key</typeparam>
+    /// <typeparam name="TValue">Type of the Value</typeparam>
+    public static void Deconstruct<TKey, TValue>(this System.Collections.Generic.KeyValuePair<TKey, TValue> pair, out TKey first, out TValue second)
+    {
+        first = pair.Key;
+        second = pair.Value;
     }
+#endif
 }

--- a/LLama/Grammars/Grammar.cs
+++ b/LLama/Grammars/Grammar.cs
@@ -112,7 +112,6 @@ namespace LLama.Grammars
                     case LLamaGrammarElementType.CHAR_ALT:
                         PrintGrammarChar(output, elem.Value);
                         break;
-
                 }
 
                 if (elem.IsCharElement())

--- a/LLama/LLamaEmbedder.cs
+++ b/LLama/LLamaEmbedder.cs
@@ -18,11 +18,22 @@ namespace LLama
         /// </summary>
         public int EmbeddingSize => _ctx.EmbeddingSize;
 
+        /// <summary>
+        /// Create a new embedder (loading temporary weights)
+        /// </summary>
+        /// <param name="allParams"></param>
+        [Obsolete("Preload LLamaWeights and use the constructor which accepts them")]
         public LLamaEmbedder(ILLamaParams allParams)
             : this(allParams, allParams)
         {
         }
 
+        /// <summary>
+        /// Create a new embedder (loading temporary weights)
+        /// </summary>
+        /// <param name="modelParams"></param>
+        /// <param name="contextParams"></param>
+        [Obsolete("Preload LLamaWeights and use the constructor which accepts them")]
         public LLamaEmbedder(IModelParams modelParams, IContextParams contextParams)
         {
             using var weights = LLamaWeights.LoadFromFile(modelParams);
@@ -31,6 +42,11 @@ namespace LLama
             _ctx = weights.CreateContext(contextParams);
         }
 
+        /// <summary>
+        /// Create a new embedder, using the given LLamaWeights
+        /// </summary>
+        /// <param name="weights"></param>
+        /// <param name="params"></param>
         public LLamaEmbedder(LLamaWeights weights, IContextParams @params)
         {
             @params.EmbeddingMode = true;

--- a/LLama/LLamaExecutorBase.cs
+++ b/LLama/LLamaExecutorBase.cs
@@ -114,7 +114,7 @@ namespace LLama
             }
             else
             {
-                _logger?.LogWarning($"[LLamaExecutor] Session file does not exist, will create");
+                _logger?.LogWarning("[LLamaExecutor] Session file does not exist, will create");
             }
 
             _n_matching_session_tokens = 0;

--- a/LLama/LLamaInstructExecutor.cs
+++ b/LLama/LLamaInstructExecutor.cs
@@ -18,10 +18,10 @@ namespace LLama
     /// </summary>
     public class InstructExecutor : StatefulExecutorBase
     {
-        bool _is_prompt_run = true;
-        string _instructionPrefix;
-        llama_token[] _inp_pfx;
-        llama_token[] _inp_sfx;
+        private bool _is_prompt_run = true;
+        private readonly string _instructionPrefix;
+        private llama_token[] _inp_pfx;
+        private llama_token[] _inp_sfx;
 
         /// <summary>
         /// 

--- a/LLama/LLamaQuantizer.cs
+++ b/LLama/LLamaQuantizer.cs
@@ -80,6 +80,7 @@ namespace LLama
                     return true;
 
                 case LLamaFtype.LLAMA_FTYPE_MOSTLY_Q4_1_SOME_F16:
+                case LLamaFtype.LLAMA_FTYPE_GUESSED:
                 default:
                     return false;
             }

--- a/LLama/LLamaWeights.cs
+++ b/LLama/LLamaWeights.cs
@@ -11,13 +11,11 @@ namespace LLama
     public sealed class LLamaWeights
         : IDisposable
     {
-        private readonly SafeLlamaModelHandle _weights;
-
         /// <summary>
         /// The native handle, which is used in the native APIs
         /// </summary>
         /// <remarks>Be careful how you use this!</remarks>
-        public SafeLlamaModelHandle NativeHandle => _weights;
+        public SafeLlamaModelHandle NativeHandle { get; }
 
         /// <summary>
         /// Total number of tokens in vocabulary of this model
@@ -46,7 +44,7 @@ namespace LLama
 
         internal LLamaWeights(SafeLlamaModelHandle weights)
         {
-            _weights = weights;
+            NativeHandle = weights;
         }
 
         /// <summary>
@@ -66,7 +64,7 @@ namespace LLama
                 if (adapter.Scale <= 0)
                     continue;
 
-                weights.ApplyLoraFromFile(adapter.Path, adapter.Scale, @params.LoraBase, @params.Threads);
+                weights.ApplyLoraFromFile(adapter.Path, adapter.Scale, @params.LoraBase);
             }
 
             return new LLamaWeights(weights);
@@ -75,7 +73,7 @@ namespace LLama
         /// <inheritdoc />
         public void Dispose()
         {
-            _weights.Dispose();
+            NativeHandle.Dispose();
         }
 
         /// <summary>

--- a/LLama/Native/LLamaGrammarElement.cs
+++ b/LLama/Native/LLamaGrammarElement.cs
@@ -45,7 +45,7 @@ namespace LLama.Native
         /// CHAR_RNG_UPPER to add an alternate char to match ([ab], [a-zA])
         /// </summary>
         CHAR_ALT = 6,
-    };
+    }
 
     /// <summary>
     /// An element of a grammar

--- a/LLama/Native/LLamaPos.cs
+++ b/LLama/Native/LLamaPos.cs
@@ -1,15 +1,26 @@
 ﻿namespace LLama.Native;
 
-public record struct LLamaPos
+/// <summary>
+/// Indicates position in a sequence
+/// </summary>
+public readonly record struct LLamaPos(int Value)
 {
-    public int Value;
+    /// <summary>
+    /// The raw value
+    /// </summary>
+    public readonly int Value = Value;
 
-    public LLamaPos(int value)
-    {
-        Value = value;
-    }
-
+    /// <summary>
+    /// Convert a LLamaPos into an integer (extract the raw value)
+    /// </summary>
+    /// <param name="pos"></param>
+    /// <returns></returns>
     public static explicit operator int(LLamaPos pos) => pos.Value;
 
+    /// <summary>
+    /// Convert an integer into a LLamaPos
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
     public static implicit operator LLamaPos(int value) => new(value);
 }

--- a/LLama/Native/LLamaSeqId.cs
+++ b/LLama/Native/LLamaSeqId.cs
@@ -1,15 +1,26 @@
 ﻿namespace LLama.Native;
 
-public record struct LLamaSeqId
+/// <summary>
+/// ID for a sequence in a batch
+/// </summary>
+/// <param name="Value"></param>
+public record struct LLamaSeqId(int Value)
 {
-    public int Value;
+    /// <summary>
+    /// The raw value
+    /// </summary>
+    public int Value = Value;
 
-    public LLamaSeqId(int value)
-    {
-        Value = value;
-    }
-
+    /// <summary>
+    /// Convert a LLamaSeqId into an integer (extract the raw value)
+    /// </summary>
+    /// <param name="pos"></param>
     public static explicit operator int(LLamaSeqId pos) => pos.Value;
 
+    /// <summary>
+    /// Convert an integer into a LLamaSeqId
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
     public static explicit operator LLamaSeqId(int value) => new(value);
 }

--- a/LLama/Native/LLamaTokenData.cs
+++ b/LLama/Native/LLamaTokenData.cs
@@ -1,28 +1,28 @@
 ﻿using System.Runtime.InteropServices;
 
-namespace LLama.Native
-{
-    [StructLayout(LayoutKind.Sequential)]
-    public struct LLamaTokenData
-    {
-        /// <summary>
-        /// token id
-        /// </summary>
-        public int id;
-        /// <summary>
-        /// log-odds of the token
-        /// </summary>
-        public float logit;
-        /// <summary>
-        /// probability of the token
-        /// </summary>
-        public float p;
+namespace LLama.Native;
 
-        public LLamaTokenData(int id, float logit, float p)
-        {
-            this.id = id;
-            this.logit = logit;
-            this.p = p;
-        }
-    }
+/// <summary>
+/// A single token along with probability of this token being selected
+/// </summary>
+/// <param name="id"></param>
+/// <param name="logit"></param>
+/// <param name="p"></param>
+[StructLayout(LayoutKind.Sequential)]
+public record struct LLamaTokenData(int id, float logit, float p)
+{
+    /// <summary>
+    /// token id
+    /// </summary>
+    public int id = id;
+
+    /// <summary>
+    /// log-odds of the token
+    /// </summary>
+    public float logit = logit;
+
+    /// <summary>
+    /// probability of the token
+    /// </summary>
+    public float p = p;
 }

--- a/LLama/Native/NativeApi.cs
+++ b/LLama/Native/NativeApi.cs
@@ -273,6 +273,7 @@ namespace LLama.Native
         /// <param name="n_past"></param>
         /// <returns>Returns 0 on success</returns>
         [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
+        [Obsolete("use llama_decode() instead")]
         public static extern int llama_eval(SafeLLamaContextHandle ctx, llama_token* tokens, int n_tokens, int n_past);
 
         /// <summary>

--- a/LLama/Native/SafeLLamaContextHandle.cs
+++ b/LLama/Native/SafeLLamaContextHandle.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Buffers;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Text;
 using LLama.Exceptions;
 
@@ -212,9 +210,17 @@ namespace LLama.Native
             }
         }
 
+        /// <summary>
+        /// </summary>
+        /// <param name="batch"></param>
+        /// <returns>Positive return values does not mean a fatal error, but rather a warning:<br />
+        ///  - 0: success<br />
+        ///  - 1: could not find a KV slot for the batch (try reducing the size of the batch or increase the context)<br />
+        ///  - &lt; 0: error<br />
+        /// </returns>
         public int Decode(LLamaBatchSafeHandle batch)
         {
-            return NativeApi.llama_decode(this, batch.Batch);
+            return NativeApi.llama_decode(this, batch.NativeBatch);
         }
 
         #region state

--- a/LLama/Native/SafeLLamaContextHandle.cs
+++ b/LLama/Native/SafeLLamaContextHandle.cs
@@ -204,6 +204,7 @@ namespace LLama.Native
             {
                 fixed (int* pinned = tokens)
                 {
+                    // the entire `eval` system needs replacing with the new batch system!
                     var ret = NativeApi.llama_eval(this, pinned, tokens.Length, n_past);
                     return ret == 0;
                 }

--- a/LLama/Native/SafeLlamaModelHandle.cs
+++ b/LLama/Native/SafeLlamaModelHandle.cs
@@ -84,14 +84,14 @@ namespace LLama.Native
         /// adapter. Can be NULL to use the current loaded model.</param>
         /// <param name="threads"></param>
         /// <exception cref="RuntimeError"></exception>
-        public void ApplyLoraFromFile(string lora, float scale, string? modelBase = null, uint? threads = null)
+        public void ApplyLoraFromFile(string lora, float scale, string? modelBase = null, int? threads = null)
         {
             var err = NativeApi.llama_model_apply_lora_from_file(
                 this,
                 lora,
                 scale,
                 string.IsNullOrEmpty(modelBase) ? null : modelBase,
-                (int?)threads ?? -1
+                threads ?? Math.Max(1, Environment.ProcessorCount / 2)
             );
 
             if (err != 0)


### PR DESCRIPTION
Assorted cleanup leftover after the huge change in the last PR (comments, syntax style, etc).

Only real change is the removal of the `IModelParams.Threads` property, which should not have been there in the first place (it's  not in the llama.cpp `llama_model_params` struct)