### PR TITLE
Chat session state management

### DIFF
--- a/LLama.Examples/ExampleRunner.cs
+++ b/LLama.Examples/ExampleRunner.cs
@@ -8,6 +8,7 @@ public class ExampleRunner
         { "Chat Session: History", ChatSessionWithHistory.Run },
         { "Chat Session: Role names", ChatSessionWithRoleName.Run },
         { "Chat Session: Role names stripped", ChatSessionStripRoleName.Run },
+        { "Chat Session: Pre-processing and reset", ChatSessionWithRestart.Run },
         { "Chat Session: Coding Assistant", CodingAssistant.Run },
         { "Chat Session: Automatic conversation", TalkToYourself.Run },
         { "Chat Session: Chinese characters", ChatChineseGB2312.Run },

--- a/LLama.Examples/Examples/ChatSessionWithHistory.cs
+++ b/LLama.Examples/Examples/ChatSessionWithHistory.cs
@@ -48,6 +48,10 @@ public class ChatSessionWithHistory
 
         Console.ForegroundColor = ConsoleColor.Yellow;
         Console.WriteLine("The chat session has started.");
+        Console.WriteLine("Type 'exit' to end the chat session.");
+        Console.WriteLine("Type 'save' to save the chat session to disk.");
+        Console.WriteLine("Type 'load' to load the chat session from disk.");
+        Console.WriteLine("Type 'regenerate' to regenerate the last response.");
 
         // show the prompt
         Console.ForegroundColor = ConsoleColor.Green;
@@ -55,12 +59,14 @@ public class ChatSessionWithHistory
 
         while (userInput != "exit")
         {
+            // Save the chat state to disk
             if (userInput == "save")
             {
                 session.SaveSession("Assets/chat-with-bob");
                 Console.ForegroundColor = ConsoleColor.Yellow;
                 Console.WriteLine("Session saved.");
             }
+            // Load the chat state from disk
             else if (userInput == "load")
             {
                 session.LoadSession("Assets/chat-with-bob");

--- a/LLama.Examples/Examples/ChatSessionWithHistory.cs
+++ b/LLama.Examples/Examples/ChatSessionWithHistory.cs
@@ -61,6 +61,12 @@ public class ChatSessionWithHistory
                 Console.ForegroundColor = ConsoleColor.Yellow;
                 Console.WriteLine("Session saved.");
             }
+            else if (userInput == "load")
+            {
+                session.LoadSession("Assets/chat-with-bob");
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                Console.WriteLine("Session loaded.");
+            }
             else if (userInput == "regenerate")
             {
                 Console.ForegroundColor = ConsoleColor.Yellow;

--- a/LLama.Examples/Examples/ChatSessionWithRestart.cs
+++ b/LLama.Examples/Examples/ChatSessionWithRestart.cs
@@ -1,0 +1,94 @@
+using LLama.Common;
+
+namespace LLama.Examples.Examples;
+
+public class ChatSessionWithRestart
+{
+    public static async Task Run()
+    {
+        string modelPath = UserSettings.GetModelPath();
+
+        var parameters = new ModelParams(modelPath)
+        {
+            ContextSize = 1024,
+            Seed = 1337,
+            GpuLayerCount = 5
+        };
+        using var model = LLamaWeights.LoadFromFile(parameters);
+        using var context = model.CreateContext(parameters);
+        var executor = new InteractiveExecutor(context);
+
+        var chatHistoryJson = File.ReadAllText("Assets/chat-with-bob.json");
+        ChatHistory chatHistory = ChatHistory.FromJson(chatHistoryJson) ?? new ChatHistory();
+        ChatSession prototypeSession = 
+            await ChatSession.InitializeSessionFromHistoryAsync(executor, chatHistory);
+        prototypeSession.WithOutputTransform(new LLamaTransforms.KeywordTextOutputStreamTransform(
+            new string[] { "User:", "Assistant:" },
+            redundancyLength: 8));
+        var resetState = prototypeSession.GetSessionState();
+
+        ChatSession session = new ChatSession(executor);
+        session.LoadSession(resetState);
+
+        InferenceParams inferenceParams = new InferenceParams()
+        {
+            Temperature = 0.9f,
+            AntiPrompts = new List<string> { "User:" }
+        };
+
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        Console.WriteLine("The chat session has started.");
+
+        // show the prompt
+        Console.ForegroundColor = ConsoleColor.Green;
+        string userInput = Console.ReadLine() ?? "";
+
+        while (userInput != "exit")
+        {
+            if(userInput == "reset")
+            {
+                session.LoadSession(resetState);
+                Console.WriteLine($"History: {session.HistoryTransform.HistoryToText(session.History)}");
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                Console.WriteLine("Session reset.");
+            }
+            else if (userInput == "save")
+            {
+                session.SaveSession("Assets/chat-with-bob");
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                Console.WriteLine("Session saved.");
+            }
+            else if (userInput == "regenerate")
+            {
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                Console.WriteLine("Regenerating last response ...");
+
+                await foreach (
+                    var text
+                    in session.RegenerateAssistantMessageAsync(
+                        inferenceParams))
+                {
+                    Console.ForegroundColor = ConsoleColor.White;
+                    Console.Write(text);
+                }
+            }
+            else
+            {
+                await foreach (
+                    var text
+                    in session.ChatAsync(
+                        new ChatHistory.Message(AuthorRole.User, userInput),
+                        inferenceParams))
+                {
+                    Console.ForegroundColor = ConsoleColor.White;
+                    Console.Write(text);
+                }
+            }
+
+            Console.ForegroundColor = ConsoleColor.Green;
+            userInput = Console.ReadLine() ?? "";
+
+            Console.ForegroundColor = ConsoleColor.White;
+        }
+    }
+}

--- a/LLama.Examples/Examples/ChatSessionWithRestart.cs
+++ b/LLama.Examples/Examples/ChatSessionWithRestart.cs
@@ -37,7 +37,8 @@ public class ChatSessionWithRestart
         };
 
         Console.ForegroundColor = ConsoleColor.Yellow;
-        Console.WriteLine("The chat session has started.");
+        Console.WriteLine("The chat session has started. Write `save` to save session in memory."
+            + " Write `reset` to start from the last saved checkpoint");
 
         // show the prompt
         Console.ForegroundColor = ConsoleColor.Green;
@@ -48,13 +49,13 @@ public class ChatSessionWithRestart
             if(userInput == "reset")
             {
                 session.LoadSession(resetState);
-                Console.WriteLine($"History: {session.HistoryTransform.HistoryToText(session.History)}");
+                Console.WriteLine($"Reset to history:\n{session.HistoryTransform.HistoryToText(session.History)}");
                 Console.ForegroundColor = ConsoleColor.Yellow;
                 Console.WriteLine("Session reset.");
             }
             else if (userInput == "save")
             {
-                session.SaveSession("Assets/chat-with-bob");
+                resetState = session.GetSessionState();
                 Console.ForegroundColor = ConsoleColor.Yellow;
                 Console.WriteLine("Session saved.");
             }

--- a/LLama.Examples/Examples/ChatSessionWithRestart.cs
+++ b/LLama.Examples/Examples/ChatSessionWithRestart.cs
@@ -37,8 +37,11 @@ public class ChatSessionWithRestart
         };
 
         Console.ForegroundColor = ConsoleColor.Yellow;
