### PR TITLE
`ReadOnlySpan<float>` in ISamplingPipeline

### DIFF
--- a/LLama.Examples/Examples/BatchedExecutorFork.cs
+++ b/LLama.Examples/Examples/BatchedExecutorFork.cs
@@ -91,8 +91,7 @@ public class BatchedExecutorFork
 
             // Sample one token
             var ctx = _conversation.Executor.Context.NativeHandle;
-            var logitsCopy = _conversation.Sample().ToArray();
-            var token = _sampler.Sample(ctx, logitsCopy, Array.Empty<LLamaToken>());
+            var token = _sampler.Sample(ctx, _conversation.Sample(), Array.Empty<LLamaToken>());
             _sampler.Accept(ctx, token);
             _decoder.Add(token);
 

--- a/LLama.Examples/Examples/BatchedExecutorRewind.cs
+++ b/LLama.Examples/Examples/BatchedExecutorRewind.cs
@@ -88,7 +88,7 @@ public class BatchedExecutorRewind
 
         public LLamaToken Sample(Conversation conversation)
         {
-            var token = Sampler.Sample(_context.NativeHandle, conversation.Sample().ToArray(), Array.Empty<LLamaToken>());
+            var token = Sampler.Sample(_context.NativeHandle, conversation.Sample(), Array.Empty<LLamaToken>());
             _tokens.Add(token);
             return token;
         }
@@ -100,14 +100,12 @@ public class BatchedExecutorRewind
             for (var i = 0; i < _tokens.Count - n_rewind; i++)
                 decoder.Add(_tokens[i]);
 
-            Console.ForegroundColor = ConsoleColor.Green;
-            Console.Write(new string(' ', depth * 3) + decoder.Read().ReplaceLineEndings(" "));
+            AnsiConsole.MarkupLine($"[green]{new string(' ', depth * 3) + decoder.Read().ReplaceLineEndings(" ")}[/]");
 
             for (var i = _tokens.Count - n_rewind; i < _tokens.Count; i++)
                 decoder.Add(_tokens[i]);
 
-            Console.ForegroundColor = ConsoleColor.DarkRed;
-            Console.WriteLine(decoder.Read().ReplaceLineEndings(" "));
+            AnsiConsole.MarkupLine($"[maroon]{decoder.Read().ReplaceLineEndings(" ")}[/]");
         }
 
         public LLamaToken GetToken(int index)

--- a/LLama/LLamaContext.cs
+++ b/LLama/LLamaContext.cs
@@ -147,8 +147,9 @@ namespace LLama
         }
 
         /// <summary>
-        /// Get the state data as an opaque handle
+        /// Get the state data as an opaque handle, which can be loaded later using <see cref="LoadState(State)"/>
         /// </summary>
