### PR TITLE
LLamaBatch Automatically Grow Capacity

### DIFF
--- a/LLama.Unittest/BeamTests.cs
+++ b/LLama.Unittest/BeamTests.cs
@@ -40,7 +40,7 @@ public sealed class BeamTests
 
         var initial_tokens = context.Tokenize(prompt);
         result.Append(prompt);
-        context.Eval(initial_tokens, 0);
+        context.Eval(initial_tokens.AsSpan(), 0);
 
         NativeApi.llama_beam_search(context.NativeHandle, (data, state) =>
         {

--- a/LLama.Unittest/StatelessExecutorTest.cs
+++ b/LLama.Unittest/StatelessExecutorTest.cs
@@ -36,7 +36,7 @@ namespace LLama.Unittest
 
             var executor = new StatelessExecutor(_weights, _params);
 
-            const string question = "Question. what is a cat?\nAnswer: ";
+            const string question = "Question. what is a cat?\nAnswer:";
             var @params = new InferenceParams { MaxTokens = 32, AntiPrompts = new[] { "." }, SamplingPipeline = pipeline };
 
             var timer = new Stopwatch();

--- a/LLama/LLamaEmbedder.cs
+++ b/LLama/LLamaEmbedder.cs
@@ -75,7 +75,7 @@ namespace LLama
             // TODO(Rinne): deal with log of prompt
 
             if (embed_inp_array.Length > 0)
-                Context.Eval(embed_inp_array, 0);
+                Context.Eval(embed_inp_array.AsSpan(), 0);
 
             var embeddings = NativeApi.llama_get_embeddings(Context.NativeHandle);
             if (embeddings == null)


### PR DESCRIPTION
 - Removed some unused `eval` methods.
 - Added a `DecodeAsync` overload which runs the work in a task
 - Replaced some `NativeHandle` usage in `BatchedDecoding` with higher level equivalents.
 - Made the `LLamaBatch` grow when token capacity is exceeded, removing the need to manage token capacity externally.