### PR TITLE
LLava Test Slowdown

### DIFF
--- a/LLama.Unittest/LLavaWeightsTests.cs
+++ b/LLama.Unittest/LLavaWeightsTests.cs
@@ -1,5 +1,4 @@
 ﻿using LLama.Common;
-using LLama.Native;
 
 namespace LLama.Unittest
 {
@@ -16,8 +15,8 @@ namespace LLama.Unittest
         {
             var @params = new ModelParams(Constants.ModelPath)
             {
-                // Llava models requires big context
-                ContextSize = 4096
+                // Exactly enough context to embed the test image
+                ContextSize = 2880
             };
             _llamaWeights = LLamaWeights.LoadFromFile(@params);
             _lLavaWeights = LLavaWeights.LoadFromFile(Constants.LLavaMmpPath);
@@ -32,21 +31,22 @@ namespace LLama.Unittest
             _lLavaWeights.Dispose();
         }
 
-      
-        
-        [Fact]
+
+
+        [Fact(Skip = "Very slow in CI")]
         public void EmbedImageAsFileName()
         {
             int n_past = 0;
             Assert.True( _lLavaWeights.EmbedImage( _context, Constants.LLavaImage, ref n_past ) );
-        }        
-        
-        [Fact]
+        }
+
+        [Fact(Skip = "Very slow in CI")]
         public void EmbedImageAsBinary()
         {
             int n_past = 0;
-            byte[] image = System.IO.File.ReadAllBytes(Constants.LLavaImage);
+            byte[] image = File.ReadAllBytes(Constants.LLavaImage);
             Assert.True( _lLavaWeights.EmbedImage( _context, image, ref n_past ) );
+            Assert.Equal(2880, n_past);
         }        
         
     }

--- a/LLama/LLavaWeights.cs
+++ b/LLama/LLavaWeights.cs
@@ -1,18 +1,29 @@
-
 using System;
 using LLama.Native;
 
 namespace LLama;
 
