### PR TITLE
Issue #350 development

### DIFF
--- a/LLama/LLamaSharp.Runtime.targets
+++ b/LLama/LLamaSharp.Runtime.targets
@@ -67,5 +67,31 @@
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <Link>runtimes/osx-x64/native/libllama.dylib</Link>
       </None>
+	  
+	  <None Include="$(MSBuildThisFileDirectory)runtimes/deps/cu11.7.1/cublas64_11.dll">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Link>cublas64_11.dll</Link>
+      </None>
+	  <None Include="$(MSBuildThisFileDirectory)runtimes/deps/cu11.7.1/cublasLt64_11.dll">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Link>cublasLt64_11.dll</Link>
+      </None>
+	  <None Include="$(MSBuildThisFileDirectory)runtimes/deps/cu11.7.1/cudart64_110.dll">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Link>cudart64_110.dll</Link>
+      </None>
+	  
+	  <None Include="$(MSBuildThisFileDirectory)runtimes/deps/cu12.1.0/cublas64_12.dll">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Link>cublas64_12.dll</Link>
+      </None>
+	  <None Include="$(MSBuildThisFileDirectory)runtimes/deps/cu12.1.0/cublasLt64_12.dll">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Link>cublasLt64_12.dll</Link>
+      </None>
+	  <None Include="$(MSBuildThisFileDirectory)runtimes/deps/cu12.1.0/cudart64_12.dll">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Link>cudart64_12.dll</Link>
+      </None>
     </ItemGroup>
 </Project>

--- a/LLama/runtimes/build/LLamaSharp.Backend.Cuda11.nuspec
+++ b/LLama/runtimes/build/LLamaSharp.Backend.Cuda11.nuspec
@@ -20,6 +20,9 @@
     
     <file src="runtimes/deps/cu11.7.1/libllama.dll" target="runtimes\win-x64\native\cuda11\libllama.dll" />
     <file src="runtimes/deps/cu11.7.1/libllama.so" target="runtimes\linux-x64\native\cuda11\libllama.so" />
+	<file src="runtimes\deps\cu11.7.1\cublas64_11.dll" target="cublas64_11.dll" />
+	<file src="runtimes\deps\cu11.7.1\cublasLt64_11.dll" target="cublasLt64_11.dll" />
+	<file src="runtimes\deps\cu11.7.1\cudart64_110.dll" target="cudart64_110.dll" />
     
     <file src="icon512.png" target="icon512.png" />
   </files>

--- a/LLama/runtimes/build/LLamaSharp.Backend.Cuda12.nuspec
+++ b/LLama/runtimes/build/LLamaSharp.Backend.Cuda12.nuspec
@@ -20,6 +20,9 @@
     
     <file src="runtimes/deps/cu12.1.0/libllama.dll" target="runtimes\win-x64\native\cuda12\libllama.dll" />
     <file src="runtimes/deps/cu12.1.0/libllama.so" target="runtimes\linux-x64\native\cuda12\libllama.so" />
+	<file src="runtimes\deps\cu12.1.0\cublas64_12.dll" target="cublas64_12.dll" />
+	<file src="runtimes\deps\cu12.1.0\cublasLt64_12.dll" target="cublasLt64_12.dll" />
+	<file src="runtimes\deps\cu12.1.0\cudart64_12.dll" target="cudart64_12.dll" />
     
     <file src="icon512.png" target="icon512.png" />
   </files>


### PR DESCRIPTION
Related to: https://github.com/SciSharp/LLamaSharp/issues/350

Nvidia CUDA binaries are taken from archives:
- CUDA 11 (cudart-llama-bin-win-cu11.7.1-x64.zip)
- CUDA 12 (cudart-llama-bin-win-cu12.2.0-x64.zip) from the latest (at the moment of writing this) build of ggerganov's [llama.cpp](https://github.com/ggerganov/llama.cpp/releases/tag/b1643).

Editing .nuspec at this point is discussible, however.