### PR TITLE
Removed `llama_eval()`

### DIFF
--- a/LLama.Unittest/BeamTests.cs
+++ b/LLama.Unittest/BeamTests.cs
@@ -40,7 +40,8 @@ public sealed class BeamTests
 
         var initial_tokens = context.Tokenize(prompt);
         result.Append(prompt);
-        context.Eval(initial_tokens.AsSpan(), 0);
+        //context.Eval(initial_tokens.AsSpan(), 0);
+        throw new NotImplementedException("Replace Eval");
 
         NativeApi.llama_beam_search(context.NativeHandle, (data, state) =>
         {

--- a/LLama/LLamaInstructExecutor.cs
+++ b/LLama/LLamaInstructExecutor.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using LLama.Exceptions;
 using LLama.Extensions;
 using Microsoft.Extensions.Logging;
 
@@ -178,6 +179,8 @@ namespace LLama
         /// <inheritdoc />
         protected override Task InferInternal(IInferenceParams inferenceParams, InferStateArgs args)
         {
+            var batch = new LLamaBatch();
+
             if (_embeds.Count > 0)
             {
                 _is_prompt_run = false;
@@ -187,7 +190,10 @@ namespace LLama
                 }
 
                 TryReuseMathingPrefix();
-                _pastTokensCount = Context.Eval(_embeds, _pastTokensCount);
+
+                var (result, _) = Context.NativeHandle.Decode(_embeds, LLamaSeqId.Zero, batch, ref _pastTokensCount);
+                if (result != DecodeResult.Ok)
+                    throw new LLamaDecodeError(result);
 
                 if (_embeds.Count > 0 && !string.IsNullOrEmpty(_pathSession))
                 {
@@ -212,12 +218,12 @@ namespace LLama
                 LLamaToken id;
                 if (inferenceParams.SamplingPipeline is not null)
                 {
-                    id = inferenceParams.SamplingPipeline.Sample(Context.NativeHandle, Context.NativeHandle.GetLogits(), _last_n_tokens.ToArray());
+                    id = inferenceParams.SamplingPipeline.Sample(Context.NativeHandle, Context.NativeHandle.GetLogitsIth(batch.TokenCount - 1), _last_n_tokens.ToArray());
                     inferenceParams.SamplingPipeline.Accept(Context.NativeHandle, id);
                 }
                 else
                 {
-                    var tokenDataArray = Context.ApplyPenalty(0, _last_n_tokens, inferenceParams.LogitBias, repeat_last_n,
+                    var tokenDataArray = Context.ApplyPenalty(batch.TokenCount - 1, _last_n_tokens, inferenceParams.LogitBias, repeat_last_n,
                         inferenceParams.RepeatPenalty, inferenceParams.FrequencyPenalty, inferenceParams.PresencePenalty, inferenceParams.PenalizeNL);
 
                     var mu = MirostatMu;

--- a/LLama/Native/NativeApi.cs
+++ b/LLama/Native/NativeApi.cs
@@ -141,20 +141,6 @@ namespace LLama.Native
         [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern bool llama_save_session_file(SafeLLamaContextHandle ctx, string path_session, LLamaToken[] tokens, ulong n_token_count);
 
-        /// <summary>
-        /// Run the llama inference to obtain the logits and probabilities for the next token.
-        /// tokens + n_tokens is the provided batch of new tokens to process
-        /// n_past is the number of tokens to use from previous eval calls
-        /// </summary>
-        /// <param name="ctx"></param>
-        /// <param name="tokens"></param>
-        /// <param name="n_tokens"></param>
-        /// <param name="n_past"></param>
-        /// <returns>Returns 0 on success</returns>
-        [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
-        [Obsolete("use llama_decode() instead")]
-        public static extern unsafe int llama_eval(SafeLLamaContextHandle ctx, LLamaToken* tokens, int n_tokens, int n_past);
-
         [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern unsafe byte* llama_token_get_text(SafeLlamaModelHandle model, LLamaToken token);
 
@@ -181,7 +167,7 @@ namespace LLama.Native
         public static extern uint llama_n_batch(SafeLLamaContextHandle ctx);
 
         /// <summary>
-        /// Token logits obtained from the last call to llama_eval()
+        /// Token logits obtained from the last call to llama_decode
         /// The logits for the last token are stored in the last row
         /// Can be mutated in order to change the probabilities of the next token.<br />
         /// Rows: n_tokens<br />


### PR DESCRIPTION
Removed `llama_eval`, it is going to be completely removed in the next version of llama.cpp.

Replaced with llama_decode.