-        Console.WriteLine("The chat session has started. Write `save` to save session in memory."
-            + " Write `reset` to start from the last saved checkpoint");
+        Console.WriteLine("The chat session has started. Starting point saved.");
+        Console.WriteLine("Type 'exit' to end the chat session.");
+        Console.WriteLine("Type 'save' to save chat session state in memory.");
+        Console.WriteLine("Type 'reset' to reset the chat session to its saved state.");
+        Console.WriteLine("Type 'answer for assistant' to add and process provided user and assistant messages.");
 
         // show the prompt
         Console.ForegroundColor = ConsoleColor.Green;
@@ -46,6 +49,7 @@ public class ChatSessionWithRestart
 
         while (userInput != "exit")
         {
+            // Load the session state from the reset state
             if(userInput == "reset")
             {
                 session.LoadSession(resetState);
@@ -53,25 +57,33 @@ public class ChatSessionWithRestart
                 Console.ForegroundColor = ConsoleColor.Yellow;
                 Console.WriteLine("Session reset.");
             }
+            // Assign new reset state.
             else if (userInput == "save")
             {
                 resetState = session.GetSessionState();
                 Console.ForegroundColor = ConsoleColor.Yellow;
                 Console.WriteLine("Session saved.");
             }
-            else if (userInput == "regenerate")
+            // Provide user and override assistant answer with your own.
+            else if (userInput == "answer for assistant")
             {
                 Console.ForegroundColor = ConsoleColor.Yellow;
-                Console.WriteLine("Regenerating last response ...");
+                Console.WriteLine("Provide user input: ");
 
-                await foreach (
-                    var text
-                    in session.RegenerateAssistantMessageAsync(
-                        inferenceParams))
-                {
-                    Console.ForegroundColor = ConsoleColor.White;
-                    Console.Write(text);
-                }
+                Console.ForegroundColor = ConsoleColor.Green;
+                string userInputOverride = Console.ReadLine() ?? "";
+
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                Console.WriteLine("Provide assistant input: ");
+                
+                Console.ForegroundColor = ConsoleColor.Green;
+                string assistantInputOverride = Console.ReadLine() ?? "";
+                
+                await session.AddAndProcessUserMessage(userInputOverride);
+                await session.AddAndProcessAssistantMessage(assistantInputOverride);
+
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                Console.WriteLine("User and assistant messages processed. Provide next user message:");
             }
             else
             {

--- a/LLama/Abstractions/IHistoryTransform.cs
+++ b/LLama/Abstractions/IHistoryTransform.cs
@@ -1,10 +1,12 @@
 ﻿using LLama.Common;
+using System.Text.Json.Serialization;
 
 namespace LLama.Abstractions
 {
     /// <summary>
     /// Transform history to plain text and vice versa.
     /// </summary>
+    [JsonConverter(typeof(PolymorphicJSONConverter<IHistoryTransform>))]
     public interface IHistoryTransform
     {
         /// <summary>

--- a/LLama/Abstractions/IHistoryTransform.cs
+++ b/LLama/Abstractions/IHistoryTransform.cs
@@ -21,5 +21,11 @@ namespace LLama.Abstractions
         /// <param name="text">The chat history as plain text.</param>
         /// <returns>The updated history.</returns>
         ChatHistory TextToHistory(AuthorRole role, string text);
+
+        /// <summary>
+        /// Copy the transform.
+        /// </summary>
+        /// <returns></returns>
+        IHistoryTransform Clone();
     }
 }

--- a/LLama/Abstractions/ITextStreamTransform.cs
+++ b/LLama/Abstractions/ITextStreamTransform.cs
@@ -13,5 +13,11 @@ namespace LLama.Abstractions
         /// <param name="tokens"></param>
         /// <returns></returns>
         IAsyncEnumerable<string> TransformAsync(IAsyncEnumerable<string> tokens);
+
+        /// <summary>
+        /// Copy the transform.
+        /// </summary>
+        /// <returns></returns>
+        ITextStreamTransform Clone();
     }
 }

