### PR TITLE
Fixed Broken Text Decoding

### DIFF
--- a/LLama/LLamaContext.cs
+++ b/LLama/LLamaContext.cs
@@ -110,7 +110,7 @@ namespace LLama
 
             var decoder = new StreamingTokenDecoder(this);
             decoder.AddRange(tokens);
-            return decoder.ToString();
+            return decoder.Read();
         }
 
         /// <summary>


### PR DESCRIPTION
Fixed `LLama.StreamingTokenDecoderLLamaLLama.StreamingTokenDecoderLLamaLLama.StreamingTokenDecoderLLama` spam in all executors except Stateless.

This was a regression introduced in #205 