### PR TITLE
fix: incorrect loading of native library with multiple backends

### DIFF
--- a/LLama/LLamaSharp.Runtime.targets
+++ b/LLama/LLamaSharp.Runtime.targets
@@ -4,68 +4,68 @@
     </PropertyGroup>
     <ItemGroup Condition="'$(IncludeBuiltInRuntimes)' == 'true'">
 
-      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/llama.dll">
+      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/llama-sharp/llama.dll">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <Link>runtimes/win-x64/native/noavx/llama.dll</Link>
+        <Link>runtimes/win-x64/native/llama-sharp/noavx/llama.dll</Link>
       </None>
-      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/avx/llama.dll">
+      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/llama-sharp/avx/llama.dll">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <Link>runtimes/win-x64/native/avx/llama.dll</Link>
+        <Link>runtimes/win-x64/native/llama-sharp/avx/llama.dll</Link>
       </None>
-      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/avx2/llama.dll">
+      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/llama-sharp/avx2/llama.dll">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <Link>runtimes/win-x64/native/avx2/llama.dll</Link>
+        <Link>runtimes/win-x64/native/llama-sharp/avx2/llama.dll</Link>
       </None>
-      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/avx512/llama.dll">
+      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/llama-sharp/avx512/llama.dll">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <Link>runtimes/win-x64/native/avx512/llama.dll</Link>
+        <Link>runtimes/win-x64/native/llama-sharp/avx512/llama.dll</Link>
       </None>
-      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/cu11.7.1/llama.dll">
+      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/llama-sharp/cu11.7.1/llama.dll">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <Link>runtimes/win-x64/native/cuda11/llama.dll</Link>
+        <Link>runtimes/win-x64/native/llama-sharp/cuda11/llama.dll</Link>
       </None>
-      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/cu12.1.0/llama.dll">
+      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/llama-sharp/cu12.1.0/llama.dll">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <Link>runtimes/win-x64/native/cuda12/llama.dll</Link>
-      </None>
-
-      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/libllama.so">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <Link>runtimes/linux-x64/native/noavx/libllama.so</Link>
-      </None>
-      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/avx/libllama.so">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <Link>runtimes/linux-x64/native/avx/libllama.so</Link>
-      </None>
-      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/avx2/libllama.so">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <Link>runtimes/linux-x64/native/avx2/libllama.so</Link>
-      </None>
-      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/avx512/libllama.so">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <Link>runtimes/linux-x64/native/avx512/libllama.so</Link>
-      </None>
-      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/cu11.7.1/libllama.so">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <Link>runtimes/linux-x64/native/cuda11/libllama.so</Link>
-      </None>
-      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/cu12.1.0/libllama.so">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <Link>runtimes/linux-x64/native/cuda12/libllama.so</Link>
+        <Link>runtimes/win-x64/native/llama-sharp/cuda12/llama.dll</Link>
       </None>
 
-      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/osx-arm64/libllama.dylib">
+      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/llama-sharp/noavx/libllama.so">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <Link>runtimes/osx-arm64/native/libllama.dylib</Link>
+        <Link>runtimes/linux-x64/native/llama-sharp/noavx/libllama.so</Link>
       </None>
-      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/osx-arm64/ggml-metal.metal">
+      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/llama-sharp/avx/libllama.so">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <Link>runtimes/osx-arm64/native/ggml-metal.metal</Link>
+        <Link>runtimes/linux-x64/native/llama-sharp/avx/libllama.so</Link>
+      </None>
+      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/llama-sharp/avx2/libllama.so">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Link>runtimes/linux-x64/native/llama-sharp/avx2/libllama.so</Link>
+      </None>
+      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/llama-sharp/avx512/libllama.so">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Link>runtimes/linux-x64/native/llama-sharp/avx512/libllama.so</Link>
+      </None>
+      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/llama-sharp/cu11.7.1/libllama.so">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Link>runtimes/linux-x64/native/llama-sharp/cuda11/libllama.so</Link>
+      </None>
+      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/llama-sharp/cu12.1.0/libllama.so">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Link>runtimes/linux-x64/native/llama-sharp/cuda12/libllama.so</Link>
       </None>
 
