### PR TITLE
Added `LLamaWeights.Metadata` property

### DIFF
--- a/LLama.Unittest/BasicTest.cs
+++ b/LLama.Unittest/BasicTest.cs
@@ -38,6 +38,8 @@ namespace LLama.Unittest
         [Fact]
         public void AdvancedModelProperties()
         {
+            // These are the keys in the llama 7B test model. This will need changing if
+            // tests are switched to use a new model!
             var expected = new Dictionary<string, string>
             {
                 { "general.name", "LLaMA v2" },
@@ -60,31 +62,16 @@ namespace LLama.Unittest
                 { "tokenizer.ggml.unknown_token_id", "0" },
             };
 
-            var metaCount = NativeApi.llama_model_meta_count(_model.NativeHandle);
-            Assert.Equal(expected.Count, metaCount);
+            // Print all keys
+            foreach (var (key, value) in _model.Metadata)
+                _testOutputHelper.WriteLine($"{key} = {value}");
 
-            Span<byte> buffer = stackalloc byte[128];
-            for (var i = 0; i < expected.Count; i++)
-            {
-                unsafe
-                {
-                    fixed (byte* ptr = buffer)
-                    {
-                        var length = NativeApi.llama_model_meta_key_by_index(_model.NativeHandle, i, ptr, 128);
-                        Assert.True(length > 0);
-                        var key = Encoding.UTF8.GetString(buffer[..length]);
+            // Check the count is equal
+            Assert.Equal(expected.Count, _model.Metadata.Count);
 
-                        length = NativeApi.llama_model_meta_val_str_by_index(_model.NativeHandle, i, ptr, 128);
-                        Assert.True(length > 0);
-                        var val = Encoding.UTF8.GetString(buffer[..length]);
-
-                        _testOutputHelper.WriteLine($"{key} == {val}");
-
-                        Assert.True(expected.ContainsKey(key));
-                        Assert.Equal(expected[key], val);
-                    }
-                }
-            }
+            // Check every key
+            foreach (var (key, value) in _model.Metadata)
+                Assert.Equal(expected[key], value);
         }
     }
 }

--- a/LLama/Extensions/EncodingExtensions.cs
+++ b/LLama/Extensions/EncodingExtensions.cs
@@ -16,7 +16,7 @@ internal static class EncodingExtensions
         return GetCharCountImpl(encoding, bytes);
     }
 #elif !NET6_0_OR_GREATER && !NETSTANDARD2_1_OR_GREATER
-    #error Target framework not supported!
+#error Target framework not supported!
 #endif
 
     internal static int GetCharsImpl(Encoding encoding, ReadOnlySpan<byte> bytes, Span<char> output)
@@ -44,6 +44,17 @@ internal static class EncodingExtensions
             fixed (byte* bytePtr = bytes)
             {
                 return encoding.GetCharCount(bytePtr, bytes.Length);
+            }
+        }
+    }
+
+    internal static string GetStringFromSpan(this Encoding encoding, ReadOnlySpan<byte> bytes)
+    {
+        unsafe
+        {
+            fixed (byte* bytesPtr = bytes)
+            {
+                return encoding.GetString(bytesPtr, bytes.Length);
             }
         }
     }

--- a/LLama/LLamaWeights.cs
+++ b/LLama/LLamaWeights.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Buffers;
 using System.Collections.Generic;
-using System.Text;
 using LLama.Abstractions;
 using LLama.Extensions;
 using LLama.Native;

--- a/LLama/LLamaWeights.cs
+++ b/LLama/LLamaWeights.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Text;
 using LLama.Abstractions;
 using LLama.Extensions;
 using LLama.Native;
@@ -58,9 +61,15 @@ namespace LLama
         /// </summary>
         public int EmbeddingSize => NativeHandle.EmbeddingSize;
 
+        /// <summary>
+        /// All metadata keys in this model
+        /// </summary>
+        public IReadOnlyDictionary<string, string> Metadata { get; set; }
+
         internal LLamaWeights(SafeLlamaModelHandle weights)
         {
             NativeHandle = weights;
+            Metadata = weights.ReadMetadata();
         }
 
         /// <summary>

--- a/LLama/Native/SafeLlamaModelHandle.cs
+++ b/LLama/Native/SafeLlamaModelHandle.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Buffers;
 using System.Collections.Generic;
-using System.Security.Cryptography;
 using System.Text;
 using LLama.Exceptions;
 

--- a/LLama/Native/SafeLlamaModelHandle.cs
+++ b/LLama/Native/SafeLlamaModelHandle.cs
@@ -3,6 +3,8 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Text;
 using LLama.Exceptions;
+using LLama.Extensions;
+using EncodingExtensions = LLama.Extensions.EncodingExtensions;
 
 namespace LLama.Native
 {
@@ -259,12 +261,12 @@ namespace LLama.Native
                     var keyBytes = MetadataKeyByIndex(i, dest.AsMemory());
                     if (keyBytes == null)
                         continue;
-                    var key = Encoding.UTF8.GetString(keyBytes.Value.Span);
+                    var key = Encoding.UTF8.GetStringFromSpan(keyBytes.Value.Span);
 
                     var valBytes = MetadataValueByIndex(i, dest.AsMemory());
                     if (valBytes == null)
                         continue;
-                    var val = Encoding.UTF8.GetString(valBytes.Value.Span);
+                    var val = Encoding.UTF8.GetStringFromSpan(valBytes.Value.Span);
 
                     result[key] = val;
                 }

