### PR TITLE
CPU Feature Detection 2

### DIFF
--- a/LLama.Examples/Program.cs
+++ b/LLama.Examples/Program.cs
@@ -7,7 +7,7 @@ Console.WriteLine(" __       __                                       ____     _
 
 Console.WriteLine("======================================================================================================");
 
-NativeLibraryConfig.Default.WithCuda().WithLogs();
+NativeLibraryConfig.Instance.WithCuda().WithLogs();
 
 NativeApi.llama_empty_call();
 Console.WriteLine();

--- a/LLama/Native/NativeApi.Load.cs
+++ b/LLama/Native/NativeApi.Load.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Text.Json;
 
 namespace LLama.Native
@@ -227,24 +226,15 @@ namespace LLama.Native
             }
             else if (platform != OSPlatform.OSX) // in macos there's absolutely no avx
             {
-#if NET8_0_OR_GREATER
-                if (configuration.AvxLevel == NativeLibraryConfig.AvxLevel.Avx512)
-                {
-                    result.Add(GetAvxLibraryPath(NativeLibraryConfig.AvxLevel.Avx512, prefix, suffix)));
-                    result.Add(GetAvxLibraryPath(NativeLibraryConfig.AvxLevel.Avx2, prefix, suffix)));
-                    result.Add(GetAvxLibraryPath(NativeLibraryConfig.AvxLevel.Avx, prefix, suffix)));
-                }
-                else 
-#endif
-                if (configuration.AvxLevel == NativeLibraryConfig.AvxLevel.Avx2)
-                {
+                if (configuration.AvxLevel >= NativeLibraryConfig.AvxLevel.Avx512)
+                    result.Add(GetAvxLibraryPath(NativeLibraryConfig.AvxLevel.Avx512, prefix, suffix));
+
+                if (configuration.AvxLevel >= NativeLibraryConfig.AvxLevel.Avx2)
                     result.Add(GetAvxLibraryPath(NativeLibraryConfig.AvxLevel.Avx2, prefix, suffix));
+                
+                if (configuration.AvxLevel >= NativeLibraryConfig.AvxLevel.Avx)
                     result.Add(GetAvxLibraryPath(NativeLibraryConfig.AvxLevel.Avx, prefix, suffix));
-                }
-                else if (configuration.AvxLevel == NativeLibraryConfig.AvxLevel.Avx)
-                {
-                    result.Add(GetAvxLibraryPath(NativeLibraryConfig.AvxLevel.Avx, prefix, suffix));
-                }
+
                 result.Add(GetAvxLibraryPath(NativeLibraryConfig.AvxLevel.None, prefix, suffix));
             }
 


### PR DESCRIPTION
The new CUDA autodetection and `NativeLibraryConfig` lost one major feature of the previous loading system that it replaced - automatic detection of AVX levels. Reintroduced that by probing support in the `NativeLibraryConfig` constructor.

I also added in support for `AVX512` even on dotnet versions that don't support it! Autodetection won't detect AVX512 except on dotnet 8.0, but you _can_ manually specify it yourself by calling `WithAvx(AvxLevel.Avx512)`.

A few other minor changes to the `NativeLibraryConfig` system while I was there:
 - Renamed `NativeLibraryConfig.Default` to `NativeLibraryConfig.Instance`. I don't think `Default` makes sense since it's mutable (so it's not the default after you've changed it)!
 - using `Lazy<T>` to initialize it automatically, just a little cleaner than doing it with a lock but basically the same thing.
 - Some spelling and grammar fixes in docs.

## Regression

I noticed that there's probably a (minor, ish) regression in the current 0.8.0 release for CPU only inference. Previously the default libllama.dll required **AVX2** support, now the system uses no SIMD at all for the default version.  That makes sense, we get wider support for older platforms. However 0.8.0 didn't ship any of the more advanced binaries for CPU, so this is probably a big slowdown for pure CPU inference!

@AsakusaRinne can we aim to get a 0.8.1 patch out next weekend with all of the various SIMD binaries for Windows and Linux? I can get started on a PR for that tomorrow if so :)