### PR TITLE
Fix missing library name prefix for cuda

### DIFF
--- a/LLama/Native/NativeApi.Load.cs
+++ b/LLama/Native/NativeApi.Load.cs
@@ -195,12 +195,12 @@ namespace LLama.Native
                 else if (cudaVersion == 11)
                 {
                     Log($"Detected cuda major version {cudaVersion}.", LogLevel.Information);
-                    result.Add($"{prefix}cuda11/{libraryName}{suffix}");
+                    result.Add($"{prefix}cuda11/{libraryNamePrefix}{libraryName}{suffix}");
                 }
                 else if (cudaVersion == 12)
                 {
                     Log($"Detected cuda major version {cudaVersion}.", LogLevel.Information);
-                    result.Add($"{prefix}cuda12/{libraryName}{suffix}");
+                    result.Add($"{prefix}cuda12/{libraryNamePrefix}{libraryName}{suffix}");
                 }
                 else if (cudaVersion > 0)
                 {


### PR DESCRIPTION
In #465 the native import, and library search path was updated, the native import had the lib prefix removed, and the search path code was updated to prepend `lib` to the name when not running on windows.

However, there was a place in the cuda path generation when not skipping checks that was not using the prefix. This PR Fixes that missing prefix.