### PR TITLE
Disposing/Releasing GPU memory

### DIFF
--- a/LLama/Native/SafeLlamaModelHandle.cs
+++ b/LLama/Native/SafeLlamaModelHandle.cs
@@ -75,6 +75,13 @@ namespace LLama.Native
         public int MetadataCount => llama_model_meta_count(this);
 
         /// <inheritdoc />
+        public new void Dispose()
+        {
+            ReleaseHandle();
+            base.Dispose();
+        }
+
+        /// <inheritdoc />
         protected override bool ReleaseHandle()
         {
             llama_free_model(handle);


### PR DESCRIPTION
The memory was not disposed when Dispose() was called because ReleaseHandle(); was not called by the base class.