### PR TITLE
🔧 Refactor Semantic Kernel chat completion implementation

### DIFF
--- a/LLama.Examples/Examples/SemanticKernelChat.cs
+++ b/LLama.Examples/Examples/SemanticKernelChat.cs
@@ -16,12 +16,11 @@ namespace LLama.Examples.Examples
             // Load weights into memory
             var parameters = new ModelParams(modelPath);
             using var model = LLamaWeights.LoadFromFile(parameters);
-            using var context = model.CreateContext(parameters);
-            var ex = new InteractiveExecutor(context);
+            var ex = new StatelessExecutor(model, parameters);
 
             var chatGPT = new LLamaSharpChatCompletion(ex);
 
-            var chatHistory = chatGPT.CreateNewChat("You are a librarian, expert about books");
+            var chatHistory = chatGPT.CreateNewChat("This is a conversation between the assistant and the user. \n\n You are a librarian, expert about books. ");
 
             Console.WriteLine("Chat content:");
             Console.WriteLine("------------------------");

--- a/LLama.SemanticKernel/ChatCompletion/HistoryTransform.cs
+++ b/LLama.SemanticKernel/ChatCompletion/HistoryTransform.cs
@@ -1,4 +1,6 @@
-﻿using static LLama.LLamaTransforms;
+﻿using LLama.Common;
+using System.Text;
+using static LLama.LLamaTransforms;
 
 namespace LLamaSharp.SemanticKernel.ChatCompletion;
 
@@ -10,8 +12,6 @@ public class HistoryTransform : DefaultHistoryTransform
     /// <inheritdoc/>
     public override string HistoryToText(global::LLama.Common.ChatHistory history)
     {
-        var prompt = base.HistoryToText(history);
-        return prompt + "\nAssistant:";
-
+        return base.HistoryToText(history) + $"{AuthorRole.Assistant}: ";
     }
 }

--- a/LLama.SemanticKernel/ExtensionMethods.cs
+++ b/LLama.SemanticKernel/ExtensionMethods.cs
@@ -35,7 +35,10 @@ public static class ExtensionMethods
             throw new ArgumentNullException(nameof(requestSettings));
         }
 
-        var antiPrompts = new List<string>(requestSettings.StopSequences) { AuthorRole.User.ToString() + ":" };
+        var antiPrompts = new List<string>(requestSettings.StopSequences)
+                                  { LLama.Common.AuthorRole.User.ToString() + ":" ,
+                                    LLama.Common.AuthorRole.Assistant.ToString() + ":",
+                                    LLama.Common.AuthorRole.System.ToString() + ":"};
         return new global::LLama.Common.InferenceParams
         {
             Temperature = (float)requestSettings.Temperature,


### PR DESCRIPTION
Breaking Changes
---
- Refactored the chat completion implementation in `LLamaSharpChatCompletion.cs` to use `StatelessExecutor` instead of `InteractiveExecutor`.

Changes
---
- Updated the chat history prompt in `LLamaSharpChatCompletion.cs` to include a conversation between the assistant and the user.
- Modified the `HistoryTransform` class in `HistoryTransform.cs` to append the assistant role to the chat history prompt.
- Updated the constructor of `LLamaSharpChatCompletion` to accept optional parameters for `historyTransform` and `outputTransform`.
- Modified the `GetChatCompletionsAsync` and `GetChatCompletions` methods in `LLamaSharpChatCompletion.cs` to use the new `StatelessExecutor` and `outputTransform`.
- Updated the `ExtensionMethods.cs` file to include the assistant and system roles in the list of anti-prompts.

Discussion
---
The current implementation refers to the handling method of History in LLamaSharp ChatSession, but the actual execution effect still needs to be combined with models and prompts.