-      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/osx-x64/libllama.dylib">
+      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/llama-sharp/osx-arm64/libllama.dylib">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <Link>runtimes/osx-x64/native/libllama.dylib</Link>
+        <Link>runtimes/osx-arm64/native/llama-sharp/libllama.dylib</Link>
+      </None>
+      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/llama-sharp/osx-arm64/ggml-metal.metal">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Link>runtimes/osx-arm64/native/llama-sharp/ggml-metal.metal</Link>
+      </None>
+
+      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/llama-sharp/osx-x64/libllama.dylib">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Link>runtimes/osx-x64/native/llama-sharp/libllama.dylib</Link>
       </None>
     </ItemGroup>
 </Project>

--- a/LLama/Native/NativeApi.Load.cs
+++ b/LLama/Native/NativeApi.Load.cs
@@ -12,26 +12,8 @@ namespace LLama.Native
 {
     public static partial class NativeApi
     {
-#if NET6_0_OR_GREATER
-        internal static partial class Libraries
-        {
-            internal const string Odbc32 = "libodbc";
-        }
-        static nint MyDllImportResolver(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
-        {
-            Console.WriteLine("*********************************** got a native load of: " + libraryName);
-            if (libraryName == Libraries.Odbc32) 
-            { 
-                return NativeLibrary.Load(libraryName, assembly, default); 
-            } 
-            return default; 
-        }
-#endif
         static NativeApi()
         {
-#if NET6_0_OR_GREATER
-            //NativeLibrary.SetDllImportResolver(typeof(NativeApi).Assembly, MyDllImportResolver);
-#endif
             // Try to load a preferred library, based on CPU feature detection
             TryLoadLibrary();
 

--- a/LLama/Native/NativeLibraryConfig.cs
+++ b/LLama/Native/NativeLibraryConfig.cs
@@ -194,10 +194,10 @@ namespace LLama.Native
         {
             return level switch
             {
-                AvxLevel.None => string.Empty,
-                AvxLevel.Avx => "avx",
-                AvxLevel.Avx2 => "avx2",
-                AvxLevel.Avx512 => "avx512",
+                AvxLevel.None => "llama-sharp/noavx",
+                AvxLevel.Avx => "llama-sharp/avx",
+                AvxLevel.Avx2 => "llama-sharp/avx2",
+                AvxLevel.Avx512 => "llama-sharp/avx512",
                 _ => throw new ArgumentException($"Unknown AvxLevel '{level}'")
             };
         }

--- a/LLama/runtimes/build/LLamaSharp.Backend.Cpu.nuspec
+++ b/LLama/runtimes/build/LLamaSharp.Backend.Cpu.nuspec
@@ -18,19 +18,19 @@
   <files>
     <file src="LLamaSharpBackend.props" target="build/netstandard2.0/LLamaSharp.Backend.Cpu.props" />
 
-    <file src="runtimes/deps/llama.dll" target="runtimes\win-x64\native\llama.dll" />
-    <file src="runtimes/deps/avx/llama.dll" target="runtimes\win-x64\native\avx\llama.dll" />
-    <file src="runtimes/deps/avx2/llama.dll" target="runtimes\win-x64\native\avx2\llama.dll" />
-    <file src="runtimes/deps/avx512/llama.dll" target="runtimes\win-x64\native\avx512\llama.dll" />
+    <file src="runtimes/deps/llama.dll" target="runtimes\win-x64\native\llama-sharp\llama.dll" />
+    <file src="runtimes/deps/avx/llama.dll" target="runtimes\win-x64\native\llama-sharp\avx\llama.dll" />
+    <file src="runtimes/deps/avx2/llama.dll" target="runtimes\win-x64\native\llama-sharp\avx2\llama.dll" />
+    <file src="runtimes/deps/avx512/llama.dll" target="runtimes\win-x64\native\llama-sharp\avx512\llama.dll" />
 
-    <file src="runtimes/deps/libllama.so" target="runtimes\linux-x64\native\libllama.so" />
-    <file src="runtimes/deps/avx/libllama.so" target="runtimes\linux-x64\native\avx\libllama.so" />
-    <file src="runtimes/deps/avx2/libllama.so" target="runtimes\linux-x64\native\avx2\libllama.so" />
-    <file src="runtimes/deps/avx512/libllama.so" target="runtimes\linux-x64\native\avx512\libllama.so" />
+    <file src="runtimes/deps/libllama.so" target="runtimes\linux-x64\native\llama-sharp\libllama.so" />
+    <file src="runtimes/deps/avx/libllama.so" target="runtimes\linux-x64\native\llama-sharp\avx\libllama.so" />
+    <file src="runtimes/deps/avx2/libllama.so" target="runtimes\linux-x64\native\llama-sharp\avx2\libllama.so" />
+    <file src="runtimes/deps/avx512/libllama.so" target="runtimes\linux-x64\native\llama-sharp\avx512\libllama.so" />
     
-    <file src="runtimes/deps/osx-x64/libllama.dylib" target="runtimes\osx-x64\native\libllama.dylib" />
-    <file src="runtimes/deps/osx-arm64/libllama.dylib" target="runtimes\osx-arm64\native\libllama.dylib" />
-    <file src="runtimes/deps/osx-arm64/ggml-metal.metal" target="runtimes\osx-arm64\native\ggml-metal.metal" />
+    <file src="runtimes/deps/osx-x64/libllama.dylib" target="runtimes\osx-x64\native\llama-sharp\libllama.dylib" />
+    <file src="runtimes/deps/osx-arm64/libllama.dylib" target="runtimes\osx-arm64\native\llama-sharp\libllama.dylib" />
+    <file src="runtimes/deps/osx-arm64/ggml-metal.metal" target="runtimes\osx-arm64\native\llama-sharp\ggml-metal.metal" />
     
     <file src="icon512.png" target="icon512.png" />
   </files>

--- a/LLama/runtimes/build/LLamaSharp.Backend.Cuda11.nuspec
+++ b/LLama/runtimes/build/LLamaSharp.Backend.Cuda11.nuspec
@@ -18,8 +18,8 @@
   <files>
     <file src="LLamaSharpBackend.props" target="build/netstandard2.0/LLamaSharp.Backend.Cuda11.props" />
     
-    <file src="runtimes/deps/cu11.7.1/llama.dll" target="runtimes\win-x64\native\cuda11\llama.dll" />
-    <file src="runtimes/deps/cu11.7.1/libllama.so" target="runtimes\linux-x64\native\cuda11\libllama.so" />
+    <file src="runtimes/deps/cu11.7.1/llama.dll" target="runtimes\win-x64\native\llama-sharp\cuda11\llama.dll" />
+    <file src="runtimes/deps/cu11.7.1/libllama.so" target="runtimes\linux-x64\native\llama-sharp\cuda11\libllama.so" />
     
     <file src="icon512.png" target="icon512.png" />
   </files>

--- a/LLama/runtimes/build/LLamaSharp.Backend.Cuda12.nuspec
+++ b/LLama/runtimes/build/LLamaSharp.Backend.Cuda12.nuspec
@@ -18,8 +18,8 @@
   <files>
     <file src="LLamaSharpBackend.props" target="build/netstandard2.0/LLamaSharp.Backend.Cuda12.props" />
     
-    <file src="runtimes/deps/cu12.1.0/llama.dll" target="runtimes\win-x64\native\cuda12\llama.dll" />
-    <file src="runtimes/deps/cu12.1.0/libllama.so" target="runtimes\linux-x64\native\cuda12\libllama.so" />
+    <file src="runtimes/deps/cu12.1.0/llama.dll" target="runtimes\win-x64\native\llama-sharp\cuda12\llama.dll" />
+    <file src="runtimes/deps/cu12.1.0/libllama.so" target="runtimes\linux-x64\native\llama-sharp\cuda12\libllama.so" />
     
     <file src="icon512.png" target="icon512.png" />
   </files>

--- a/LLama/runtimes/build/LLamaSharp.Backend.OpenCL.nuspec
+++ b/LLama/runtimes/build/LLamaSharp.Backend.OpenCL.nuspec
@@ -18,9 +18,9 @@
   <files>
     <file src="LLamaSharpBackend.props" target="build/netstandard2.0/LLamaSharp.Backend.OpenCL.props" />
 
-    <file src="runtimes/deps/clblast/llama.dll" target="runtimes\win-x64\native\clblast\llama.dll" />
-    <file src="runtimes/deps/clblast/clblast.dll" target="runtimes\win-x64\native\clblast\clblast.dll" />
-    <file src="runtimes/deps/clblast/libllama.so" target="runtimes\linux-x64\native\clblast\libllama.so" />
+    <file src="runtimes/deps/clblast/llama.dll" target="runtimes\win-x64\native\llama-sharp\clblast\llama.dll" />
+    <file src="runtimes/deps/clblast/clblast.dll" target="runtimes\win-x64\native\llama-sharp\clblast\clblast.dll" />
+    <file src="runtimes/deps/clblast/libllama.so" target="runtimes\linux-x64\native\llama-sharp\clblast\libllama.so" />
 
     <file src="icon512.png" target="icon512.png" />
   </files>


### PR DESCRIPTION
## What this PR does

It fixes the incorrect loading of native library when having multiple backends installed. This issue has been mentioned in #456 and #589.

## Description about the issue

The behavior in master branch now is quite wierd.
1. When using LLama.Example project directly, all things go as exepected.
2. When installing both cpu and cuda backend packages and using LLamaSharp in another project, it cannot load correct library **even if the log does show it loads the desired library**.


Let's consider the case2. I had many tries and it's concluded as below.
- When I used `WithCuda` or `WithLibrary` to load the cuda version library, the log shown it had selected that file to load but actually no gpu is used. Besides I could confirm it's not because of the model loading problem.
- There were 5 folders/files in my output path, which are `llama.dll`, `avx`, `avx2`, `avx512`, `cuda11`. When I was trying to load the cuda library, I could delete neither `avx` or `cuda11` folder. That means, these two files were both occupied by a certain process, which is obviously the one I started.
- If I deleted `avx` folder, the case became that `avx2` and `cuda11` were both occupied. Still, cuda library could not be used.
- I confirmed the order of searching was correct and I didn't see a double-loading in logs.

After deleting all the folders except `cuda11`, I found it works. The only thing I could come up with is that `avx`, `avx2`, etc. hit the keywords of dotnet runtime and it does not obey the rules we write in our code.

Finally I changed all the paths and insert one more level directory `llama-sharp` into the paths of native libraries. All things worked as expected again on my PC.

**To be honest I don't think my solution is good enough because I still don't know the reason behind it. Besides, through this debug I found some problems in current native loading code, so I'd like to take this PR as a discussion before releasing next version with LLaVA.** 

@martindevans @SignalRT Hope that this mention doesn't bother you. Your participation will help a lot. :)

---

## Discussion

### NativeLibraryConfig with LLaVA
I think we just need to use the same way with llama.dll to deal with LLaVA here. If I'm not mistaking it, there was already a discussion about whether to put llava libraries in each backend packages. I'm not sure if it still needs discussion. 

### OpenCL support
It seems that OpenCL related logic has not been added to `NativeLibraryConfig`. I'll add it later if it's not ignored intentionally. 

### More flexible loading strategy
I think maybe we should make a better abstraction and allow user to override some APIs to add more flexible control of library loading. Currently, as far as I know, users who want to publish an app with LLamaSharp often maintain the location of native libraries themselves, while their user could have various environments. Finally it always fallbacks to using `WithLibrary`, limiting the usage of our control strategy.

However the time cost of it seems to be a problem. I think it should at least be no hurry.