--- a/LLama/Abstractions/ITextStreamTransform.cs
+++ b/LLama/Abstractions/ITextStreamTransform.cs
@@ -1,10 +1,13 @@
-﻿using System.Collections.Generic;
+﻿using LLama.Common;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace LLama.Abstractions
 {
     /// <summary>
     /// Takes a stream of tokens and transforms them.
     /// </summary>
+    [JsonConverter(typeof(PolymorphicJSONConverter<ITextStreamTransform>))]
     public interface ITextStreamTransform
     {
         /// <summary>

--- a/LLama/Abstractions/ITextTransform.cs
+++ b/LLama/Abstractions/ITextTransform.cs
@@ -1,4 +1,7 @@
-﻿namespace LLama.Abstractions
+﻿using System.Text.Json.Serialization;
+using LLama.Common;
+
+namespace LLama.Abstractions
 {
     /// <summary>
     /// An interface for text transformations.
@@ -9,6 +12,7 @@
     /// - Trimming
     /// - etc.
     /// </summary>
+    [JsonConverter(typeof(PolymorphicJSONConverter<ITextTransform>))]
     public interface ITextTransform
     {
         /// <summary>

--- a/LLama/Abstractions/ITextTransform.cs
+++ b/LLama/Abstractions/ITextTransform.cs
@@ -17,5 +17,11 @@
         /// <param name="text"></param>
         /// <returns></returns>
         string Transform(string text);
+
+        /// <summary>
+        /// Copy the transform.
+        /// </summary>
+        /// <returns></returns>
+        ITextTransform Clone();
     }
 }

--- a/LLama/ChatSession.cs
+++ b/LLama/ChatSession.cs
@@ -214,7 +214,7 @@ public class ChatSession
     {
         var state = SessionState.Load(path);
         // Handle non-polymorphic serialization of executor state
-        if (state.ExecutorState is ExecutorBaseState)
+        if (state.ExecutorState is null)
         {
             var executorPath = Path.Combine(path, EXECUTOR_STATE_FILENAME);
             ((StatefulExecutorBase) Executor).LoadState(filename: executorPath); 
@@ -588,7 +588,7 @@ public record SessionState
     /// <summary>
     /// Saved executor state for the session in JSON format.
     /// </summary>
-    public ExecutorBaseState ExecutorState { get; set; }
+    public ExecutorBaseState? ExecutorState { get; set; }
 
     /// <summary>
     /// Saved context state (KV cache) for the session.
@@ -702,8 +702,7 @@ public record SessionState
             : null;
 
         string executorStateFilepath = Path.Combine(path, ChatSession.EXECUTOR_STATE_FILENAME);
-        var executorState = JsonSerializer.Deserialize<ExecutorBaseState>(File.ReadAllText(executorStateFilepath))
-            ?? throw new ArgumentException("Executor state file is invalid", nameof(path));
+        var executorState = JsonSerializer.Deserialize<ExecutorBaseState>(File.ReadAllText(executorStateFilepath));
 
         string historyFilepath = Path.Combine(path, ChatSession.HISTORY_STATE_FILENAME);
         string historyJson = File.ReadAllText(historyFilepath);

--- a/LLama/ChatSession.cs
+++ b/LLama/ChatSession.cs
@@ -189,9 +189,9 @@ public class ChatSession
         }
         Executor.Context.LoadState(state.ContextState);
         History = new ChatHistory(state.History);
-        InputTransformPipeline = state.InputTransformPipeline.ToList();
-        OutputTransform = state.OutputTransform;
-        HistoryTransform = state.HistoryTransform;
+        InputTransformPipeline = state.InputTransformPipeline.Select(t => t.Clone()).ToList();
+        OutputTransform = state.OutputTransform.Clone();
+        HistoryTransform = state.HistoryTransform.Clone();
     }
 
     /// <summary>
@@ -634,8 +634,8 @@ public record SessionState
         ContextState = contextState;
         ExecutorState = executorState;
         History = history.Messages.ToArray();
-        InputTransformPipeline = inputTransformPipeline.ToArray();
-        OutputTransform = outputTransform;
-        HistoryTransform = historyTransform;
+        InputTransformPipeline = inputTransformPipeline.Select(t => t.Clone()).ToArray();
+        OutputTransform = outputTransform.Clone();
+        HistoryTransform = historyTransform.Clone();
     }
 }

