### PR TITLE
Added conditional compilation code to progress_callback (in LlamaModelParams struct)

### DIFF
--- a/LLama/Native/LLamaModelParams.cs
+++ b/LLama/Native/LLamaModelParams.cs
@@ -33,7 +33,13 @@ namespace LLama.Native
         /// called with a progress value between 0 and 1, pass NULL to disable. If the provided progress_callback
         /// returns true, model loading continues. If it returns false, model loading is immediately aborted.
         /// </summary>
+#if NETSTANDARD2_0
+        // this code is intended to be used when running LlamaSharp on NET Framework 4.8 (NET Standard 2.0) 
+        // as NET Framework 4.8 does not play nice with the LlamaProgressCallback type
+        public IntPtr progress_callback;
+#else
         public LlamaProgressCallback progress_callback;
+#endif
 
         /// <summary>
         /// context pointer passed to the progress callback


### PR DESCRIPTION
The NET framework 4.8 marshaller does not accept the LlamaProgressCallback delegate used in the LlamaModelParams struct, so a conditional compilation was added to use IntPtr instead of LlamaProgressCallback when targeting NET Standard 2.0 (and not NET 6.0 or greater) which essentially means running on NET Framework for us.