### PR TITLE
Removed some unnecessary uses of `unsafe`

### DIFF
--- a/LLama/LLamaEmbedder.cs
+++ b/LLama/LLamaEmbedder.cs
@@ -77,14 +77,11 @@ namespace LLama
             if (embed_inp_array.Length > 0)
                 Context.Eval(embed_inp_array, 0);
 
-            unsafe
-            {
-                var embeddings = NativeApi.llama_get_embeddings(Context.NativeHandle);
-                if (embeddings == null)
-                    return Array.Empty<float>();
+            var embeddings = NativeApi.llama_get_embeddings(Context.NativeHandle);
+            if (embeddings == null)
+                return Array.Empty<float>();
 
-                return embeddings.ToArray();
-            }
+            return embeddings.ToArray();
         }
 
         /// <summary>

--- a/LLama/LLamaExecutorBase.cs
+++ b/LLama/LLamaExecutorBase.cs
@@ -70,7 +70,7 @@ namespace LLama
         /// </summary>
         protected float? MirostatMu { get; set; }
 
-        private StreamingTokenDecoder _decoder;
+        private readonly StreamingTokenDecoder _decoder;
 
         /// <summary>
         /// 

--- a/LLama/LLamaExecutorBase.cs
+++ b/LLama/LLamaExecutorBase.cs
@@ -95,7 +95,7 @@ namespace LLama
         /// <returns></returns>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="RuntimeError"></exception>
