### PR TITLE
Removed `SafeLLamaHandleBase` Constructor

### DIFF
--- a/LLama/LLamaContext.cs
+++ b/LLama/LLamaContext.cs
@@ -443,7 +443,7 @@ namespace LLama
             : SafeLLamaHandleBase
         {
             internal State(IntPtr memory)
-                : base(memory)
+                : base(memory, true)
             {
             }
 

--- a/LLama/Native/SafeLLamaGrammarHandle.cs
+++ b/LLama/Native/SafeLLamaGrammarHandle.cs
@@ -21,7 +21,7 @@ namespace LLama.Native
         /// </summary>
         /// <param name="handle"></param>
         internal SafeLLamaGrammarHandle(IntPtr handle)
-            : base(handle)
+            : base(handle, true)
         {
         }
 

--- a/LLama/Native/SafeLLamaHandleBase.cs
+++ b/LLama/Native/SafeLLamaHandleBase.cs
@@ -14,12 +14,6 @@ namespace LLama.Native
         {
         }
 
-        private protected SafeLLamaHandleBase(IntPtr handle)
-            : base(IntPtr.Zero, ownsHandle: true)
-        {
-            SetHandle(handle);
-        }
-
         private protected SafeLLamaHandleBase(IntPtr handle, bool ownsHandle)
             : base(IntPtr.Zero, ownsHandle)
         {
@@ -30,7 +24,6 @@ namespace LLama.Native
         public override bool IsInvalid => handle == IntPtr.Zero;
 
         /// <inheritdoc />
-        public override string ToString()
-            => $"0x{handle:x16}";
+        public override string ToString() => handle.ToString();
     }
 }


### PR DESCRIPTION
 - Removed one of the constructors of `SafeLLamaHandleBase`, which implicitly states that memory is owned. Better to be explicit about this kind of thing!
 - Also fixed `ToString()` in `SafeLLamaHandleBase`

This is a purely internal change, constructor is not accessible outside of LLamaSharp