### PR TITLE
Removed some CI targets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,21 +14,12 @@ jobs:
       matrix:
         build: [linux-debug, linux-release, windows-debug, windows-release]
         include:
-          - build: linux-debug
-            os: ubuntu-latest
-            config: debug
           - build: linux-release
             os: ubuntu-latest
             config: release          
-        # - build: macos-debug
-        #   os: macos-latest
-        #   config: debug
         # - build: macos-release
         #   os: macos-latest
         #   config: release
-          - build: windows-debug
-            os: windows-2019
-            config: debug
           - build: windows-release
             os: windows-2019
             config: release


### PR DESCRIPTION
Reduced it down to Linux and Windows only, always `release` mode.