--- a/LLama/Native/SafeLlamaModelHandle.cs
+++ b/LLama/Native/SafeLlamaModelHandle.cs
@@ -222,10 +222,10 @@ namespace LLama.Native
             unsafe
             {
                 using var pin = buffer.Pin();
-                var keyLength = NativeApi.llama_model_meta_key_by_index(this, index, (byte*)pin.Pointer, 1024);
+                var keyLength = NativeApi.llama_model_meta_key_by_index(this, index, (byte*)pin.Pointer, buffer.Length);
                 if (keyLength < 0)
                     return null;
-                return buffer.Slice(keyLength);
+                return buffer.Slice(0, keyLength);
             }
         }
 
@@ -240,10 +240,10 @@ namespace LLama.Native
             unsafe
             {
                 using var pin = buffer.Pin();
-                var keyLength = NativeApi.llama_model_meta_key_by_index(this, index, (byte*)pin.Pointer, 1024);
+                var keyLength = NativeApi.llama_model_meta_val_str_by_index(this, index, (byte*)pin.Pointer, buffer.Length);
                 if (keyLength < 0)
                     return null;
-                return buffer.Slice(keyLength);
+                return buffer.Slice(0, keyLength);
             }
         }
 

--- a/LLama/Native/SafeLlamaModelHandle.cs
+++ b/LLama/Native/SafeLlamaModelHandle.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Buffers;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 using System.Text;
 using LLama.Exceptions;
 
@@ -36,6 +38,12 @@ namespace LLama.Native
         /// </summary>
         public ulong ParameterCount { get; }
 
+        /// <summary>
+        /// Get the number of metadata key/value pairs
+        /// </summary>
+        /// <returns></returns>
+        public int MetadataCount { get; }
+
         internal SafeLlamaModelHandle(IntPtr handle)
             : base(handle)
         {
@@ -44,6 +52,7 @@ namespace LLama.Native
             EmbeddingSize = NativeApi.llama_n_embd(this);
             SizeInBytes = NativeApi.llama_model_size(this);
             ParameterCount = NativeApi.llama_model_n_params(this);
+            MetadataCount = NativeApi.llama_model_meta_count(this);
         }
 
         /// <inheritdoc />
@@ -197,6 +206,76 @@ namespace LLama.Native
         public SafeLLamaContextHandle CreateContext(LLamaContextParams @params)
         {
             return SafeLLamaContextHandle.Create(this, @params);
+        }
+        #endregion
+
+        #region metadata
+        /// <summary>
+        /// Get the metadata key for the given index
+        /// </summary>
+        /// <param name="index">The index to get</param>
+        /// <param name="buffer">A temporary buffer to store key characters in. Must be large enough to contain the key.</param>
+        /// <returns>The key, null if there is no such key or if the buffer was too small</returns>
+        public Memory<byte>? MetadataKeyByIndex(int index, Memory<byte> buffer)
+        {
+            unsafe
+            {
+                using var pin = buffer.Pin();
+                var keyLength = NativeApi.llama_model_meta_key_by_index(this, index, (byte*)pin.Pointer, 1024);
+                if (keyLength < 0)
+                    return null;
+                return buffer.Slice(keyLength);
+            }
+        }
+
+        /// <summary>
+        /// Get the metadata value for the given index
+        /// </summary>
+        /// <param name="index">The index to get</param>
+        /// <param name="buffer">A temporary buffer to store value characters in. Must be large enough to contain the value.</param>
+        /// <returns>The value, null if there is no such value or if the buffer was too small</returns>
+        public Memory<byte>? MetadataValueByIndex(int index, Memory<byte> buffer)
+        {
+            unsafe
+            {
+                using var pin = buffer.Pin();
+                var keyLength = NativeApi.llama_model_meta_key_by_index(this, index, (byte*)pin.Pointer, 1024);
+                if (keyLength < 0)
+                    return null;
+                return buffer.Slice(keyLength);
+            }
+        }
+
+        internal IReadOnlyDictionary<string, string> ReadMetadata()
+        {
+            var result = new Dictionary<string, string>();
+
+            var dest = ArrayPool<byte>.Shared.Rent(1024);
+            try
+            {
+                for (var i = 0; i < MetadataCount; i++)
+                {
+                    Array.Clear(dest, 0, dest.Length);
+
+                    var keyBytes = MetadataKeyByIndex(i, dest.AsMemory());
+                    if (keyBytes == null)
+                        continue;
+                    var key = Encoding.UTF8.GetString(keyBytes.Value.Span);
+
+                    var valBytes = MetadataValueByIndex(i, dest.AsMemory());
+                    if (valBytes == null)
+                        continue;
+                    var val = Encoding.UTF8.GetString(valBytes.Value.Span);
+
+                    result[key] = val;
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(dest);
+            }
+
+            return result;
         }
         #endregion
     }


### PR DESCRIPTION
exposed some ways to get model metadata:

 - `LLamaWeights.Metadata : IReadOnlyDictionary<string, string>`
 - `SafeLlamaModelHandle.MetadataKeyByIndex`
 - `SafeLlamaModelHandle.MetadataValueByIndex`