### PR TITLE
Prevent duplication of user prompts / chat history in ChatSession.

### DIFF
--- a/LLama/ChatSession.cs
+++ b/LLama/ChatSession.cs
@@ -146,7 +146,7 @@ namespace LLama
         /// <param name="prompt"></param>
         /// <param name="inferenceParams"></param>
         /// <param name="cancellationToken"></param>
-        /// <returns>Returns generated tokens of the assistant message.</returns>
+        /// <returns>Returns generated text of the assistant message.</returns>
         public async IAsyncEnumerable<string> ChatAsync(string prompt, IInferenceParams? inferenceParams = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             foreach (var inputTransform in InputTransformPipeline)
@@ -196,7 +196,7 @@ namespace LLama
         /// <param name="history"></param>
         /// <param name="inferenceParams"></param>
         /// <param name="cancellationToken"></param>
-        /// <returns></returns>
+        /// <returns>Returns generated text of the assistant message.</returns>
         public async IAsyncEnumerable<string> ChatAsync(ChatHistory history, IInferenceParams? inferenceParams = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             if (history.Messages.Count == 0)


### PR DESCRIPTION
The way ChatSession.ChatAsync was using the provided methods from a IHistoryTransform interface implementation created unexpected duplication of the chat history messages. It also prevented loading previous history into the current session.