### PR TITLE
Improved support for AVX512

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -57,7 +57,7 @@ jobs:
           - build: 'avx'
             defines: '-DLLAMA_AVX2=OFF'
           - build: 'avx512'
-            defines: '-DLLAMA_AVX512=ON'
+            defines: '-DLLAMA_AVX512=ON -LLAMA_AVX512_VBMI=ON -DLLAMA_AVX512_VNNI=ON'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
 - Enabled more features in build process (VBMI and VNNI)
   - I haven't rebuilt the binaries yet, so this improvement will be picked up in the next binary update
 - Added runtime checking for these new features
 - Improved runtime checking to no longer require dotnet8.0!