### PR TITLE
Update ToLLamaSharpChatHistory extension method to be public and support semantic-kernel author roles

### DIFF
--- a/LLama.SemanticKernel/ExtensionMethods.cs
+++ b/LLama.SemanticKernel/ExtensionMethods.cs
@@ -5,7 +5,7 @@ namespace LLamaSharp.SemanticKernel;
 
 public static class ExtensionMethods
 {
-    public static global::LLama.Common.ChatHistory ToLLamaSharpChatHistory(this ChatHistory chatHistory)
+    public static global::LLama.Common.ChatHistory ToLLamaSharpChatHistory(this ChatHistory chatHistory, bool ignoreCase = true)
     {
         if (chatHistory is null)
         {
@@ -16,7 +16,7 @@ public static class ExtensionMethods
 
         foreach (var chat in chatHistory)
         {
-            var role = Enum.TryParse<global::LLama.Common.AuthorRole>(chat.Role.Label, true, out var _role) ? _role : global::LLama.Common.AuthorRole.Unknown;
+            var role = Enum.TryParse<global::LLama.Common.AuthorRole>(chat.Role.Label, ignoreCase, out var _role) ? _role : global::LLama.Common.AuthorRole.Unknown;
             history.AddMessage(role, chat.Content);
         }
 

--- a/LLama.SemanticKernel/ExtensionMethods.cs
+++ b/LLama.SemanticKernel/ExtensionMethods.cs
@@ -3,9 +3,9 @@ using Microsoft.SemanticKernel.AI.ChatCompletion;
 
 namespace LLamaSharp.SemanticKernel;
 
-internal static class ExtensionMethods
+public static class ExtensionMethods
 {
-    internal static global::LLama.Common.ChatHistory ToLLamaSharpChatHistory(this ChatHistory chatHistory)
+    public static global::LLama.Common.ChatHistory ToLLamaSharpChatHistory(this ChatHistory chatHistory)
     {
         if (chatHistory is null)
         {
@@ -16,7 +16,7 @@ internal static class ExtensionMethods
 
         foreach (var chat in chatHistory)
         {
-            var role = Enum.TryParse<global::LLama.Common.AuthorRole>(chat.Role.Label, out var _role) ? _role : global::LLama.Common.AuthorRole.Unknown;
+            var role = Enum.TryParse<global::LLama.Common.AuthorRole>(chat.Role.Label, true, out var _role) ? _role : global::LLama.Common.AuthorRole.Unknown;
             history.AddMessage(role, chat.Content);
         }
 


### PR DESCRIPTION
Currently when semantic-kernel ChatHistory is converted to LLamaSharp ChatHistory through the ToLLamaSharpChatHistory extension method in https://github.com/SciSharp/LLamaSharp/blob/master/LLama.SemanticKernel/ExtensionMethods.cs the AuthorRole in the resulting LLamaSharp ChatHistory is set to AuthorRoles.Unknown as semantic-kernel uses lowercase author names while LLamaSharp capitalizes the first character. This PR tells the Enum.TryParse method to ignore letter case when matching.

Further, it exposes the ToLLamaSharpChatHistory extension method publicly since it would be useful for debugging in downstream applications.