### PR TITLE
Upgrade unittest target framework to .NET 8.0

### DIFF
--- a/LLama.Unittest/LLama.Unittest.csproj
+++ b/LLama.Unittest/LLama.Unittest.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\LLama\LLamaSharp.Runtime.targets" />
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>LLama.Unittest</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Platforms>AnyCPU;x64</Platforms>

--- a/LLama.Unittest/ModelsParamsTests.cs
+++ b/LLama.Unittest/ModelsParamsTests.cs
@@ -1,4 +1,5 @@
 ﻿using LLama.Common;
+using System.Text.Json;
 
 namespace LLama.Unittest
 {
@@ -7,6 +8,8 @@ namespace LLama.Unittest
         [Fact]
         public void SerializeRoundTripSystemTextJson()
         {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new EncodingConverter());
             var expected = new ModelParams("abc/123")
             {
                 BatchSize = 17,
@@ -16,8 +19,8 @@ namespace LLama.Unittest
                 TensorSplits = { [0] = 3 }
             };
 
-            var json = System.Text.Json.JsonSerializer.Serialize(expected);
-            var actual = System.Text.Json.JsonSerializer.Deserialize<ModelParams>(json)!;
+            var json = JsonSerializer.Serialize(expected, options);
+            var actual = JsonSerializer.Deserialize<ModelParams>(json, options)!;
 
             // Cannot compare splits with default equality, check they are sequence equal and then set to null
             Assert.Equal((IEnumerable<float>)expected.TensorSplits, expected.TensorSplits);

--- a/LLama.Unittest/ModelsParamsTests.cs
+++ b/LLama.Unittest/ModelsParamsTests.cs
@@ -8,8 +8,6 @@ namespace LLama.Unittest
         [Fact]
         public void SerializeRoundTripSystemTextJson()
         {
-            var options = new JsonSerializerOptions();
-            options.Converters.Add(new EncodingConverter());
             var expected = new ModelParams("abc/123")
             {
                 BatchSize = 17,
@@ -19,13 +17,18 @@ namespace LLama.Unittest
                 TensorSplits = { [0] = 3 }
             };
 
-            var json = JsonSerializer.Serialize(expected, options);
-            var actual = JsonSerializer.Deserialize<ModelParams>(json, options)!;
+            var json = JsonSerializer.Serialize(expected);
+            var actual = JsonSerializer.Deserialize<ModelParams>(json)!;
 
             // Cannot compare splits with default equality, check they are sequence equal and then set to null
             Assert.Equal((IEnumerable<float>)expected.TensorSplits, expected.TensorSplits);
             actual.TensorSplits = null!;
             expected.TensorSplits = null!;
+
+            // Check encoding is the same
+            var b1 = expected.Encoding.GetBytes("Hello");
+            var b2 = actual.Encoding.GetBytes("Hello");
+            Assert.True(b1.SequenceEqual(b2));
 
             Assert.Equal(expected, actual);
         }

--- a/LLama/Abstractions/IModelParams.cs
+++ b/LLama/Abstractions/IModelParams.cs
@@ -3,6 +3,9 @@ using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using LLama.Common;
 using LLama.Native;
 
 namespace LLama.Abstractions
@@ -105,6 +108,7 @@ namespace LLama.Abstractions
     /// <summary>
     /// A fixed size array to set the tensor splits across multiple GPUs
     /// </summary>
+    [JsonConverter(typeof(TensorSplitsCollectionConverter))]
     public sealed class TensorSplitsCollection
         : IEnumerable<float>
     {
@@ -173,5 +177,25 @@ namespace LLama.Abstractions
             return Splits.GetEnumerator();
         }
         #endregion
+    }
+
+    /// <summary>
+    /// A JSON converter for <see cref="TensorSplitsCollection"/>
+    /// </summary>
+    public class TensorSplitsCollectionConverter
+        : JsonConverter<TensorSplitsCollection>
+    {
+        /// <inheritdoc/>
+        public override TensorSplitsCollection? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var arr = JsonSerializer.Deserialize<float[]>(ref reader, options) ?? Array.Empty<float>();
+            return new TensorSplitsCollection(arr);
+        }
+
+        /// <inheritdoc/>
+        public override void Write(Utf8JsonWriter writer, TensorSplitsCollection value, JsonSerializerOptions options)
+        {
+            JsonSerializer.Serialize(writer, value.Splits, options);
+        }
     }
 }

