### PR TITLE
Update compile.yml to fix not building for windows

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -57,7 +57,7 @@ jobs:
           - build: 'avx'
             defines: '-DLLAMA_AVX2=OFF'
           - build: 'avx512'
-            defines: '-DLLAMA_AVX512=ON -LLAMA_AVX512_VBMI=ON -DLLAMA_AVX512_VNNI=ON'
+            defines: '-DLLAMA_AVX512=ON -DLLAMA_AVX512_VBMI=ON -DLLAMA_AVX512_VNNI=ON'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This fixes the build step: Compile (Windows) (avx512, -DLLAMA_AVX512=ON -LLAMA_AVX512_VBMI=ON -DLLAMA_AVX512_VNNI=ON)

There is a typo in the cmake command: `cmake .. -DLLAMA_NATIVE=OFF -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_EXAMPLES=OFF -DLLAMA_BUILD_SERVER=OFF -DBUILD_SHARED_LIBS=ON -DLLAMA_AVX512=ON -LLAMA_AVX512_VBMI=ON -DLLAMA_AVX512_VNNI=ON
  cmake --build . --config Release -j ${env:NUMBER_OF_PROCESSORS}`

`-LLAMA_AVX512_VBMI`
Should be
`-DLLAMA_AVX512_VBMI`

Here is a link to the build error: **https://github.com/edgett/LLamaSharp/actions/runs/7316984325/job/19932084747#logs**

And a working build after this change:
**https://github.com/edgett/LLamaSharp/actions/runs/7317114102/job/19932341049**