-        public unsafe StatefulExecutorBase WithSessionFile(string filename)
+        public StatefulExecutorBase WithSessionFile(string filename)
         {
             _pathSession = filename;
             if (string.IsNullOrEmpty(filename))
@@ -105,9 +105,8 @@ namespace LLama
             if (File.Exists(filename))
             {
                 _logger?.LogInformation($"[LLamaExecutor] Attempting to load saved session from {filename}");
-                llama_token[] session_tokens = new llama_token[Context.ContextSize];
-                ulong n_token_count_out = 0;
-                if (!NativeApi.llama_load_session_file(Context.NativeHandle, _pathSession, session_tokens, (ulong)Context.ContextSize, &n_token_count_out))
+                var session_tokens = new llama_token[Context.ContextSize];
+                if (!NativeApi.llama_load_session_file(Context.NativeHandle, _pathSession, session_tokens, (ulong)Context.ContextSize, out var n_token_count_out))
                 {
                     _logger?.LogError($"[LLamaExecutor] Failed to load session file {filename}");
                     throw new RuntimeError($"Failed to load session file {_pathSession}");

--- a/LLama/LLamaQuantizer.cs
+++ b/LLama/LLamaQuantizer.cs
@@ -20,8 +20,7 @@ namespace LLama
         /// <param name="quantizeOutputTensor"></param>
         /// <returns>Whether the quantization is successful.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public static unsafe bool Quantize(string srcFileName, string dstFilename, LLamaFtype ftype, int nthread = -1, bool allowRequantize = true, 
-                                           bool quantizeOutputTensor = false)
+        public static bool Quantize(string srcFileName, string dstFilename, LLamaFtype ftype, int nthread = -1, bool allowRequantize = true, bool quantizeOutputTensor = false)
         {
             if (!ValidateFtype(ftype))
             {
@@ -34,7 +33,10 @@ namespace LLama
             quantizeParams.nthread = nthread;
             quantizeParams.allow_requantize = allowRequantize;
             quantizeParams.quantize_output_tensor = quantizeOutputTensor;
-            return NativeApi.llama_model_quantize(srcFileName, dstFilename, &quantizeParams) == 0;
+            unsafe
+            {
+                return NativeApi.llama_model_quantize(srcFileName, dstFilename, &quantizeParams) == 0;
+            }
         }
 
         /// <summary>

--- a/LLama/Native/NativeApi.cs
+++ b/LLama/Native/NativeApi.cs
@@ -447,7 +447,7 @@ namespace LLama.Native
         {
             unsafe
             {
-                fixed (byte* destPtr = &dest[0])
+                fixed (byte* destPtr = dest)
                 {
                     return llama_model_meta_key_by_index_native(model, index, destPtr, dest.Length);
                 }
@@ -468,7 +468,7 @@ namespace LLama.Native
         {
             unsafe
             {
-                fixed (byte* destPtr = &dest[0])
+                fixed (byte* destPtr = dest)
                 {
                     return llama_model_meta_val_str_by_index_native(model, index, destPtr, dest.Length);
                 }

--- a/LLama/Native/NativeApi.cs
+++ b/LLama/Native/NativeApi.cs
@@ -175,7 +175,7 @@ namespace LLama.Native
         /// <param name="n_token_count_out"></param>
         /// <returns></returns>
         [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern unsafe bool llama_load_session_file(SafeLLamaContextHandle ctx, string path_session, llama_token[] tokens_out, ulong n_token_capacity, ulong* n_token_count_out);
+        public static extern bool llama_load_session_file(SafeLLamaContextHandle ctx, string path_session, llama_token[] tokens_out, ulong n_token_capacity, out ulong n_token_count_out);
 
         /// <summary>
         /// Save session file
@@ -439,24 +439,44 @@ namespace LLama.Native
         /// <summary>
         /// Get metadata key name by index
         /// </summary>
-        /// <param name="model"></param>
-        /// <param name="index"></param>
-        /// <param name="buf"></param>
-        /// <param name="buf_size"></param>
+        /// <param name="model">Model to fetch from</param>
+        /// <param name="index">Index of key to fetch</param>
+        /// <param name="dest">buffer to write result into</param>
         /// <returns>The length of the string on success, or -1 on failure</returns>
-        [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern unsafe int llama_model_meta_key_by_index(SafeLlamaModelHandle model, int index, byte* buf, long buf_size);
+        public static int llama_model_meta_key_by_index(SafeLlamaModelHandle model, int index, Span<byte> dest)
+        {
+            unsafe
+            {
+                fixed (byte* destPtr = &dest[0])
+                {
+                    return llama_model_meta_key_by_index_native(model, index, destPtr, dest.Length);
+                }
+            }
+
+            [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "llama_model_meta_key_by_index")]
+            static extern unsafe int llama_model_meta_key_by_index_native(SafeLlamaModelHandle model, int index, byte* buf, long buf_size);
+        }
 
         /// <summary>
         /// Get metadata value as a string by index
         /// </summary>
-        /// <param name="model"></param>
-        /// <param name="index"></param>
-        /// <param name="buf"></param>
-        /// <param name="buf_size"></param>
+        /// <param name="model">Model to fetch from</param>
+        /// <param name="index">Index of val to fetch</param>
+        /// <param name="dest">Buffer to write result into</param>
         /// <returns>The length of the string on success, or -1 on failure</returns>
-        [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern unsafe int llama_model_meta_val_str_by_index(SafeLlamaModelHandle model, int index, byte* buf, long buf_size);
+        public static int llama_model_meta_val_str_by_index(SafeLlamaModelHandle model, int index, Span<byte> dest)
+        {
+            unsafe
+            {
+                fixed (byte* destPtr = &dest[0])
+                {
+                    return llama_model_meta_val_str_by_index_native(model, index, destPtr, dest.Length);
+                }
+            }
+
+            [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "llama_model_meta_val_str_by_index")]
+            static extern unsafe int llama_model_meta_val_str_by_index_native(SafeLlamaModelHandle model, int index, byte* buf, long buf_size);
+        }
 
         /// <summary>
         /// Get a string describing the model type

--- a/LLama/Native/SafeLlamaModelHandle.cs
+++ b/LLama/Native/SafeLlamaModelHandle.cs
@@ -221,21 +221,17 @@ namespace LLama.Native
             unsafe
             {
                 // Check if the key exists, without getting any bytes of data
-                keyLength = NativeApi.llama_model_meta_key_by_index(this, index, (byte*)0, 0);
+                keyLength = NativeApi.llama_model_meta_key_by_index(this, index, Array.Empty<byte>());
                 if (keyLength < 0)
                     return null;
             }
 
             // get a buffer large enough to hold it
             var buffer = new byte[keyLength + 1];
-            unsafe
-            {
-                using var pin = buffer.AsMemory().Pin();
-                keyLength = NativeApi.llama_model_meta_key_by_index(this, index, (byte*)pin.Pointer, buffer.Length);
-                Debug.Assert(keyLength >= 0);
+            keyLength = NativeApi.llama_model_meta_key_by_index(this, index, buffer);
+            Debug.Assert(keyLength >= 0);
 
-                return buffer.AsMemory().Slice(0, keyLength);
-            }
+            return buffer.AsMemory().Slice(0, keyLength);
         }
 
         /// <summary>
@@ -245,25 +241,17 @@ namespace LLama.Native
         /// <returns>The value, null if there is no such value or if the buffer was too small</returns>
         public Memory<byte>? MetadataValueByIndex(int index)
         {
-            int valueLength;
-            unsafe
-            {
-                // Check if the key exists, without getting any bytes of data
-                valueLength = NativeApi.llama_model_meta_val_str_by_index(this, index, (byte*)0, 0);
-                if (valueLength < 0)
-                    return null;
-            }
+            // Check if the key exists, without getting any bytes of data
+            var valueLength = NativeApi.llama_model_meta_val_str_by_index(this, index, Array.Empty<byte>());
+            if (valueLength < 0)
+                return null;
 
             // get a buffer large enough to hold it
             var buffer = new byte[valueLength + 1];
-            unsafe
-            {
-                using var pin = buffer.AsMemory().Pin();
-                valueLength = NativeApi.llama_model_meta_val_str_by_index(this, index, (byte*)pin.Pointer, buffer.Length);
-                Debug.Assert(valueLength >= 0);
+            valueLength = NativeApi.llama_model_meta_val_str_by_index(this, index, buffer);
+            Debug.Assert(valueLength >= 0);
 
-                return buffer.AsMemory().Slice(0, valueLength);
-            }
+            return buffer.AsMemory().Slice(0, valueLength);
         }
 
         internal IReadOnlyDictionary<string, string> ReadMetadata()


### PR DESCRIPTION
 - Wrapped some native functions which take (pointer, length) in function which take a `span` instead.
 - Removed some `unsafe` where it wasn't necessary