### PR TITLE
build: add llama.cpp as submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "llama.cpp"]
+	path = llama.cpp
+	url = https://github.com/ggerganov/llama.cpp.git


### PR DESCRIPTION
Add llama.cpp as a submodule here for some reason:

1. It's easy for users to find which commit they should head to if they want to compile native library themselves.
2. It makes it more convenient for development based on llama.cpp in LLamaSharp.
