### PR TITLE
`SetDllImportResolver` based loading

### DIFF
--- a/LLama.Examples/Program.cs
+++ b/LLama.Examples/Program.cs
@@ -16,11 +16,14 @@ AnsiConsole.MarkupLineInterpolated(
 
     """);
 
+// Configure native library to use
 NativeLibraryConfig
    .Instance
    .WithCuda()
-   .WithLogs(LLamaLogLevel.Warning);
+   .WithLogs(LLamaLogLevel.Info);
 
+// Calling this method forces loading to occur now.
 NativeApi.llama_empty_call();
 
 await ExampleRunner.Run();
+

--- a/LLama/Native/NativeApi.Load.cs
+++ b/LLama/Native/NativeApi.Load.cs
@@ -275,7 +275,7 @@ namespace LLama.Native
         {
             GetPlatformPathParts(out _, out var os, out var fileExtension, out var libPrefix);
 
-            return $"{os}{libPrefix}{libraryName}{fileExtension}";
+            return $"runtimes/{os}/native/{libPrefix}{libraryName}{fileExtension}";
         }
 
         /// <summary>


### PR DESCRIPTION
Using `SetDllImportResolver` to load llama DLLs as a prototype.

This is just a prototype to check if using this fixes the issue with some DLLs seemingly being loaded twice.

@AsakusaRinne @zsogitbe I'd appreciate if you would test this (particularly with CUDA) and tell me if it seems to help.