### PR TITLE
Better TensorSplitsCollection Initialisation

### DIFF
--- a/LLama/Abstractions/IModelParams.cs
+++ b/LLama/Abstractions/IModelParams.cs
@@ -134,9 +134,10 @@ namespace LLama.Abstractions
         /// <exception cref="ArgumentException"></exception>
         public TensorSplitsCollection(float[] splits)
         {
-            if (splits.Length != Splits.Length)
-                throw new ArgumentException($"tensor splits length must equal {Splits.Length}");
-            Splits = splits;
+            if (splits.Length > Splits.Length)
+                throw new ArgumentException($"Must supply at most {Splits.Length} tensor splits", nameof(splits));
+
+            splits.CopyTo(Splits.AsSpan());
         }
 
         /// <summary>


### PR DESCRIPTION
The `TensorSplitsCollection` constructor allows passing an array of splits. At the moment this array must be exactly `NativeApi.llama_max_devices()` items long.

Modified it so that the supplied value can be less than that long, the rest will be set to zero.