+/// <summary>
+/// A set of llava model weights (mmproj), loaded into memory.
+/// </summary>
 public sealed class LLavaWeights : IDisposable
 {
+    /// <summary>
+    /// The native handle, which is used in the native APIs
+    /// </summary>
+    /// <remarks>Be careful how you use this!</remarks>
     public SafeLlavaModelHandle NativeHandle { get; }   
     
     internal LLavaWeights(SafeLlavaModelHandle weights)
     {
         NativeHandle = weights;
     }
-    
+
+    /// <summary>
+    /// Load weights into memory
+    /// </summary>
+    /// <param name="mmProject">path to the "mmproj" model file</param>
+    /// <returns></returns>
     public static LLavaWeights LoadFromFile(string mmProject)
     {
         var weights = SafeLlavaModelHandle.LoadFromFile(mmProject, 1);
@@ -38,11 +49,12 @@ public sealed class LLavaWeights : IDisposable
     /// <param name="Image"></param>
     /// <param name="n_past"></param>
     /// <returns></returns>
-    public bool EmbedImage(LLamaContext ctxLlama, Byte[] Image, ref int n_past )
+    public bool EmbedImage(LLamaContext ctxLlama, byte[] Image, ref int n_past )
     {
         return NativeHandle.EmbedImage(ctxLlama, Image, ref n_past );
     }
-    
+
+    /// <inheritdoc />
     public void Dispose()
     {
         NativeHandle.Dispose();

--- a/LLama/Native/NativeApi.LLava.cs
+++ b/LLama/Native/NativeApi.LLava.cs
@@ -3,7 +3,6 @@ using System.Runtime.InteropServices;
 
 namespace LLama.Native;
 
-using clip_ctx = IntPtr;
 public static unsafe partial class NativeApi
 {
     /// <summary>
@@ -45,13 +44,16 @@ public static unsafe partial class NativeApi
     /// <param name="embed"></param>
     /// <returns></returns>
     [DllImport(llavaLibraryName, EntryPoint = "llava_image_embed_free", CallingConvention = CallingConvention.Cdecl)]
-    public static extern SafeLlavaImageEmbedHandle llava_image_embed_free(IntPtr embed);
+    public static extern void llava_image_embed_free(IntPtr embed);
 
     /// <summary>
     /// Write the image represented by embed into the llama context with batch size n_batch, starting at context
     /// pos n_past. on completion, n_past points to the next position in the context after the image embed.
     /// </summary>
+    /// <param name="ctc_llama"></param>
     /// <param name="embed">ctx_llama</param>
+    /// <param name="n_batch"></param>
+    /// <param name="n_past"></param>
     /// <returns></returns>
     [DllImport(llavaLibraryName, EntryPoint = "llava_eval_image_embed", CallingConvention = CallingConvention.Cdecl)]
     public static extern bool llava_eval_image_embed(SafeLLamaContextHandle ctc_llama, SafeLlavaImageEmbedHandle embed,

--- a/LLama/Native/SafeLlamaModelHandle.cs
+++ b/LLama/Native/SafeLlamaModelHandle.cs
@@ -363,7 +363,8 @@ namespace LLama.Native
                         var tokens = new LLamaToken[count];
                         fixed (LLamaToken* tokensPtr = tokens)
                         {
-                            NativeApi.llama_tokenize(this, bytesPtr, bytesCount, tokensPtr, count, add_bos, special);
+                            var result = NativeApi.llama_tokenize(this, bytesPtr, bytesCount, tokensPtr, count, add_bos, special);
+                            Debug.Assert(result == count);
                             return tokens;
                         }
                     }

--- a/LLama/Native/SafeLlavaImageEmbedHandle.cs
+++ b/LLama/Native/SafeLlavaImageEmbedHandle.cs
@@ -1,16 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using LLama;
-using LLama.Exceptions;
 
 
 namespace LLama.Native
 {
     /// <summary>
-    /// A Reference to a set of llava Image Embed handle
+    /// A Reference to a llava Image Embed handle
     /// </summary>
     public sealed class SafeLlavaImageEmbedHandle
         : SafeLLamaHandleBase
@@ -24,12 +19,49 @@ namespace LLama.Native
         private SafeLlavaImageEmbedHandle()
         {}
 
+        /// <summary>
+        /// Create an image embed from an image file
+        /// </summary>
+        /// <param name="ctxLlava"></param>
+        /// <param name="ctxLlama"></param>
+        /// <param name="image">Path to the image file. Supported formats:
+        /// <list type="bullet">
+        ///     <item>JPG</item>
+        ///     <item>PNG</item>
+        ///     <item>BMP</item>
+        ///     <item>TGA</item>
+        /// </list>
+        /// </param>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException"></exception>
         public static SafeLlavaImageEmbedHandle CreateFromFileName( SafeLlavaModelHandle ctxLlava, LLamaContext ctxLlama, string image )
         {
+            // Try to open the image file, this will check:
+            // - File exists (automatically throws FileNotFoundException)
+            // - File is readable (explicit check)
+            // This provides better error messages that llama.cpp, which would throw an access violation exception in both cases.
+            using (var fs = new FileStream(image, FileMode.Open))
+                if (!fs.CanRead)
+                    throw new InvalidOperationException($"Llava image file '{image}' is not readable");
+
             return NativeApi.llava_image_embed_make_with_filename(ctxLlava,  (int) ctxLlama.BatchThreads, image);
         }
-        
-        public static SafeLlavaImageEmbedHandle CreateFromMemory( SafeLlavaModelHandle ctxLlava, LLamaContext ctxLlama, Byte[] image  )
+
+        /// <summary>
+        /// Create an image embed from the bytes of an image.
+        /// </summary>
+        /// <param name="ctxLlava"></param>
+        /// <param name="ctxLlama"></param>
+        /// <param name="image">Image bytes. Supported formats:
+        /// <list type="bullet">
+        ///     <item>JPG</item>
+        ///     <item>PNG</item>
+        ///     <item>BMP</item>
+        ///     <item>TGA</item>
+        /// </list>
+        /// </param>
+        /// <returns></returns>
+        public static SafeLlavaImageEmbedHandle CreateFromMemory( SafeLlavaModelHandle ctxLlava, LLamaContext ctxLlama, byte[] image  )
         {
             return NativeApi.llava_image_embed_make_with_bytes(ctxLlava,  (int) ctxLlama.BatchThreads, image, image.Length);
         }

--- a/LLama/Native/SafeLlavaModelHandle.cs
+++ b/LLama/Native/SafeLlavaModelHandle.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using LLama;
 using LLama.Exceptions;
 
 
@@ -37,12 +33,11 @@ namespace LLama.Native
         /// Load a model from the given file path into memory
         /// </summary>
         /// <param name="modelPath"></param>
-        /// <param name="lparams"></param>
+        /// <param name="verbosity"></param>
         /// <returns></returns>
         /// <exception cref="RuntimeError"></exception>
-        public static SafeLlavaModelHandle LoadFromFile(string modelPath, int verbosity )
+        public static SafeLlavaModelHandle LoadFromFile(string modelPath, int verbosity)
         {
-            
             // Try to open the model file, this will check:
             // - File exists (automatically throws FileNotFoundException)
             // - File is readable (explicit check)
@@ -76,7 +71,7 @@ namespace LLama.Native
         /// <param name="image">jpeg image</param>
         /// <param name="n_past"></param>
         /// <returns></returns>
-        public bool EmbedImage(LLamaContext ctxLlama, Byte[] image, ref int n_past )
+        public bool EmbedImage(LLamaContext ctxLlama, byte[] image, ref int n_past )
         {
             var ImageEmbed = SafeLlavaImageEmbedHandle.CreateFromMemory(this, ctxLlama, image );
             bool result = NativeApi.llava_eval_image_embed(ctxLlama.NativeHandle, ImageEmbed, (int)ctxLlama.Params.BatchSize, ref n_past );


### PR DESCRIPTION
Investigated why LLava embedding tests are slow. It looks like they are simply extremely CPU heavy (even on my powerful PC, taking ~10-20 seconds to finish with CPU load the entire time). I tried shrinking the image down 50% (25% as many pixels) but this wasn't much of an improvement.

For now I have **disabled** the image embedding tests to keep CI time under control (another PR took 25 minutes to complete the tests).

Other things fixed while investigating this:
 - Added doc comments on various llava methods/classes.
 - Fixed `llava_image_embed_free` returning `SafeLlavaImageEmbedHandle` when it should be `void`