### PR TITLE
Metadata Fixes

### DIFF
--- a/LLama/Abstractions/IModelParams.cs
+++ b/LLama/Abstractions/IModelParams.cs
@@ -269,7 +269,7 @@ namespace LLama.Abstractions
                     dest.FloatValue = _valueFloat;
                     break;
                 case LLamaModelKvOverrideType.LLAMA_KV_OVERRIDE_BOOL:
-                    dest.BoolValue = _valueBool ? -1 : 0;
+                    dest.BoolValue = _valueBool ? -1L : 0;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();

--- a/LLama/Extensions/EncodingExtensions.cs
+++ b/LLama/Extensions/EncodingExtensions.cs
@@ -6,6 +6,11 @@ namespace LLama.Extensions;
 internal static class EncodingExtensions
 {
 #if NETSTANDARD2_0
+    public static int GetBytes(this Encoding encoding, ReadOnlySpan<char> chars, Span<byte> output)
+    {
+        return GetBytesImpl(encoding, chars, output);
+    }
+
     public static int GetChars(this Encoding encoding, ReadOnlySpan<byte> bytes, Span<char> output)
     {
         return GetCharsImpl(encoding, bytes, output);
@@ -18,6 +23,21 @@ internal static class EncodingExtensions
 #elif !NET6_0_OR_GREATER && !NETSTANDARD2_1_OR_GREATER
 #error Target framework not supported!
 #endif
+
+    internal static int GetBytesImpl(Encoding encoding, ReadOnlySpan<char> chars, Span<byte> output)
+    {
+        if (chars.Length == 0)
+            return 0;
+
+        unsafe
+        {
+            fixed (char* charPtr = chars)
+            fixed (byte* bytePtr = output)
+            {
+                return encoding.GetBytes(charPtr, chars.Length, bytePtr, output.Length);
+            }
+        }
+    }
 
     internal static int GetCharsImpl(Encoding encoding, ReadOnlySpan<byte> bytes, Span<char> output)
     {

--- a/LLama/Native/LLamaModelMetadataOverride.cs
+++ b/LLama/Native/LLamaModelMetadataOverride.cs
@@ -21,22 +21,28 @@ public unsafe struct LLamaModelMetadataOverride
     public LLamaModelKvOverrideType Tag;
 
     /// <summary>
-    /// Value, **must** only be used if Tag == LLAMA_KV_OVERRIDE_INT
+    /// Add 4 bytes of padding, to align the next fields to 8 bytes
     /// </summary>
     [FieldOffset(132)]
+    private readonly int PADDING;
+
+    /// <summary>
+    /// Value, **must** only be used if Tag == LLAMA_KV_OVERRIDE_INT
+    /// </summary>
+    [FieldOffset(136)]
     public long IntValue;
 
     /// <summary>
     /// Value, **must** only be used if Tag == LLAMA_KV_OVERRIDE_FLOAT
     /// </summary>
-    [FieldOffset(132)]
+    [FieldOffset(136)]
     public double FloatValue;
 
     /// <summary>
     /// Value, **must** only be used if Tag == LLAMA_KV_OVERRIDE_BOOL
     /// </summary>
-    [FieldOffset(132)]
-    public int BoolValue;
+    [FieldOffset(136)]
+    public long BoolValue;
 }
 
 /// <summary>


### PR DESCRIPTION
Fixed some issues which were causing metadata overrides not to work (mostly importantly, converting the key was failing so all keys were null bytes and thus ignored).

Fixed alignment issue with fields, which was causing the incorrect values to be applied.