### PR TITLE
ChatSession: improve exception message

### DIFF
--- a/LLama/ChatSession.cs
+++ b/LLama/ChatSession.cs
@@ -196,7 +196,7 @@ public class ChatSession
             if (lastMessage is null
                 || lastMessage.AuthorRole != AuthorRole.User)
             {
-                throw new ArgumentException("Assistant message must be preceeded with a user message", nameof(message));
+                throw new ArgumentException("Assistant message must be preceded with a user message", nameof(message));
             }
         }
 


### PR DESCRIPTION
This is a small fix, but I noticed that the original exception message contained the word "preceeded" which should be spelled as "preceded"