### PR TITLE
Use NBGV for versioning

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "nbgv": {
+      "version": "3.6.133",
+      "commands": [
+        "nbgv"
+      ]
+    }
+  }
+}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,13 @@ jobs:
             config: release
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Nerdbank.GitVersioning
+      uses: dotnet/nbgv@v0.4.2
+      id: nbgv
+    - name: Output NuGet version
+      run: echo "NuGet version = ${{steps.nbgv.outputs.NuGetPackageVersion}}"
     - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: | 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Condition="!Exists('packages.config')">
+      <PrivateAssets>all</PrivateAssets>
+      <Version>3.6.133</Version>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/version.json
+++ b/version.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "0.9",
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$",
+    "^refs/heads/v\\d+(?:\\.\\d+)?$"
+  ],
+  "cloudBuild": {
+    "buildNumber": {
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
## README FIRST
*This commit is a draft, it requires changes to work, if this is merged without those changes, actions other than CI that attempt to build the project will fail. The fetch depth must be set to 0 for NBGV to work, as it needs the entire commit history to determine the version number. This was not done yet, as it's ultimately up to @martindevans if they would like this done or not*

## PR Details
This is a demo, without touching the prepare scripts, of using NBGV to manage versioning.
The build (Via Directory.Build.props), will pick up the version automagically.
The version is deterministic based on the branch and git commit height. The same commit on the same branch will generate the same version number every time.
The NuGet version for this commit would be: `0.9.3-g744be1adba`
If this commit were on master, as it is currently configured, the version would be (as is: `0.9.3`, with a merge commit `0.9.4`)

The variables generated are trivial to use with nuget pack as well. See the build step for CI that outputs the nuget package version.

Here's a sample of the variables it generates:
```json
{
  "CloudBuildNumber": "0.9.3+744be1adba",
  "CloudBuildNumberEnabled": true,
  "BuildMetadataWithCommitId": [
    "744be1adba"
  ],
  "VersionFileFound": true,
  "VersionOptions": {
    "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
    "Version": {
      "Version": "0.9",
      "Prerelease": "",
      "BuildMetadata": "",
      "VersionHeightPosition": 2
    },
    "PublicReleaseRefSpec": [
      "^refs/heads/master$",
      "^refs/heads/v\\d+(?:\\.\\d+)?$"
    ],
    "CloudBuild": {
      "SetAllVariables": null,
      "SetVersionVariables": null,
      "BuildNumber": {
        "Enabled": true,
        "IncludeCommitId": null
      }
    }
  },
  "AssemblyVersion": "0.9.0.0",
  "AssemblyFileVersion": "0.9.3.29771",
  "AssemblyInformationalVersion": "0.9.3+744be1adba",
  "PublicRelease": false,
  "PrereleaseVersion": "",
  "PrereleaseVersionNoLeadingHyphen": "",
  "SimpleVersion": "0.9.3",
  "BuildNumber": 3,
  "VersionRevision": 29771,
  "MajorMinorVersion": "0.9",
  "VersionMajor": 0,
  "VersionMinor": 9,
  "GitCommitId": "744be1adbac16aed8c30e7a1874e81bfef04e2cb",
  "GitCommitIdShort": "744be1adba",
  "GitCommitDate": "2024-02-05T[11](https://github.com/jasoncouture/LLamaSharp/actions/runs/7783786751/job/21222966784#step:3:12):32:38+00:00",
  "VersionHeight": 3,
  "VersionHeightOffset": 0,
  "BuildingRef": "744be1adbac[16](https://github.com/jasoncouture/LLamaSharp/actions/runs/7783786751/job/21222966784#step:3:17)aed8c30e7a[18](https://github.com/jasoncouture/LLamaSharp/actions/runs/7783786751/job/21222966784#step:3:19)74e81bfef04e2cb",
  "Version": "0.9.3.29771",
  "CloudBuildAllVarsEnabled": false,
  "CloudBuildAllVars": {
    "NBGV_CloudBuildNumber": "0.9.3+744be1adba",
    "NBGV_VersionFileFound": "True",
    "NBGV_AssemblyVersion": "0.9.0.0",
    "NBGV_AssemblyFileVersion": "0.9.3.29771",
    "NBGV_AssemblyInformationalVersion": "0.9.3+744be1adba",
    "NBGV_PublicRelease": "False",
    "NBGV_PrereleaseVersion": "",
    "NBGV_PrereleaseVersionNoLeadingHyphen": "",
    "NBGV_SimpleVersion": "0.9.3",
    "NBGV_BuildNumber": "3",
    "NBGV_VersionRevision": "29771",
    "NBGV_MajorMinorVersion": "0.9",
    "NBGV_VersionMajor": "0",
    "NBGV_VersionMinor": "9",
    "NBGV_GitCommitId": "744be1adbac16aed8c30e7a1874e81bfef04e2cb",
    "NBGV_GitCommitIdShort": "744be1adba",
    "NBGV_GitCommitDate": "[20](https://github.com/jasoncouture/LLamaSharp/actions/runs/7783786751/job/21222966784#step:3:21)[24](https://github.com/jasoncouture/LLamaSharp/actions/runs/7783786751/job/21222966784#step:3:25)-02-05T11:32:38.0000000+00:00",
    "NBGV_VersionHeight": "3",
    "NBGV_VersionHeightOffset": "0",
    "NBGV_BuildingRef": "744be1adbac16aed8c30e7a1874e81bfef04e2cb",
    "NBGV_Version": "0.9.3.[29](https://github.com/jasoncouture/LLamaSharp/actions/runs/7783786751/job/21222966784#step:3:30)771",
    "NBGV_BuildMetadataFragment": "+7[44](https://github.com/jasoncouture/LLamaSharp/actions/runs/7783786751/job/21222966784#step:3:45)be1adba",
    "NBGV_NuGetPackageVersion": "0.9.3-g744be1adba",
    "NBGV_ChocolateyPackageVersion": "0.9.3-g744be1adba",
    "NBGV_NpmPackageVersion": "0.9.3-g744be1adba",
    "NBGV_SemVer1": "0.9.3-744be1adba",
    "NBGV_SemVer2": "0.9.3-g744be1adba",
    "NBGV_SemVer1NumericIdentifierPadding": "4"
  },
  "CloudBuildVersionVarsEnabled": true,
  "CloudBuildVersionVars": {
    "GitAssemblyInformationalVersion": "0.9.3+744be1adba",
    "GitBuildVersion": "0.9.3.297[71](https://github.com/jasoncouture/LLamaSharp/actions/runs/7783786751/job/21222966784#step:3:72)",
    "GitBuildVersionSimple": "0.9.3"
  },
  "BuildMetadata": [],
  "BuildMetadataFragment": "+[74](https://github.com/jasoncouture/LLamaSharp/actions/runs/7783786751/job/21222966784#step:3:75)4be1adba",
  "NuGetPackageVersion": "0.9.3-g744be1adba",
  "ChocolateyPackageVersion": "0.9.3-g744be1adba",
  "NpmPackageVersion": "0.9.3-g744be1adba",
  "SemVer1": "0.9.3-744be1adba",
  "SemVer2": "0.9.3-g744be1adba",
  "SemVer1NumericIdentifierPadding": 4
}
```