### PR TITLE
Fixed prepare_release script

### DIFF
--- a/.github/prepare_release.sh
+++ b/.github/prepare_release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 is_minor="$1"    # type is "minor" or "patch"
 is_patch="$2"    # type is "minor" or "patch"

--- a/.github/prepare_release.sh
+++ b/.github/prepare_release.sh
@@ -44,7 +44,8 @@ if [[ $type == "minor" ]]; then
         updated_version="${version%%.*}.$b.0"
         echo "Updated version: $updated_version"
     else
-        echo "Invalid version format" exit 1
+        echo "Invalid version format"
+        exit 1
     fi
 elif [[ $type == "patch" ]]; then
     regex="([0-9]+)$"

--- a/.github/prepare_release.sh
+++ b/.github/prepare_release.sh
@@ -22,8 +22,7 @@ fi
 
 mkdir ./temp;
 mkdir ./temp/runtimes;
-# For sure it could be done better but cp -R did not work on osx
-cp  ./LLama/runtimes/*.* ./temp/runtimes/;
+cp ./LLama/runtimes ./temp/runtimes -R;
 cp ./LLama/runtimes/build/*.* ./temp/;
 
 # get the current version

--- a/.github/workflows/release-minor.yml
+++ b/.github/workflows/release-minor.yml
@@ -49,5 +49,5 @@ jobs:
         name: "drop-ci-packages"
         path: './temp'
 
-    - name: Push LLamaSharp packages to nuget.org
-      run: dotnet nuget push ./temp/LLamaSharp*.nupkg --source https://www.nuget.org -k ${{ secrets.LLAMA_SHARP_NUGET_KEY }} --skip-duplicate
+#    - name: Push LLamaSharp packages to nuget.org
+#      run: dotnet nuget push ./temp/LLamaSharp*.nupkg --source https://www.nuget.org -k ${{ secrets.LLAMA_SHARP_NUGET_KEY }} --skip-duplicate

--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -49,5 +49,5 @@ jobs:
         name: "drop-ci-packages"
         path: './temp'
 
-    - name: Push LLamaSharp packages to nuget.org
-      run: dotnet nuget push ./temp/LLamaSharp*.nupkg --source https://www.nuget.org -k ${{ secrets.LLAMA_SHARP_NUGET_KEY }} --skip-duplicate
+#    - name: Push LLamaSharp packages to nuget.org
+#      run: dotnet nuget push ./temp/LLamaSharp*.nupkg --source https://www.nuget.org -k ${{ secrets.LLAMA_SHARP_NUGET_KEY }} --skip-duplicate


### PR DESCRIPTION
Fixed prepare_release.sh script so it can properly copy all of the binary deps. Also added -e flag so the script fails fast, instead of concealing errors.

This error caused the `nuget pack` command to fail for all of the backend packages, resulting in half a release (0.9.0).