### PR TITLE
Rework how native libraries are loaded

### DIFF
--- a/LLama/LLamaSharp.Runtime.targets
+++ b/LLama/LLamaSharp.Runtime.targets
@@ -28,6 +28,14 @@
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <Link>runtimes/win-x64/native/cuda12/llama.dll</Link>
       </None>
+      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/clblast/llama.dll">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Link>runtimes/win-x64/native/clblast/llama.dll</Link>
+      </None>
+      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/clblast/clblast.dll">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Link>runtimes/win-x64/native/clblast/clblast.dll</Link>
+      </None>
 
       <None Include="$(MSBuildThisFileDirectory)runtimes/deps/libllama.so">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -52,6 +60,10 @@
       <None Include="$(MSBuildThisFileDirectory)runtimes/deps/cu12.1.0/libllama.so">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <Link>runtimes/linux-x64/native/cuda12/libllama.so</Link>
+      </None>
+      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/clblast/libllama.so">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Link>runtimes/win-x64/native/clblast/libllama.so</Link>
       </None>
 
       <None Include="$(MSBuildThisFileDirectory)runtimes/deps/osx-arm64/libllama.dylib">

--- a/LLama/Native/Initializer.cs
+++ b/LLama/Native/Initializer.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace LLama.Native;
+#if NET6_0_OR_GREATER
+[SuppressMessage("Usage", "CA2255:The \'ModuleInitializer\' attribute should not be used in libraries",
+    Justification = "Intended to allow hooking native library resolution")]
+internal static class LlamaModuleInitializer
+{
+    private static string? _selectedPath = null;
+    private static string? _platformExtension;
+    private static ConcurrentDictionary<string, IntPtr> _libraryHandles = new();
+    public static string? CurrentPath => _selectedPath;
+    public static List<string> SearchPaths { get; } = new List<string>();
+
+    // Hook up import resolver whenever this library is loaded.
+    // The import resolver is specific to this assembly, so it has no impact on the application loading it.
+    [ModuleInitializer]
+    internal static void InitializeLibrary()
+    {
+        NativeLibrary.SetDllImportResolver(typeof(LlamaModuleInitializer).Assembly, ImportResolver);
+    }
+
+    private static IntPtr ImportResolver(string libraryName, Assembly assembly, DllImportSearchPath? searchpath)
+    {
+        if (SearchPaths.Count == 0)
+            return IntPtr.Zero;
+        // We'll be adding this back after, need to strip it off so we don't end up with liblib
+        if (libraryName.StartsWith("lib"))
+            libraryName = libraryName[3..];
+        // don't want the extension either.
+        if (libraryName.EndsWith(PlatformExtension))
+            libraryName = libraryName[..^PlatformExtension.Length];
+        return _libraryHandles.GetOrAdd(libraryName, TryLocateLibrary);
+    }
+
+    private static IntPtr TryLocateLibrary(string libraryName)
+    {
+        foreach (var path in EnumerateSearchPaths().Select(Path.GetFullPath))
+        {
+            if (!Directory.Exists(path))
+                continue;
+
+            foreach (var fileName in EnumerateFileNamePermutations(libraryName))
+            {
+                var targetFile = Path.Combine(path, fileName);
+                if (!File.Exists(targetFile))
+                    continue;
+                if (!NativeLibrary.TryLoad(targetFile, out var handle) || handle == IntPtr.Zero)
+                    continue;
+                // Set selected path, if it was null. Do it in a thread safe way though
+                Interlocked.CompareExchange(ref _selectedPath, path, null);
+                return handle;
+            }
+        }
+
+        // This will trigger the next/default import resolver to take over.
+        return IntPtr.Zero;
+    }
+
+    /// <summary>
+    /// Unloads native libraries loaded by this class, and removes the learned path.
+    /// The libraries must not be in use, or bad things will happen.
+    /// </summary>
+    public static void Reset()
+    {
+        Interlocked.Exchange(ref _selectedPath, null);
+
+        var handles = _libraryHandles.ToArray();
+
+        foreach (var handle in handles)
+        {
+            NativeLibrary.Free(handle.Value);
+            _libraryHandles.TryRemove(handle.Key, out _);
+        }
+    }
+
+    private static IEnumerable<string> EnumerateSearchPaths()
+    {
+        if (_selectedPath is not null)
+        {
+            // Always prefer the first location we found
+            yield return _selectedPath;
+        }
+
+        foreach (var path in SearchPaths)
+            yield return path;
+    }
+
+    // The reason for this, is we don't want the static initializer to fail during the module initializer hook in.
+    // That may be very difficult to debug. Doing it this way causes this to run on first use, instead of first type access.
+    private static string PlatformExtension => _platformExtension ??=
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? ".dll"
+            : RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                ? ".so"
+                : ".dylib";
+
+    private static IEnumerable<string> EnumerateFileNamePermutations(string libraryName)
+    {
+        // By convention, libxxxx comes first on non-windows, and second on windows.
+        var names = new[]
+        {
+            $"{libraryName}{PlatformExtension}",
+            $"lib{libraryName}{PlatformExtension}"
+        };
+
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            Array.Reverse(names);
+
+        return names;
+    }
+}
+
+#endif