+        /// <remarks>Use <see cref="SaveState"/> if you intend to save this state to disk.</remarks>
         /// <returns></returns>
         public State GetState()
         {

--- a/LLama/Sampling/BaseSamplingPipeline.cs
+++ b/LLama/Sampling/BaseSamplingPipeline.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Buffers;
-using System.Collections.Generic;
 using LLama.Native;
 
 namespace LLama.Sampling;
@@ -11,103 +9,28 @@ namespace LLama.Sampling;
 public abstract class BaseSamplingPipeline
     : ISamplingPipeline
 {
-    private int _savedLogitsCount;
-    private (LLamaToken index, float logit)[]? _savedLogits;
-
-    private float[]? _logits;
+    /// <summary>
+    /// Grammar to constrain valid tokens
+    /// </summary>
+    public SafeLLamaGrammarHandle? Grammar { get; set; }
 
     /// <inheritdoc/>
-    public LLamaToken Sample(SafeLLamaContextHandle ctx, ReadOnlySpan<float> logitsIn, ReadOnlySpan<LLamaToken> lastTokens)
+    public LLamaToken Sample(SafeLLamaContextHandle ctx, ReadOnlySpan<float> logits, ReadOnlySpan<LLamaToken> lastTokens)
     {
-        var protectedLogits = GetProtectedTokens(ctx);
-        _savedLogitsCount = protectedLogits.Count;
-        _savedLogits = ArrayPool<(LLamaToken, float)>.Shared.Rent(_savedLogitsCount);
-        try
-        {
-            // Save the values of protected logits
-            for (var i = 0; i < protectedLogits.Count; i++)
-            {
-                var index = protectedLogits[i];
-                var value = logitsIn[(int)index];
-                _savedLogits[i] = (index, value);
-            }
+        // Apply processing to raw logit values
+        logits = ProcessLogits(ctx, logits, lastTokens);
 
-            if (ShouldProcessLogits)
-            {
-                // Logit input is a readonly span, copy to an array so it can be modified
-                if (_logits == null || _logits.Length < logitsIn.Length)
-                {
-                    _logits = new float[logitsIn.Length];
-                    logitsIn.CopyTo(_logits);
-                }
-
-                // Process raw logits
-                ProcessLogits(ctx, _logits, lastTokens);
-
-                // Automatically restore saved logit values after processing
-                RestoreProtectedTokens(_logits);
-
-                // Process token data array to select a final token
-                return ProcessTokenDataArray(ctx, LLamaTokenDataArray.Create(_logits), lastTokens);
-            }
-            else
-            {
-                // We skipped modifying logits, so process the input logits directly
-                return ProcessTokenDataArray(ctx, LLamaTokenDataArray.Create(logitsIn), lastTokens);
-            }
-        }
-        finally
-        {
-            ArrayPool<(LLamaToken, float)>.Shared.Return(_savedLogits);
-            _savedLogits = null;
-            _savedLogitsCount = 0;
-        }
+        // Process token data array to select a final token
+        var candidates = LLamaTokenDataArray.Create(logits);
+        candidates.ApplyGrammar(ctx, Grammar);
+        return ProcessTokenDataArray(ctx, candidates, lastTokens);
     }
 
     /// <inheritdoc />
-    public abstract void Accept(SafeLLamaContextHandle ctx, LLamaToken token);
-
-    #region protected tokens
-    /// <summary>
-    /// Get all of the "protected" tokens that cannot be changed by ProcessLogits
-    /// </summary>
-    /// <returns></returns>
-    protected abstract IReadOnlyList<LLamaToken> GetProtectedTokens(SafeLLamaContextHandle ctx);
-
-    /// <summary>
-    /// Restore the value of the "protected" tokens which were saved before the call to ProcessLogits
-    /// </summary>
-    /// <param name="logits"></param>
-    protected void RestoreProtectedTokens(Span<float> logits)
+    public virtual void Accept(SafeLLamaContextHandle ctx, LLamaToken token)
     {
-        if (_savedLogits == null)
-            return;
-
-        // The array may be bigger than necessary, get a span of the valid bit
-        var saved = _savedLogits.AsSpan(0, _savedLogitsCount);
-
-        // Restore the values of protected logits
-        for (var i = 0; i < saved.Length; i++)
-            logits[(int)saved[i].index] = saved[i].logit;
+        Grammar?.AcceptToken(ctx, token);
     }
-
-    /// <summary>
-    /// Restore the value of the "protected" tokens which were saved before the call to ProcessLogits
-    /// </summary>
-    /// <param name="candidates"></param>
-    protected void RestoreProtectedTokens(LLamaTokenDataArray candidates)
-    {
-        if (_savedLogits == null || _savedLogits.Length == 0)
-            return;
-
-        candidates.OverwriteLogits(_savedLogits.AsSpan(0, _savedLogitsCount));
-    }
-    #endregion
-
-    /// <summary>
-    /// If `false` then <see cref="ProcessLogits"/> will <b>not</b> be called.
-    /// </summary>
-    protected abstract bool ShouldProcessLogits { get; }
 
     /// <summary>
     /// Process the raw logit values
@@ -115,7 +38,7 @@ public abstract class BaseSamplingPipeline
     /// <param name="ctx">The context being sampled from</param>
     /// <param name="logits">The logits produced by the model</param>
     /// <param name="lastTokens">A list of tokens recently returned by the model</param>
-    protected abstract void ProcessLogits(SafeLLamaContextHandle ctx, Span<float> logits, ReadOnlySpan<LLamaToken> lastTokens);
+    protected abstract ReadOnlySpan<float> ProcessLogits(SafeLLamaContextHandle ctx, ReadOnlySpan<float> logits, ReadOnlySpan<LLamaToken> lastTokens);
 
     /// <summary>
     /// Process the LLamaTokenDataArray and select a single token

--- a/LLama/Sampling/DefaultSamplingPipeline.cs
+++ b/LLama/Sampling/DefaultSamplingPipeline.cs
@@ -146,6 +146,7 @@ public sealed class DefaultSamplingPipeline
         return id;
     }
 
+    /// <inheritdoc />
     public override void Accept(SafeLLamaContextHandle ctx, LLamaToken token)
     {
         Grammar?.AcceptToken(ctx, token);

--- a/LLama/Sampling/DefaultSamplingPipeline.cs
+++ b/LLama/Sampling/DefaultSamplingPipeline.cs
@@ -99,6 +99,11 @@ public sealed class DefaultSamplingPipeline
     /// </summary>
     public bool PenalizeNewline { get; set; } = false;
 
+    /// <summary>
+    /// Default sampling pipeline only applies logit bias in logit processing. Skip logit processing if possible.
+    /// </summary>
+    protected override bool ShouldProcessLogits => LogitBias.Count > 0;
+
     private readonly LLamaToken[] _newlineToken = new LLamaToken[1];
 
     /// <inheritdoc />

--- a/LLama/Sampling/GreedySamplingPipeline.cs
+++ b/LLama/Sampling/GreedySamplingPipeline.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using LLama.Native;
+
+namespace LLama.Sampling;
+
+/// <summary>
+/// A sampling pipeline which always selects the most likely token
+/// </summary>
+public class GreedySamplingPipeline
+    : BaseSamplingPipeline
+{
+    /// <inheritdoc />
+    protected override ReadOnlySpan<float> ProcessLogits(SafeLLamaContextHandle ctx, ReadOnlySpan<float> logits, ReadOnlySpan<LLamaToken> lastTokens)
+    {
+        return logits;
+    }
+
+    /// <inheritdoc />
+    protected override LLamaToken ProcessTokenDataArray(SafeLLamaContextHandle ctx, LLamaTokenDataArray candidates, ReadOnlySpan<LLamaToken> lastTokens)
+    {
+        return candidates.SampleTokenGreedy(ctx);
+    }
+
+    /// <inheritdoc />
+    public override ISamplingPipeline Clone()
+    {
+        return new GreedySamplingPipeline
+        {
+            Grammar = Grammar?.Clone()
+        };
+    }
+}

--- a/LLama/Sampling/ISamplingPipeline.cs
+++ b/LLama/Sampling/ISamplingPipeline.cs
@@ -19,7 +19,7 @@ public interface ISamplingPipeline
     /// <param name="logits">The logits produced by the model</param>
     /// <param name="lastTokens">A span of tokens recently returned by the model</param>
     /// <returns></returns>
-    LLamaToken Sample(SafeLLamaContextHandle ctx, Span<float> logits, ReadOnlySpan<LLamaToken> lastTokens);
+    LLamaToken Sample(SafeLLamaContextHandle ctx, ReadOnlySpan<float> logits, ReadOnlySpan<LLamaToken> lastTokens);
 
     /// <summary>
     /// Update the pipeline, with knowledge that a particular token was just accepted
@@ -53,7 +53,7 @@ public static class ISamplingPipelineExtensions
     /// <param name="logits">The logits produced by the model</param>
     /// <param name="lastTokens">A list of tokens recently returned by the model</param>
     /// <returns></returns>
-    public static LLamaToken Sample(this ISamplingPipeline pipeline, SafeLLamaContextHandle ctx, Span<float> logits, List<LLamaToken> lastTokens)
+    public static LLamaToken Sample(this ISamplingPipeline pipeline, SafeLLamaContextHandle ctx, ReadOnlySpan<float> logits, List<LLamaToken> lastTokens)
     {
 #if NET5_0_OR_GREATER
         var span = CollectionsMarshal.AsSpan(lastTokens);

--- a/LLama/Sampling/Mirostat2SamplingPipeline.cs
+++ b/LLama/Sampling/Mirostat2SamplingPipeline.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using LLama.Native;
+
+namespace LLama.Sampling;
+
+/// <summary>
+/// A sampling pipeline which uses mirostat (v2) to select tokens
+/// </summary>
+public class Mirostate2SamplingPipeline
+    : BaseSamplingPipeline
+{
+    private const float DEFAULT_TAU = 5;
+
+    private float _mu = DEFAULT_TAU * 2;
+    /// <summary>
+    /// Currently learned mu value
+    /// </summary>
+    public float Mu => _mu;
+
+    private float _tau = DEFAULT_TAU;
+    /// <summary>
+    /// target entropy
+    /// </summary>
+    public float Tau
+    {
+        get => _tau;
+        set
+        {
+            _tau = value;
+            _mu = value * 2;
+        }
+    }
+
+    /// <summary>
+    /// learning rate
+    /// </summary>
+    public float Eta { get; set; } = 0.1f;
+
+    /// <inheritdoc />
+    protected override ReadOnlySpan<float> ProcessLogits(SafeLLamaContextHandle ctx, ReadOnlySpan<float> logits, ReadOnlySpan<LLamaToken> lastTokens)
+    {
+        return logits;
+    }
+
+    /// <inheritdoc />
+    protected override LLamaToken ProcessTokenDataArray(SafeLLamaContextHandle ctx, LLamaTokenDataArray candidates, ReadOnlySpan<LLamaToken> lastTokens)
+    {
+        return candidates.SampleTokenMirostat2(ctx, Tau, Eta, ref _mu);
+    }
+
+    /// <inheritdoc />
+    public override void Reset()
+    {
+        base.Reset();
+
+        _mu = Tau * 2;
+    }
+
+    /// <inheritdoc />
+    public override ISamplingPipeline Clone()
+    {
+        return new Mirostate2SamplingPipeline
+        {
+            Grammar = Grammar?.Clone(),
+
+            _mu = _mu,
+            _tau = _tau,
+            Eta = Eta
+        };
+    }
+}

--- a/LLama/Sampling/MirostatSamplingPipeline.cs
+++ b/LLama/Sampling/MirostatSamplingPipeline.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using LLama.Native;
+
+namespace LLama.Sampling;
+
+/// <summary>
+/// A sampling pipeline which uses mirostat (v1) to select tokens
+/// </summary>
+public class MirostateSamplingPipeline
+    : BaseSamplingPipeline
+{
+    private const int MIROSTAT_M = 100;
+    private const float DEFAULT_TAU = 5;
+
+    private float _mu = DEFAULT_TAU * 2;
+    /// <summary>
+    /// Currently learned mu value
+    /// </summary>
+    public float Mu => _mu;
+
+    private float _tau = DEFAULT_TAU;
+    /// <summary>
+    /// target entropy
+    /// </summary>
+    public float Tau
+    {
+        get => _tau;
+        set
+        {
+            _tau = value;
+            _mu = value * 2;
+        }
+    }
+
+    /// <summary>
+    /// learning rate
+    /// </summary>
+    public float Eta { get; set; } = 0.1f;
+
+    /// <inheritdoc />
+    protected override ReadOnlySpan<float> ProcessLogits(SafeLLamaContextHandle ctx, ReadOnlySpan<float> logits, ReadOnlySpan<LLamaToken> lastTokens)
+    {
+        return logits;
+    }
+
+    /// <inheritdoc />
+    protected override LLamaToken ProcessTokenDataArray(SafeLLamaContextHandle ctx, LLamaTokenDataArray candidates, ReadOnlySpan<LLamaToken> lastTokens)
+    {
+        return candidates.SampleTokenMirostat(ctx, Tau, Eta, MIROSTAT_M, ref _mu);
+    }
+
+    /// <inheritdoc />
+    public override void Reset()
+    {
+        base.Reset();
+
+        _mu = Tau * 2;
+    }
+
+    /// <inheritdoc />
+    public override ISamplingPipeline Clone()
+    {
+        return new MirostateSamplingPipeline
+        {
+            Grammar = Grammar?.Clone(),
+
+            _mu = _mu,
+            _tau = _tau,
+            Eta = Eta
+        };
+    }
+}


### PR DESCRIPTION
 - Modified ISamplingPipeline to accept `ReadOnlySpan<float>` of logits directly. This moves responsibility to copy the logits into the pipeline.
 - Removed concept of "protected tokens" from base pipeline, since it was introducing a lot of incidental comlpexity and was only used in one place (the default pipeline)
 - Moved Grammar sampling to `BaseSamplingPipeline`
 - Implemented several new pipelines (greedy, mirostat1, mirostat2)