### PR TITLE
NativeLibraryConfig.WithLogs() overload to set log level

### DIFF
--- a/LLama.Examples/Program.cs
+++ b/LLama.Examples/Program.cs
@@ -10,7 +10,7 @@ Console.WriteLine("=============================================================
 NativeLibraryConfig
    .Instance
    .WithCuda()
-   .WithLogs();
+   .WithLogs(LLamaLogLevel.Warning);
 
 NativeApi.llama_empty_call();
 Console.WriteLine();

--- a/LLama/Native/NativeApi.Load.cs
+++ b/LLama/Native/NativeApi.Load.cs
@@ -35,8 +35,12 @@ namespace LLama.Native
 
         private static void Log(string message, LogLevel level)
         {
-            if (!enableLogging) return;
-            Debug.Assert(level is LogLevel.Information or LogLevel.Error or LogLevel.Warning);
+            if (!enableLogging)
+                return;
+
+            if ((int)level < (int)logLevel)
+                return;
+
             ConsoleColor color;
             string levelPrefix;
             if (level == LogLevel.Information)
@@ -221,7 +225,7 @@ namespace LLama.Native
 
                 if (configuration.AvxLevel >= NativeLibraryConfig.AvxLevel.Avx2)
                     result.Add(GetAvxLibraryPath(NativeLibraryConfig.AvxLevel.Avx2, prefix, suffix, libraryNamePrefix));
-                
+
                 if (configuration.AvxLevel >= NativeLibraryConfig.AvxLevel.Avx)
                     result.Add(GetAvxLibraryPath(NativeLibraryConfig.AvxLevel.Avx, prefix, suffix, libraryNamePrefix));
 
@@ -246,6 +250,7 @@ namespace LLama.Native
 #if NET6_0_OR_GREATER
             var configuration = NativeLibraryConfig.CheckAndGatherDescription();
             enableLogging = configuration.Logging;
+            logLevel = configuration.LogLevel;
             // We move the flag to avoid loading library when the variable is called else where.
             NativeLibraryConfig.LibraryHasLoaded = true;
             Log(configuration.ToString(), LogLevel.Information);
@@ -336,5 +341,6 @@ namespace LLama.Native
         private const string cudaVersionFile = "version.json";
         private const string loggingPrefix = "[LLamaSharp Native]";
         private static bool enableLogging = false;
+        private static LLamaLogLevel logLevel = LLamaLogLevel.Info;
     }
 }

--- a/LLama/Native/NativeLibraryConfig.cs
+++ b/LLama/Native/NativeLibraryConfig.cs
@@ -29,6 +29,7 @@ namespace LLama.Native
         private bool _allowFallback = true;
         private bool _skipCheck = false;
         private bool _logging = false;
+        private LLamaLogLevel _logLevel = LLamaLogLevel.Info;
 
         /// <summary>
         /// search directory -> priority level, 0 is the lowest.
@@ -119,11 +120,26 @@ namespace LLama.Native
         /// <param name="enable"></param>
         /// <returns></returns>
         /// <exception cref="InvalidOperationException">Thrown if `LibraryHasLoaded` is true.</exception>
-        public NativeLibraryConfig WithLogs(bool enable = true)
+        public NativeLibraryConfig WithLogs(bool enable)
         {
             ThrowIfLoaded();
 
             _logging = enable;
+            return this;
+        }
+
+        /// <summary>
+        /// Enable console logging with the specified log logLevel.
+        /// </summary>
+        /// <param name="logLevel"></param>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException">Thrown if `LibraryHasLoaded` is true.</exception>
+        public NativeLibraryConfig WithLogs(LLamaLogLevel logLevel = LLamaLogLevel.Info)
+        {
+            ThrowIfLoaded();
+
+            _logging = true;
+            _logLevel = logLevel;
             return this;
         }
 
@@ -161,14 +177,15 @@ namespace LLama.Native
         {
             if (Instance._allowFallback && Instance._skipCheck)
                 throw new ArgumentException("Cannot skip the check when fallback is allowed.");
-            
+
             return new Description(
-                Instance._libraryPath, 
-                Instance._useCuda, 
-                Instance._avxLevel, 
-                Instance._allowFallback, 
-                Instance._skipCheck, 
-                Instance._logging, 
+                Instance._libraryPath,
+                Instance._useCuda,
+                Instance._avxLevel,
+                Instance._allowFallback,
+                Instance._skipCheck,
+                Instance._logging,
+                Instance._logLevel,
                 Instance._searchDirectories.Concat(new[] { "./" }).ToArray()
             );
         }
@@ -250,7 +267,7 @@ namespace LLama.Native
             Avx512,
         }
 
-        internal record Description(string Path, bool UseCuda, AvxLevel AvxLevel, bool AllowFallback, bool SkipCheck, bool Logging, string[] SearchDirectories)
+        internal record Description(string Path, bool UseCuda, AvxLevel AvxLevel, bool AllowFallback, bool SkipCheck, bool Logging, LLamaLogLevel LogLevel, string[] SearchDirectories)
         {
             public override string ToString()
             {
@@ -263,7 +280,7 @@ namespace LLama.Native
                     _ => "Unknown"
                 };
 
-                string searchDirectoriesString = "{ " +  string.Join(", ", SearchDirectories) + " }";
+                string searchDirectoriesString = "{ " + string.Join(", ", SearchDirectories) + " }";
 
                 return $"NativeLibraryConfig Description:\n" +
                        $"- Path: {Path}\n" +
@@ -272,9 +289,10 @@ namespace LLama.Native
                        $"- AllowFallback: {AllowFallback}\n" +
                        $"- SkipCheck: {SkipCheck}\n" +
                        $"- Logging: {Logging}\n" +
+                       $"- LogLevel: {LogLevel}\n" +
                        $"- SearchDirectories and Priorities: {searchDirectoriesString}";
             }
         }
     }
 #endif
-        }
+}


### PR DESCRIPTION
Adds a NativeLibraryConfig.WithLogs() overload to let the user indicate the log level (with "info" as the default)