### PR TITLE
Smaller Unit Test Model

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
     name: Test
     runs-on: ${{ matrix.os }}
     strategy:
+      max-parallel: 2
       fail-fast: false
       matrix:
         build: [linux-release, windows-release, osx-release]

--- a/LLama.Unittest/BasicTest.cs
+++ b/LLama.Unittest/BasicTest.cs
@@ -45,7 +45,7 @@ namespace LLama.Unittest
                 { "general.name", "LLaMA v2" },
                 { "general.architecture", "llama" },
                 { "general.quantization_version", "2" },
-                { "general.file_type", "2" },
+                { "general.file_type", "11" },
 
                 { "llama.context_length", "4096" },
                 { "llama.rope.dimension_count", "128" },

--- a/LLama.Unittest/Constants.cs
+++ b/LLama.Unittest/Constants.cs
@@ -2,6 +2,6 @@
 {
     internal static class Constants
     {
-        public static string ModelPath = "Models/llama-2-7b-chat.Q4_0.gguf";
+        public static string ModelPath = "Models/llama-2-7b-chat.Q3_K_S.gguf";
     }
 }

--- a/LLama.Unittest/LLama.Unittest.csproj
+++ b/LLama.Unittest/LLama.Unittest.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <Target Name="DownloadContentFiles" BeforeTargets="Build">
-      <DownloadFile SourceUrl="https://huggingface.co/TheBloke/Llama-2-7b-Chat-GGUF/resolve/main/llama-2-7b-chat.Q4_0.gguf" DestinationFolder="Models" DestinationFileName="llama-2-7b-chat.Q4_0.gguf" SkipUnchangedFiles="true">
+      <DownloadFile SourceUrl="https://huggingface.co/TheBloke/Llama-2-7b-Chat-GGUF/resolve/main/llama-2-7b-chat.Q3_K_S.gguf" DestinationFolder="Models" DestinationFileName="llama-2-7b-chat.Q3_K_S.gguf" SkipUnchangedFiles="true">
     </DownloadFile>
   </Target>
 
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="Models\llama-2-7b-chat.Q4_0.gguf">
+    <None Update="Models\llama-2-7b-chat.Q3_K_S.gguf">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
Switched to `Q3_K_S` for unit test model, instead of `Q4`. This is almost 1gb smaller and _may_ make the macos tests less flakey.