--- a/LLama/ChatSession.cs
+++ b/LLama/ChatSession.cs
@@ -178,17 +178,17 @@ public class ChatSession
     /// Load a session from a session state.
     /// </summary>
     /// <param name="state"></param>
+    /// <param name="loadTransforms">If true loads transforms saved in the session state.</param>
     /// <returns></returns>
     /// <exception cref="ArgumentException"></exception>
-    public void LoadSession(SessionState state)
+    public void LoadSession(SessionState state, bool loadTransforms = true)
     {
         if (Executor is StatefulExecutorBase statefulExecutor)
         {
-            statefulExecutor.LoadState(state.ExecutorState);
-        }
-        else
-        {
-            throw new ArgumentException("Executor must be a StatefulExecutorBase to support loading of session state", nameof(state));
+            if (state.ExecutorState is not null)
+            {
+                statefulExecutor.LoadState(state.ExecutorState);
+            }
         }
         if (state.ContextState is null)
         {
@@ -199,18 +199,22 @@ public class ChatSession
             Executor.Context.LoadState(state.ContextState);
         }
         History = new ChatHistory(state.History);
-        InputTransformPipeline = state.InputTransformPipeline.Select(t => t.Clone()).ToList();
-        OutputTransform = state.OutputTransform.Clone();
-        HistoryTransform = state.HistoryTransform.Clone();
+        if (loadTransforms)
+        {
+            InputTransformPipeline = state.InputTransformPipeline.Select(t => t.Clone()).ToList();
+            OutputTransform = state.OutputTransform.Clone();
+            HistoryTransform = state.HistoryTransform.Clone();
+        }
     }
 
     /// <summary>
     /// Load a session from a directory.
     /// </summary>
     /// <param name="path"></param>
+    /// <param name="loadTransforms">If true loads transforms saved in the session state.</param>
     /// <returns></returns>
     /// <exception cref="ArgumentException"></exception>
-    public void LoadSession(string path)
+    public void LoadSession(string path, bool loadTransforms = true)
     {
         var state = SessionState.Load(path);
         // Handle non-polymorphic serialization of executor state
@@ -219,7 +223,7 @@ public class ChatSession
             var executorPath = Path.Combine(path, EXECUTOR_STATE_FILENAME);
             ((StatefulExecutorBase) Executor).LoadState(filename: executorPath); 
         }
-        LoadSession(state);
+        LoadSession(state, loadTransforms);
     }
 
     /// <summary>

--- a/LLama/Common/ChatHistory.cs
+++ b/LLama/Common/ChatHistory.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -79,6 +80,15 @@ namespace LLama.Common
         /// </summary>
         [JsonConstructor]
         public ChatHistory() { }
+
+        /// <summary>
+        /// Create a new instance of the chat history from array of messages
+        /// </summary>
+        /// <param name="messageHistory"></param>
+        public ChatHistory(Message[] messageHistory)
+        {
+            this.Messages = messageHistory.ToList();
+        }
 
         /// <summary>
         /// Add a message to the chat history

--- a/LLama/Common/PolymorphicJSONConverter.cs
+++ b/LLama/Common/PolymorphicJSONConverter.cs
@@ -1,0 +1,57 @@
+﻿using LLama.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace LLama.Common
+{
+    internal class PolymorphicJSONConverter<T> : JsonConverter<T>
+    {
+        public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+                throw new JsonException();
+            reader.Read();
+            if (reader.TokenType != JsonTokenType.PropertyName)
+                throw new JsonException();
+            string? propertyName = reader.GetString();
+            if (propertyName != "Name")
+                throw new JsonException();
+            reader.Read();
+            if (reader.TokenType != JsonTokenType.String)
+                throw new JsonException();
+            string? name = reader.GetString() ?? throw new JsonException();
+            var inheritedTypes = Assembly.GetExecutingAssembly().GetTypes().Where(
+                t => typeof(T).IsAssignableFrom(t) && !t.IsAbstract && !t.IsInterface
+            );
+            var type = inheritedTypes.FirstOrDefault(t => t.Name == name);
+            if (type == null)
+                throw new JsonException();
+            reader.Read();
+            if (reader.TokenType != JsonTokenType.PropertyName)
+                throw new JsonException();
+            propertyName = reader.GetString();
+            if (propertyName != "Data")
+                throw new JsonException();
+            var data = JsonSerializer.Deserialize(ref reader, type, options);
+            if (data == null)
+                throw new JsonException();
+            reader.Read();
+            reader.Read();
+            return (T)data;
+        }
+
+        public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("Name", value.GetType().Name);
+            writer.WritePropertyName("Data");
+            JsonSerializer.Serialize(writer, value, value.GetType(), options);
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/LLama/Common/PolymorphicJSONConverter.cs
+++ b/LLama/Common/PolymorphicJSONConverter.cs
@@ -20,7 +20,7 @@ namespace LLama.Common
                 throw new JsonException();
             string? propertyName = reader.GetString();
             if (propertyName != "Name")
-                throw new JsonException();
+                return default;
             reader.Read();
             if (reader.TokenType != JsonTokenType.String)
                 throw new JsonException();

--- a/LLama/LLamaContext.cs
+++ b/LLama/LLamaContext.cs
@@ -24,7 +24,6 @@ namespace LLama
         : IDisposable
     {
         private readonly ILogger? _logger;
-        private readonly State _emptyState;
 
         /// <summary>
         /// Total number of tokens in vocabulary of this model
@@ -76,7 +75,6 @@ namespace LLama
 
             @params.ToLlamaContextParams(out var lparams);
             NativeHandle = SafeLLamaContextHandle.Create(model.NativeHandle, lparams);
-            _emptyState = GetState();
         }
 
         /// <summary>
@@ -214,15 +212,6 @@ namespace LLama
             {
                 NativeHandle.SetState((byte*)state.DangerousGetHandle().ToPointer());
             }
-        }
-
-        /// <summary>
-        /// Reset the context to the empty state.
-        /// </summary>
-        /// <exception cref="RuntimeError"></exception>
-        public void ResetState()
-        {
-            NativeApi.llama_kv_cache_clear(NativeHandle);
         }
 
         /// <summary>

