### PR TITLE
Model Metadata Loading Cleanup

### DIFF
--- a/LLama/Native/NativeApi.cs
+++ b/LLama/Native/NativeApi.cs
@@ -406,7 +406,7 @@ namespace LLama.Native
         /// <param name="model">Model to fetch from</param>
         /// <param name="index">Index of key to fetch</param>
         /// <param name="dest">buffer to write result into</param>
-        /// <returns>The length of the string on success, or -1 on failure</returns>
+        /// <returns>The length of the string on success (even if the buffer is too small). -1 is the key does not exist.</returns>
         public static int llama_model_meta_key_by_index(SafeLlamaModelHandle model, int index, Span<byte> dest)
         {
             unsafe
@@ -427,7 +427,7 @@ namespace LLama.Native
         /// <param name="model">Model to fetch from</param>
         /// <param name="index">Index of val to fetch</param>
         /// <param name="dest">Buffer to write result into</param>
-        /// <returns>The length of the string on success, or -1 on failure</returns>
+        /// <returns>The length of the string on success (even if the buffer is too small). -1 is the key does not exist.</returns>
         public static int llama_model_meta_val_str_by_index(SafeLlamaModelHandle model, int index, Span<byte> dest)
         {
             unsafe

--- a/LLama/Native/SafeLlamaModelHandle.cs
+++ b/LLama/Native/SafeLlamaModelHandle.cs
@@ -230,14 +230,10 @@ namespace LLama.Native
         /// <returns>The key, null if there is no such key or if the buffer was too small</returns>
         public Memory<byte>? MetadataKeyByIndex(int index)
         {
-            int keyLength;
-            unsafe
-            {
-                // Check if the key exists, without getting any bytes of data
-                keyLength = NativeApi.llama_model_meta_key_by_index(this, index, Array.Empty<byte>());
-                if (keyLength < 0)
-                    return null;
-            }
+            // Check if the key exists, without getting any bytes of data
+            var keyLength = NativeApi.llama_model_meta_key_by_index(this, index, Array.Empty<byte>());
+            if (keyLength < 0)
+                return null;
 
             // get a buffer large enough to hold it
             var buffer = new byte[keyLength + 1];


### PR DESCRIPTION
 - Removed unnecessary `unsafe` block in model metadata loading
 - Clarified comments on native metadata loading methods