### PR TITLE
llama_decode lock

### DIFF
--- a/LLama/Native/SafeLLamaContextHandle.cs
+++ b/LLama/Native/SafeLLamaContextHandle.cs
@@ -192,6 +192,7 @@ namespace LLama.Native
         #endregion
 
         #region infer
+
         /// <summary>
         /// </summary>
         /// <param name="batch"></param>
@@ -203,7 +204,8 @@ namespace LLama.Native
         public DecodeResult Decode(LLamaBatch batch)
         {
             using (batch.ToNativeBatch(out var nb))
-                return (DecodeResult)NativeApi.llama_decode(this, nb);
+                lock (ModelHandle.ModelLockObject)
+                    return (DecodeResult)NativeApi.llama_decode(this, nb);
         }
 
         /// <summary>

--- a/LLama/Native/SafeLLamaContextHandle.cs
+++ b/LLama/Native/SafeLLamaContextHandle.cs
@@ -192,6 +192,17 @@ namespace LLama.Native
         #endregion
 
         #region infer
+        /// <summary>
+        /// This object exists to ensure there is only ever 1 inference running at a time. This is a workaround for thread safety issues in llama.cpp itself.
+        /// Most notably CUDA, which seems to use some global singleton resources and will crash if multiple inferences are run (even against different models).
+        /// 
+        /// For more information see these issues:
+        ///  - https://github.com/SciSharp/LLamaSharp/issues/596
+        ///  - https://github.com/ggerganov/llama.cpp/issues/3960
+        ///
+        /// If these are ever resolved this lock can probably be removed.
+        /// </summary>
+        private static readonly object GlobalInferenceLock = new();
 
         /// <summary>
         /// </summary>
@@ -203,8 +214,8 @@ namespace LLama.Native
         /// </returns>
         public DecodeResult Decode(LLamaBatch batch)
         {
-            using (batch.ToNativeBatch(out var nb))
-                lock (ModelHandle.ModelLockObject)
+            lock (GlobalInferenceLock)
+                using (batch.ToNativeBatch(out var nb))
                     return (DecodeResult)NativeApi.llama_decode(this, nb);
         }
 

--- a/LLama/Native/SafeLlamaModelHandle.cs
+++ b/LLama/Native/SafeLlamaModelHandle.cs
@@ -18,6 +18,12 @@ namespace LLama.Native
         : SafeLLamaHandleBase
     {
         /// <summary>
+        /// Any contexts running inference with this model should lock this object first.
+        /// This is a workaround for some backends (notably CUDA) not being threadsafe on the llama.cpp side, see https://github.com/ggerganov/llama.cpp/issues/3960
+        /// </summary>
+        internal readonly object ModelLockObject = new();
+
+        /// <summary>
         /// Total number of tokens in vocabulary of this model
         /// </summary>
         public int VocabCount => llama_n_vocab(this);

--- a/LLama/Native/SafeLlamaModelHandle.cs
+++ b/LLama/Native/SafeLlamaModelHandle.cs
@@ -18,12 +18,6 @@ namespace LLama.Native
         : SafeLLamaHandleBase
     {
         /// <summary>
-        /// Any contexts running inference with this model should lock this object first.
-        /// This is a workaround for some backends (notably CUDA) not being threadsafe on the llama.cpp side, see https://github.com/ggerganov/llama.cpp/issues/3960
-        /// </summary>
-        internal readonly object ModelLockObject = new();
-
-        /// <summary>
         /// Total number of tokens in vocabulary of this model
         /// </summary>
         public int VocabCount => llama_n_vocab(this);


### PR DESCRIPTION
Added a lock object into `SafeLlamaModelHandle` which all calls to `llama_decode` (in the `SafeLLamaContextHandle`) lock first.

This prevents two contexts from running inference on the same model at the same time, which seems to be unsafe in llama.cpp. We _may_ need an even wider lock (preventing inference on _any_ two models simultaneously). Testing required.