--- a/LLama/Native/NativeLibraryConfig.cs
+++ b/LLama/Native/NativeLibraryConfig.cs
@@ -43,12 +43,12 @@ namespace LLama.Native
         }
 
         /// <summary>
-        /// Load a specified native library as backend for LLamaSharp.
-        /// When this method is called, all the other configurations will be ignored.
+        /// Load a llama from a specified path. This must be a directory containing (lib?)llama.(so|dll|dylib) and
+        /// any associated dependencies
         /// </summary>
         /// <param name="libraryPath"></param>
         /// <exception cref="InvalidOperationException">Thrown if `LibraryHasLoaded` is true.</exception>
-        public NativeLibraryConfig WithLibrary(string libraryPath)
+        public NativeLibraryConfig WithLibraryPath(string libraryPath)
         {
             ThrowIfLoaded();
 
@@ -185,11 +185,10 @@ namespace LLama.Native
         {
             return level switch
             {
+                > AvxLevel.Avx512 => throw new ArgumentOutOfRangeException(nameof(level),
+                    $"Unknown AvxLevel: '{level}'"),
                 AvxLevel.None => string.Empty,
-                AvxLevel.Avx => "avx",
-                AvxLevel.Avx2 => "avx2",
-                AvxLevel.Avx512 => "avx512",
-                _ => throw new ArgumentException($"Unknown AvxLevel '{level}'")
+                _ => level.ToString("G").ToLower()
             };
         }
 

--- a/LLama/Native/NativeLibraryConfig.cs
+++ b/LLama/Native/NativeLibraryConfig.cs
@@ -24,6 +24,7 @@ namespace LLama.Native
         public static bool LibraryHasLoaded { get; internal set; } = false;
 
         private string _libraryPath = string.Empty;
+        private bool _useOpenCL = true;
         private bool _useCuda = true;
         private AvxLevel _avxLevel;
         private bool _allowFallback = true;
@@ -52,6 +53,12 @@ namespace LLama.Native
             ThrowIfLoaded();
 
             _libraryPath = libraryPath;
+            return this;
+        }
+
+        public NativeLibraryConfig WithOpenCL(bool enable = true)
+        {
+            _useOpenCL = enable;
             return this;
         }
 
@@ -165,6 +172,7 @@ namespace LLama.Native
             return new Description(
                 Instance._libraryPath, 
                 Instance._useCuda, 
+                Instance._useOpenCL,
                 Instance._avxLevel, 
                 Instance._allowFallback, 
                 Instance._skipCheck, 
@@ -250,7 +258,7 @@ namespace LLama.Native
             Avx512,
         }
 
-        internal record Description(string Path, bool UseCuda, AvxLevel AvxLevel, bool AllowFallback, bool SkipCheck, bool Logging, string[] SearchDirectories)
+        internal record Description(string Path, bool UseCuda, bool UseOpenCL, AvxLevel AvxLevel, bool AllowFallback, bool SkipCheck, bool Logging, string[] SearchDirectories)
         {
             public override string ToString()
             {
@@ -268,6 +276,7 @@ namespace LLama.Native
                 return $"NativeLibraryConfig Description:\n" +
                        $"- Path: {Path}\n" +
                        $"- PreferCuda: {UseCuda}\n" +
+                       $"- PreferOpenCL: {UseOpenCL}\n" +
                        $"- PreferredAvxLevel: {avxLevelString}\n" +
                        $"- AllowFallback: {AllowFallback}\n" +
                        $"- SkipCheck: {SkipCheck}\n" +


### PR DESCRIPTION
The way we currently load libraries doesn't handle the case where we load a library, but it doesn't initialize due to a lazy loaded dependnecy, or some other issue.

This PR reworks that to use SetDllImportResolver instead. Which we then use to dynamically unload libraries that don't initialize properly. This makes startup much more resilient.

One breaking change:
`WithLibrary` was intentionally renamed to `WithLibraryPath`, since originally it took a file name, and must now take a path instead.

I also added some missing CLBlast stuff