### PR TITLE
Only allow one build in parallel per ref

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,9 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
I tend to push a lit of commits in a short period of time, in the interest of not burning up GHA quota this PR limits the concurrency per ref (branch/pr/tag) to a single build, and cancels any in progress builds prior to the newest, if there are any. This means, if someone like me pushes lots of commits one by one, we will only ever have one outstanding build, and the other prior builds will be cancelled, protecting the project from burning up GHA minutes.

Without this change, I've held changes in my fork longer than I'd like to, so that I don't hammer this projects GHA quotas, I'd like to get this change in so I can post PRs without fear of impacting the project, and show the progress of what I'm working on via draft PRs.