--- a/LLama/LLamaContext.cs
+++ b/LLama/LLamaContext.cs
@@ -222,7 +222,7 @@ namespace LLama
         /// <exception cref="RuntimeError"></exception>
         public void ResetState()
         {
-            LoadState(_emptyState);
+            NativeApi.llama_kv_cache_clear(NativeHandle);
         }
 
         /// <summary>

--- a/LLama/LLamaContext.cs
+++ b/LLama/LLamaContext.cs
@@ -24,6 +24,7 @@ namespace LLama
         : IDisposable
     {
         private readonly ILogger? _logger;
+        private readonly State _emptyState;
 
         /// <summary>
         /// Total number of tokens in vocabulary of this model
@@ -75,6 +76,7 @@ namespace LLama
 
             @params.ToLlamaContextParams(out var lparams);
             NativeHandle = SafeLLamaContextHandle.Create(model.NativeHandle, lparams);
+            _emptyState = GetState();
         }
 
         /// <summary>
@@ -212,6 +214,15 @@ namespace LLama
             {
                 NativeHandle.SetState((byte*)state.DangerousGetHandle().ToPointer());
             }
+        }
+
+        /// <summary>
+        /// Reset the context to the empty state.
+        /// </summary>
+        /// <exception cref="RuntimeError"></exception>
+        public void ResetState()
+        {
+            LoadState(_emptyState);
         }
 
         /// <summary>

--- a/LLama/LLamaContext.cs
+++ b/LLama/LLamaContext.cs
@@ -166,7 +166,7 @@ namespace LLama
                 memory = Marshal.ReAllocHGlobal(memory, (nint)actualSize);
 
                 // Wrap memory in a "state"
-                var state = new State(memory);
+                var state = new State(memory, actualSize);
 
                 // Set memory to zero, to prevent it being freed in finally block
                 memory = IntPtr.Zero;
@@ -384,9 +384,12 @@ namespace LLama
         public class State
             : SafeLLamaHandleBase
         {
-            internal State(IntPtr memory)
+            private ulong _size;
+
+            internal State(IntPtr memory, ulong size)
                 : base(memory, true)
             {
+                _size = size;
             }
 
             /// <inheritdoc />
@@ -394,6 +397,29 @@ namespace LLama
             {
                 Marshal.FreeHGlobal(handle);
                 return true;
+            }
+
+            /// <summary>
+            /// Convert this state to a byte array
+            /// </summary>
+            /// <returns></returns>
+            public byte[] ToByteArray()
+            {
+                var bytes = new byte[_size];
+                Marshal.Copy(handle, bytes, 0, (int)_size);
+                return bytes;
+            }
+
+            /// <summary>
+            /// Load state from a byte array
+            /// </summary>
+            /// <param name="bytes"></param>
+            /// <returns></returns>
+            public static State FromByteArray(byte[] bytes)
+            {
+                var memory = Marshal.AllocHGlobal(bytes.Length);
+                Marshal.Copy(bytes, 0, memory, bytes.Length);
+                return new State(memory, (ulong)bytes.Length);
             }
         }
     }

--- a/LLama/LLamaExecutorBase.cs
+++ b/LLama/LLamaExecutorBase.cs
@@ -388,13 +388,13 @@ namespace LLama
             public string? SessionFilePath { get; set; }
 
             [JsonPropertyName("embd")]
-            public List<LLamaToken> Embeds { get; set; }
+            public LLamaToken[] Embeds { get; set; }
 
             [JsonPropertyName("embd_inps")]
-            public List<LLamaToken> EmbedInps { get; set; }
+            public LLamaToken[] EmbedInps { get; set; }
 
             [JsonPropertyName("session_tokens")]
-            public List<LLamaToken> SessionTokens { get; set; }
+            public LLamaToken[] SessionTokens { get; set; }
 
             [JsonPropertyName("last_n_tokens")]
             public LLamaToken[] LastTokens { get; set; }

--- a/LLama/LLamaExecutorBase.cs
+++ b/LLama/LLamaExecutorBase.cs
@@ -317,11 +317,11 @@ namespace LLama
 
         /// <summary>
         /// Asynchronously runs a prompt through the model to compute KV cache without generating any new tokens.
+        /// It could reduce the latency of the first time response if the first input from the user is not immediate.
         /// </summary>
         /// <param name="prompt">Prompt to process</param>
-        /// <param name="cancellationToken">A cancellation token</param>
         /// <returns></returns>
