### PR TITLE
chore: Update LLama.Examples and LLama.SemanticKernel

### DIFF
--- a/LLama.Examples/NewVersion/SemanticKernelPrompt.cs
+++ b/LLama.Examples/NewVersion/SemanticKernelPrompt.cs
@@ -45,9 +45,9 @@ One line TLDR with the fewest words.";
 2. The acceleration of an object depends on the mass of the object and the amount of force applied.
 3. Whenever one object exerts a force on another object, the second object exerts an equal and opposite on the first.";
 
-            Console.WriteLine(await kernel.RunAsync(text1, summarize));
+            Console.WriteLine((await kernel.RunAsync(text1, summarize)).GetValue<string>());
 
-            Console.WriteLine(await kernel.RunAsync(text2, summarize));
+            Console.WriteLine((await kernel.RunAsync(text2, summarize)).GetValue<string>());
         }
     }
 }

--- a/LLama.SemanticKernel/TextCompletion/LLamaSharpTextCompletion.cs
+++ b/LLama.SemanticKernel/TextCompletion/LLamaSharpTextCompletion.cs
@@ -2,6 +2,7 @@
 using LLamaSharp.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.AI;
 using Microsoft.SemanticKernel.AI.TextCompletion;
+using System.Runtime.CompilerServices;
 
 namespace LLamaSharp.SemanticKernel.TextCompletion;
 
@@ -22,7 +23,7 @@ public sealed class LLamaSharpTextCompletion : ITextCompletion
     }
 
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously.
-    public async IAsyncEnumerable<ITextStreamingResult> GetStreamingCompletionsAsync(string text, AIRequestSettings? requestSettings, CancellationToken cancellationToken = default)
+    public async IAsyncEnumerable<ITextStreamingResult> GetStreamingCompletionsAsync(string text, AIRequestSettings? requestSettings,[EnumeratorCancellation] CancellationToken cancellationToken = default)
 #pragma warning restore CS1998
     {
         var settings = (ChatRequestSettings?)requestSettings;

--- a/LLama.SemanticKernel/TextEmbedding/LLamaSharpEmbeddingGeneration.cs
+++ b/LLama.SemanticKernel/TextEmbedding/LLamaSharpEmbeddingGeneration.cs
@@ -15,6 +15,7 @@ public sealed class LLamaSharpEmbeddingGeneration : ITextEmbeddingGeneration
     /// <inheritdoc/>
     public async Task<IList<ReadOnlyMemory<float>>> GenerateEmbeddingsAsync(IList<string> data, CancellationToken cancellationToken = default)
     {
-        return data.Select(text => new ReadOnlyMemory<float>(_embedder.GetEmbeddings(text))).ToList();
+        var embeddings = data.Select(text => new ReadOnlyMemory<float>(_embedder.GetEmbeddings(text))).ToList();
+        return await Task.FromResult(embeddings);
     }
 }


### PR DESCRIPTION
Summary:
---
This pull request updates the LLama.Examples and LLama.SemanticKernel projects. The changes include improvements to the SemanticKernelMemory and SemanticKernelPrompt classes in the
LLama.Examples project, as well as updates to the LLamaSharpTextCompletion and LLamaSharpEmbeddingGeneration classes in the LLama.SemanticKernel project. These changes enhance the
functionality and performance of the projects.

Changes:
---
- In the LLama.Examples project:
  - The SemanticKernelMemory class has been updated to use a MemoryBuilder instead of the Kernel.Builder. This change improves the memory storage and text embedding generation
capabilities of the class.
  - The RunExampleAsync method now accepts an ISemanticTextMemory parameter instead of an IKernel parameter. This change allows for better separation of concerns and improves code
readability.
  - The SearchMemoryAsync method now accepts an ISemanticTextMemory parameter instead of an IKernel parameter. This change allows for better separation of concerns and improves codereadability.
  - The StoreMemoryAsync method now accepts an ISemanticTextMemory parameter instead of an IKernel parameter. This change allows for better separation of concerns and improves code
readability.
- In the LLama.SemanticKernel project:
  - The LLamaSharpTextCompletion class has been updated to include the [EnumeratorCancellation] attribute on the cancellationToken parameter of the GetStreamingCompletionsAsync
method. This change improves the cancellation behavior of the method.
  - The LLamaSharpEmbeddingGeneration class has been updated to return the embeddings as a Task<IList<ReadOnlyMemory<float>>> instead of directly returning the embeddings. This
change improves the asynchronous behavior of the method.

These changes enhance the functionality and performance of the LLama.Examples and LLama.SemanticKernel projects.