### PR TITLE
Correctly format followup messages in turn-based (chat) inference

### DIFF
--- a/LLama/ChatSession.cs
+++ b/LLama/ChatSession.cs
@@ -233,9 +233,6 @@ namespace LLama
 
         private async IAsyncEnumerable<string> ChatAsyncInternal(string prompt, IInferenceParams? inferenceParams = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
-            Console.ForegroundColor = ConsoleColor.Gray;
-            Console.WriteLine(prompt);
-
             var results = _executor.InferAsync(prompt, inferenceParams, cancellationToken);
             await foreach (var textToken in OutputTransform.TransformAsync(results).WithCancellation(cancellationToken))
             {


### PR DESCRIPTION
While working with another model than in my previous tests, I noticed that the model always started its responses with the token that indicates the start of a turn (e.g. <|assistant|>) to the second, third, etc. question I asked.

I investigated and found that it is not enough to just send in the raw text for this model as it happened to be for the other model I initially tested with.

I changed the code so that the correct turn template as per `HistoryTransform` class is applied before sending the prompt into the `InternalChatAsync` method.

This resolved the issue and turn-based inference started working as expected.