-        public virtual async Task AddPromptAsync(string prompt, CancellationToken cancellationToken = default)
+        public virtual async Task PrefillPromptAsync(string prompt)
         {
             var inferenceParams = new InferenceParams
             {

--- a/LLama/LLamaExecutorBase.cs
+++ b/LLama/LLamaExecutorBase.cs
@@ -250,6 +250,14 @@ namespace LLama
         /// <returns></returns>
         public abstract ExecutorBaseState GetStateData();
 
+        
+        /// <summary>
+        /// Resets the executor to its initial state.
+        /// Note: Does not affect the context and KV cache.
+        /// </summary>
+        /// <returns></returns>
+        public abstract void ResetState();
+
         /// <summary>
         /// Load the state from data.
         /// </summary>

--- a/LLama/LLamaExecutorBase.cs
+++ b/LLama/LLamaExecutorBase.cs
@@ -324,6 +324,34 @@ namespace LLama
         }
 
         /// <summary>
+        /// Asynchronously runs a prompt through the model to compute KV cache without generating any new tokens.
+        /// </summary>
+        /// <param name="prompt">Prompt to process</param>
+        /// <param name="cancellationToken">A cancellation token</param>
+        /// <returns></returns>
+        public virtual async Task AddPromptAsync(string prompt, CancellationToken cancellationToken = default)
+        {
+            var inferenceParams = new InferenceParams
+            {
+                MaxTokens = 0
+            };
+            var args = new InferStateArgs
+            {
+                Antiprompts = new List<string>(),
+                RemainedTokens = 0,
+                ReturnValue = false,
+                WaitForInput = true,
+                NeedToSaveSession = false
+            };
+
+            await PreprocessInputs(prompt, args);
+            // First run adds the prompt to the _embeds
+            await InferInternal(inferenceParams, args);
+            // Second run puts it through decode
+            await InferInternal(inferenceParams, args);
+        }   
+
+        /// <summary>
         /// State arguments that are used in single inference
         /// </summary>
         protected class InferStateArgs

--- a/LLama/LLamaExecutorBase.cs
+++ b/LLama/LLamaExecutorBase.cs
@@ -250,14 +250,6 @@ namespace LLama
         /// <returns></returns>
         public abstract ExecutorBaseState GetStateData();
 
-        
-        /// <summary>
-        /// Resets the executor to its initial state.
-        /// Note: Does not affect the context and KV cache.
-        /// </summary>
-        /// <returns></returns>
-        public abstract void ResetState();
-
         /// <summary>
         /// Load the state from data.
         /// </summary>

--- a/LLama/LLamaExecutorBase.cs
+++ b/LLama/LLamaExecutorBase.cs
@@ -370,6 +370,7 @@ namespace LLama
             public bool NeedToSaveSession { get; set; }
         }
 
+        [JsonConverter(typeof(PolymorphicJSONConverter<ExecutorBaseState>))]
         public class ExecutorBaseState
         {
             [JsonPropertyName("n_past")]

--- a/LLama/LLamaInstructExecutor.cs
+++ b/LLama/LLamaInstructExecutor.cs
@@ -49,17 +49,17 @@ namespace LLama
             InstructExecutorState state = new()
             {
                 ConsumedSessionCount = _n_session_consumed,
-                EmbedInps = _embed_inps,
+                EmbedInps = _embed_inps.ToArray(),
                 IsPromptRun = _is_prompt_run,
                 ConsumedTokensCount = _consumedTokensCount,
-                Embeds = _embeds,
+                Embeds = _embeds.ToArray(),
                 LastTokens = _last_n_tokens.ToArray(),
                 InputPrefixTokens = _inp_pfx,
                 InputSuffixTokens = _inp_sfx,
                 MatchingSessionTokensCount = _n_matching_session_tokens,
                 PastTokensCount = _pastTokensCount,
                 SessionFilePath = _pathSession,
-                SessionTokens = _session_tokens,
+                SessionTokens = _session_tokens.ToArray(),
                 LastTokensCapacity = _last_n_tokens.Capacity,
                 MirostatMu = MirostatMu
             };
@@ -71,17 +71,17 @@ namespace LLama
             if(data is InstructExecutorState state)
             {
                 _n_session_consumed = state.ConsumedSessionCount;
-                _embed_inps = state.EmbedInps;
+                _embed_inps = state.EmbedInps.ToList();
                 _is_prompt_run = state.IsPromptRun;
                 _consumedTokensCount = state.ConsumedTokensCount;
-                _embeds = state.Embeds;
+                _embeds = state.Embeds.ToList();
                 _last_n_tokens = new FixedSizeQueue<LLamaToken>(state.LastTokensCapacity, state.LastTokens);
                 _inp_pfx = state.InputPrefixTokens;
                 _inp_sfx = state.InputSuffixTokens;
                 _n_matching_session_tokens = state.MatchingSessionTokensCount;
                 _pastTokensCount = state.PastTokensCount;
                 _pathSession = state.SessionFilePath;
-                _session_tokens = state.SessionTokens;
+                _session_tokens = state.SessionTokens.ToList();
             }
             else
             {

--- a/LLama/LLamaInstructExecutor.cs
+++ b/LLama/LLamaInstructExecutor.cs
@@ -111,6 +111,22 @@ namespace LLama
         }
 
         /// <inheritdoc />
+        public override void ResetState()
+        {
+            _n_session_consumed = 0;
+            _embed_inps = new List<LLamaToken>();
+            _is_prompt_run = true;
+            _consumedTokensCount = 0;
+            _embeds = new List<LLamaToken>();
+            _last_n_tokens = new FixedSizeQueue<LLamaToken>((int) Context.ContextSize);
+            _n_matching_session_tokens = 0;
+            _pastTokensCount = 0;
+            _pathSession = null;
+            _session_tokens = new List<LLamaToken>();
+            MirostatMu = 0;
+        }   
+
+        /// <inheritdoc />
         protected override Task<bool> GetLoopCondition(InferStateArgs args)
         {
             return Task.FromResult(args.RemainedTokens != 0 || _is_prompt_run);

--- a/LLama/LLamaInstructExecutor.cs
+++ b/LLama/LLamaInstructExecutor.cs
@@ -111,22 +111,6 @@ namespace LLama
         }
 
         /// <inheritdoc />
-        public override void ResetState()
-        {
-            _n_session_consumed = 0;
-            _embed_inps = new List<LLamaToken>();
-            _is_prompt_run = true;
-            _consumedTokensCount = 0;
-            _embeds = new List<LLamaToken>();
-            _last_n_tokens = new FixedSizeQueue<LLamaToken>((int) Context.ContextSize);
-            _n_matching_session_tokens = 0;
-            _pastTokensCount = 0;
-            _pathSession = null;
-            _session_tokens = new List<LLamaToken>();
-            MirostatMu = 0;
-        }   
-
-        /// <inheritdoc />
         protected override Task<bool> GetLoopCondition(InferStateArgs args)
         {
             return Task.FromResult(args.RemainedTokens != 0 || _is_prompt_run);

--- a/LLama/LLamaInteractExecutor.cs
+++ b/LLama/LLamaInteractExecutor.cs
@@ -93,22 +93,6 @@ namespace LLama
             }
         }
 