--- a/LLama/Common/ModelParams.cs
+++ b/LLama/Common/ModelParams.cs
@@ -96,6 +96,7 @@ namespace LLama.Common
         /// `Encoding` cannot be directly JSON serialized, instead store the name as a string which can
         /// </summary>
         [JsonPropertyName("Encoding")]
+        [JsonInclude]
         private string EncodingName { get; set; } = Encoding.UTF8.WebName;
 
         /// <inheritdoc />

--- a/LLama/Common/ModelParams.cs
+++ b/LLama/Common/ModelParams.cs
@@ -92,9 +92,19 @@ namespace LLama.Common
         /// <inheritdoc />
         public bool VocabOnly { get; set; }
 
+        /// <summary>
+        /// `Encoding` cannot be directly JSON serialized, instead store the name as a string which can
+        /// </summary>
+        [JsonPropertyName("Encoding")]
+        private string EncodingName { get; set; } = Encoding.UTF8.WebName;
+
         /// <inheritdoc />
-        [JsonConverter(typeof(EncodingConverter))]
-        public Encoding Encoding { get; set; } = Encoding.UTF8;
+        [JsonIgnore]
+        public Encoding Encoding
+        {
+            get => Encoding.GetEncoding(EncodingName);
+            set => EncodingName = value.WebName;
+        }
 
         /// <summary>
         /// 
@@ -113,22 +123,6 @@ namespace LLama.Common
         }
     }
 
-    internal class EncodingConverter
-        : JsonConverter<Encoding>
-    {
-        public override Encoding? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            var name = reader.GetString();
-            if (name == null)
-                return null;
-            return Encoding.GetEncoding(name);
-        }
-
-        public override void Write(Utf8JsonWriter writer, Encoding value, JsonSerializerOptions options)
-        {
-            writer.WriteStringValue(value.WebName);
-        }
-    }
 
     internal class TensorSplitsCollectionConverter
         : JsonConverter<TensorSplitsCollection>

--- a/LLama/Common/ModelParams.cs
+++ b/LLama/Common/ModelParams.cs
@@ -59,7 +59,6 @@ namespace LLama.Common
         public bool EmbeddingMode { get; set; }
 
         /// <inheritdoc />
-        [JsonConverter(typeof(TensorSplitsCollectionConverter))]
         public TensorSplitsCollection TensorSplits { get; set; } = new();
 
         /// <inheritdoc />
@@ -121,22 +120,6 @@ namespace LLama.Common
         {
             // This constructor (default parameterless constructor) is used by Newtonsoft to deserialize!
             ModelPath = "";
-        }
-    }
-
-
-    internal class TensorSplitsCollectionConverter
-        : JsonConverter<TensorSplitsCollection>
-    {
-        public override TensorSplitsCollection? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            var arr = JsonSerializer.Deserialize<float[]>(ref reader, options) ?? Array.Empty<float>();
-            return new TensorSplitsCollection(arr);
-        }
-
-        public override void Write(Utf8JsonWriter writer, TensorSplitsCollection value, JsonSerializerOptions options)
-        {
-            JsonSerializer.Serialize(writer, value.Splits, options);
         }
     }
 }


### PR DESCRIPTION
This pull request upgrades the target framework of the unittest project to .NET 8.0.
 It also updates the serialization and deserialization code to use JsonSerializer with custom options for ModelsParamsTests .

It fixed the issue on https://github.com/SciSharp/LLamaSharp/pull/356#issuecomment-1851185829

Ref: https://github.com/dotnet/runtime/issues/95893?notification_referrer_id=NT_kwDOADd2vbI4NzMxNTMzMTE0OjM2MzQ4Nzc#issuecomment-1851644867