### PR TITLE
Improve "embeddings" example

### DIFF
--- a/LLama.Examples/Examples/GetEmbeddings.cs
+++ b/LLama.Examples/Examples/GetEmbeddings.cs
@@ -9,18 +9,34 @@ namespace LLama.Examples.Examples
             Console.Write("Please input your model path: ");
             var modelPath = Console.ReadLine();
 
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.WriteLine(
+                """
+                This example displays embeddings from a text prompt.
+                Embeddings are numerical codes that represent information like words, images, or concepts.
+                These codes capture important relationships between those objects, 
+                like how similar words are in meaning or how close images are visually.
+                This allows machine learning models to efficiently understand and process complex data.
+                Embeddings of a text in LLM is sometimes useful, for example, to train other MLP models.
+                """); // NOTE: this description was AI generated
+
             var @params = new ModelParams(modelPath) { EmbeddingMode = true };
+
             using var weights = LLamaWeights.LoadFromFile(@params);
             var embedder = new LLamaEmbedder(weights, @params);
 
             while (true)
             {
+                Console.ForegroundColor = ConsoleColor.White;
                 Console.Write("Please input your text: ");
                 Console.ForegroundColor = ConsoleColor.Green;
                 var text = Console.ReadLine();
                 Console.ForegroundColor = ConsoleColor.White;
 
-                Console.WriteLine(string.Join(", ", embedder.GetEmbeddings(text)));
+                float[] embeddings = embedder.GetEmbeddings(text).Result;
+                Console.WriteLine($"Embeddings contain {embeddings.Length:N0} floating point values:");
+                Console.ForegroundColor = ConsoleColor.DarkGray;
+                Console.WriteLine(string.Join(", ", embeddings.Take(20)) + ", ...");
                 Console.WriteLine();
             }
         }

--- a/LLama.Examples/Examples/GetEmbeddings.cs
+++ b/LLama.Examples/Examples/GetEmbeddings.cs
@@ -6,8 +6,14 @@ namespace LLama.Examples.Examples
     {
         public static void Run()
         {
+            Console.ForegroundColor = ConsoleColor.White;
             Console.Write("Please input your model path: ");
             var modelPath = Console.ReadLine();
+
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            var @params = new ModelParams(modelPath) { EmbeddingMode = true };
+            using var weights = LLamaWeights.LoadFromFile(@params);
+            var embedder = new LLamaEmbedder(weights, @params);
 
             Console.ForegroundColor = ConsoleColor.Yellow;
             Console.WriteLine(
@@ -19,11 +25,6 @@ namespace LLama.Examples.Examples
                 This allows machine learning models to efficiently understand and process complex data.
                 Embeddings of a text in LLM is sometimes useful, for example, to train other MLP models.
                 """); // NOTE: this description was AI generated
-
-            var @params = new ModelParams(modelPath) { EmbeddingMode = true };
-
-            using var weights = LLamaWeights.LoadFromFile(@params);
-            var embedder = new LLamaEmbedder(weights, @params);
 
             while (true)
             {

--- a/LLama.Examples/Examples/GetEmbeddings.cs
+++ b/LLama.Examples/Examples/GetEmbeddings.cs
@@ -9,7 +9,7 @@ namespace LLama.Examples.Examples
             Console.Write("Please input your model path: ");
             var modelPath = Console.ReadLine();
 
-            var @params = new ModelParams(modelPath);
+            var @params = new ModelParams(modelPath) { EmbeddingMode = true };
             using var weights = LLamaWeights.LoadFromFile(@params);
             var embedder = new LLamaEmbedder(weights, @params);
 

--- a/docs/Examples/GetEmbeddings.md
+++ b/docs/Examples/GetEmbeddings.md
@@ -14,7 +14,8 @@ public class GetEmbeddings
     {
         Console.Write("Please input your model path: ");
         string modelPath = Console.ReadLine();
-        var embedder = new LLamaEmbedder(new ModelParams(modelPath)) { EmbeddingMode = true };
+        var modelParams = new ModelParams(modelPath) { EmbeddingMode = true };
+        var embedder = new LLamaEmbedder(modelParams);
 
         while (true)
         {

--- a/docs/Examples/GetEmbeddings.md
+++ b/docs/Examples/GetEmbeddings.md
@@ -14,7 +14,7 @@ public class GetEmbeddings
     {
         Console.Write("Please input your model path: ");
         string modelPath = Console.ReadLine();
-        var embedder = new LLamaEmbedder(new ModelParams(modelPath));
+        var embedder = new LLamaEmbedder(new ModelParams(modelPath)) { EmbeddingMode = true };
 
         while (true)
         {


### PR DESCRIPTION
Previously the embeddings example throws an exception because `EmbeddingMode` was not set to `true`.

This PR fixes that and adds extra documentation to the embeddings example.

![image](https://github.com/SciSharp/LLamaSharp/assets/4165489/c177cc67-f307-42b4-90e2-16630a03f16b)