-        /// <inheritdoc />
-        public override void ResetState()
-        {
-            _n_session_consumed = 0;
-            _embed_inps = new List<LLamaToken>();
-            _is_prompt_run = true;
-            _consumedTokensCount = 0;
-            _embeds = new List<LLamaToken>();
-            _last_n_tokens = new FixedSizeQueue<LLamaToken>((int)Context.ContextSize);
-            _n_matching_session_tokens = 0;
-            _pastTokensCount = 0;
-            _pathSession = null;
-            _session_tokens = new List<LLamaToken>();
-            MirostatMu = 0;
-        }
-
         /// <summary>
         /// Define whether to continue the loop to generate responses.
         /// </summary>

--- a/LLama/LLamaInteractExecutor.cs
+++ b/LLama/LLamaInteractExecutor.cs
@@ -93,6 +93,22 @@ namespace LLama
             }
         }
 
+        /// <inheritdoc />
+        public override void ResetState()
+        {
+            _n_session_consumed = 0;
+            _embed_inps = new List<LLamaToken>();
+            _is_prompt_run = true;
+            _consumedTokensCount = 0;
+            _embeds = new List<LLamaToken>();
+            _last_n_tokens = new FixedSizeQueue<LLamaToken>((int)Context.ContextSize);
+            _n_matching_session_tokens = 0;
+            _pastTokensCount = 0;
+            _pathSession = null;
+            _session_tokens = new List<LLamaToken>();
+            MirostatMu = 0;
+        }
+
         /// <summary>
         /// Define whether to continue the loop to generate responses.
         /// </summary>

--- a/LLama/LLamaInteractExecutor.cs
+++ b/LLama/LLamaInteractExecutor.cs
@@ -39,15 +39,15 @@ namespace LLama
             InteractiveExecutorState state = new()
             {
                 ConsumedSessionCount = _n_session_consumed,
-                EmbedInps = _embed_inps,
+                EmbedInps = _embed_inps.ToArray(),
                 IsPromptRun = _is_prompt_run,
                 ConsumedTokensCount = _consumedTokensCount,
-                Embeds = _embeds,
+                Embeds = _embeds.ToArray(),
                 LastTokens = _last_n_tokens.ToArray(),
                 MatchingSessionTokensCount = _n_matching_session_tokens,
                 PastTokensCount = _pastTokensCount,
                 SessionFilePath = _pathSession,
-                SessionTokens = _session_tokens,
+                SessionTokens = _session_tokens.ToArray(),
                 LastTokensCapacity = _last_n_tokens.Capacity,
                 MirostatMu = MirostatMu
             };
@@ -59,15 +59,15 @@ namespace LLama
             if (data is InteractiveExecutorState state)
             {
                 _n_session_consumed = state.ConsumedSessionCount;
-                _embed_inps = state.EmbedInps;
+                _embed_inps = state.EmbedInps.ToList();
                 _is_prompt_run = state.IsPromptRun;
                 _consumedTokensCount = state.ConsumedTokensCount;
-                _embeds = state.Embeds;
+                _embeds = state.Embeds.ToList();
                 _last_n_tokens = new FixedSizeQueue<LLamaToken>(state.LastTokensCapacity, state.LastTokens);
                 _n_matching_session_tokens = state.MatchingSessionTokensCount;
                 _pastTokensCount = state.PastTokensCount;
                 _pathSession = state.SessionFilePath;
-                _session_tokens = state.SessionTokens;
+                _session_tokens = state.SessionTokens.ToList();
             }
             else
                 throw new ArgumentException("Invalid state data type.");

--- a/LLama/LLamaTransforms.cs
+++ b/LLama/LLamaTransforms.cs
@@ -48,6 +48,12 @@ namespace LLama
             }
 
             /// <inheritdoc />
+            public IHistoryTransform Clone()
+            {
+                return new DefaultHistoryTransform(_userName, _assistantName, _systemName, _unknownName, _isInstructMode);
+            }
+
+            /// <inheritdoc />
             public virtual string HistoryToText(ChatHistory history)
             {
                 StringBuilder sb = new();
@@ -116,6 +122,12 @@ namespace LLama
             {
                 return text.Trim();
             }
+
+            /// <inheritdoc />
+            public ITextTransform Clone()
+            {
+                return new NaiveTextInputTransform();
+            }
         }
 
         /// <summary>
@@ -128,6 +140,12 @@ namespace LLama
             public IAsyncEnumerable<string> TransformAsync(IAsyncEnumerable<string> tokens)
             {
                 return tokens;
+            }
+
+            /// <inheritdoc />
+            public ITextStreamTransform Clone()
+            {
+                return new EmptyTextOutputStreamTransform();
             }
         }
 
@@ -155,6 +173,12 @@ namespace LLama
                 _maxKeywordLength = _keywords.Max(x => x.Length) + redundancyLength;
                 _maxKeywordLength = _keywords.Select(x => x.Length).Max() + redundancyLength;
                 _removeAllMatchedTokens = removeAllMatchedTokens;
+            }
+
+            /// <inheritdoc />
+            public ITextStreamTransform Clone()
+            {
+                return new KeywordTextOutputStreamTransform(_keywords, _maxKeywordLength, _removeAllMatchedTokens);
             }
 
             /// <inheritdoc />

--- a/LLama/LLamaTransforms.cs
+++ b/LLama/LLamaTransforms.cs
@@ -3,6 +3,7 @@ using LLama.Common;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.Json.Serialization;
 
 namespace LLama
 {
@@ -28,6 +29,12 @@ namespace LLama
             private readonly string _systemName;
             private readonly string _unknownName;
             private readonly bool _isInstructMode;
+
+            public string UserName => _userName;
+            public string AssistantName => _assistantName;
+            public string SystemName => _systemName;
+            public string UnknownName => _unknownName;
+            public bool IsInstructMode => _isInstructMode;
 
             /// <summary>
             /// 
@@ -157,6 +164,42 @@ namespace LLama
             private readonly HashSet<string> _keywords;
             private readonly int _maxKeywordLength;
             private readonly bool _removeAllMatchedTokens;
+
+            /// <summary>
+            /// Keywords that you want to remove from the response.
+            /// This property is used for JSON serialization.
+            /// </summary>
+            [JsonPropertyName("keywords")]
+            public HashSet<string> Keywords => _keywords;
+
+            /// <summary>
+            /// Maximum length of the keywords.
+            /// This property is used for JSON serialization.
+            /// </summary>
+            [JsonPropertyName("maxKeywordLength")]
+            public int MaxKeywordLength => _maxKeywordLength;
+
+            /// <summary>
+            /// If set to true, when getting a matched keyword, all the related tokens will be removed. 
+            /// Otherwise only the part of keyword will be removed.
+            /// This property is used for JSON serialization.
+            /// </summary>
+            [JsonPropertyName("removeAllMatchedTokens")]
+            public bool RemoveAllMatchedTokens => _removeAllMatchedTokens;
+
+            /// <summary>
+            /// JSON constructor.
+            /// </summary>
+            [JsonConstructor]
+            public KeywordTextOutputStreamTransform(
+                HashSet<string> keywords,
+                int maxKeywordLength,
+                bool removeAllMatchedTokens)
+            {
+                _keywords = new(keywords);
+                _maxKeywordLength = maxKeywordLength;
+                _removeAllMatchedTokens = removeAllMatchedTokens;
+            }
 
             /// <summary>
             /// 


### PR DESCRIPTION
As discussed here https://github.com/SciSharp/LLamaSharp/issues/559

I've added few things:
- `StatefulExecutorBase.AddPromptAsync` - basically runs the text through decode without sampling new tokens.
  I am basically running InferInternal twice with WaitForInput = true, but it's very reliant on specific implementation of child classes and not the abstraction itself, so maybe you'll have some suggestions on how to improve it.
- SessionState record class reperesenting ChatSession state in memory.
- `void LoadSession(SessionState state)` and `SessionState GetSessionState()` for ChatSession class to save session state at arbitrary point.
- `static Task<ChatSession> ChatSession.InitializeSessionFromHistoryAsync(ILLamaExecutor executor, ChatHistory history, CancellationToken cancellationToken = default)` and `Task<ChatSession> ChatSession.ProcessSystemMessage(string content)` to pre-process KV cache.
- Functions to reset states of StatefulExecutors and LlamaContext.
- Example `ChatSessionWithRestart` to show off how it works

I didn't find any ChatSession unit tests so I did not write any.

BR,
Mykyta