### PR TITLE
Thread-safe queued batched executor

### DIFF
--- a/LLama/Batched/BatchedExecutor.cs
+++ b/LLama/Batched/BatchedExecutor.cs
@@ -267,10 +267,5 @@ public sealed class BatchedExecutor
                 }
             }
         }
-        Console.WriteLine("Logit cache:");
-        foreach (var pair in _logitCache)
-        {
-            Console.WriteLine($"{pair.Key} -> {string.Join(", ", pair.Value.Take(4))}");
-        }
     }
 }

--- a/LLama/Batched/BatchedExecutor.cs
+++ b/LLama/Batched/BatchedExecutor.cs
@@ -148,7 +148,7 @@ public sealed class BatchedExecutor
                 while (_batchQueue.TryPeek(out var batch))
                 {
                     status = await Context.DecodeAsync(batch, cancellation);
-                    if (status == DecodeResult.NoKvSlot)
+                    if (status != DecodeResult.Ok)
                         break;
                     if (status == DecodeResult.Ok)
                     {

--- a/LLama/Batched/BatchedExecutor.cs
+++ b/LLama/Batched/BatchedExecutor.cs
@@ -1,10 +1,49 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 using LLama.Abstractions;
 using LLama.Native;
 
 namespace LLama.Batched;
+
+struct AsyncMutex : IDisposable
+{
+    private readonly SemaphoreSlim _semaphore = new(1, 1);
+
+    public AsyncMutex()
+    {
+    }
+
+    public void Wait()
+    {
+        _semaphore.Wait();
+    }
+
+    public void Release()
+    {
+        _semaphore.Release(1);
+    }
+
+    public async Task WithMutexAsync(Func<Task> t)
+    {
+        await _semaphore.WaitAsync();
+
+        try
+        {
+            await t();
+        }
+        finally
+        {
+            _semaphore.Release(1);
+        }
+    }
+
+    public void Dispose()
+    {
+        _semaphore.Dispose();
+    }
+}
 
 /// <summary>
 /// A batched executor that can infer multiple separate "conversations" simultaneously.
@@ -14,7 +53,9 @@ public sealed class BatchedExecutor
 {
     private int _nextSequenceId;
 
-    internal LLamaBatch Batch { get; }
+    private readonly AsyncMutex _mutex = new AsyncMutex();
+
+    private ConcurrentQueue<LLamaBatch> _batchQueue;
 
     /// <summary>
     /// Epoch is incremented every time Infer is called. Conversations can use this to keep track of
@@ -35,7 +76,16 @@ public sealed class BatchedExecutor
     /// <summary>
     /// Get the number of tokens in the batch, waiting for <see cref="Infer"/> to be called
     /// </summary>
-    public int BatchedTokenCount => Batch.TokenCount;
+    public int BatchedTokenCount
+    {
+        get
+        {
+            var count = 0;
+            foreach (var batch in _batchQueue)
+                count += batch.TokenCount;
+            return count;
+        }
+    }
 
     /// <summary>
     /// Check if this executor has been disposed.
@@ -50,7 +100,7 @@ public sealed class BatchedExecutor
     public BatchedExecutor(LLamaWeights model, IContextParams contextParams)
     {
         Model = model;
-        Batch = new LLamaBatch();
+        _batchQueue = new ConcurrentQueue<LLamaBatch>();
         Context = model.CreateContext(contextParams);
         Epoch = 1;
     }
@@ -72,10 +122,8 @@ public sealed class BatchedExecutor
     {
         if (IsDisposed)
             throw new ObjectDisposedException(nameof(BatchedExecutor));
-
         var conversation = new Conversation(this, GetNextSequenceId(), 0);
         conversation.Prompt(prompt);
-
         return conversation;
     }
 
@@ -85,22 +133,71 @@ public sealed class BatchedExecutor
     /// If the result is `NoKvSlot` then there is not enough memory for inference, try disposing some conversation
     /// threads and running inference again.
     /// </summary>
-    public async Task<DecodeResult> Infer(CancellationToken cancellation = default)
+    /// <param name="processAll">If true processes the whole Queue, otherwise only single batch</param>
+    /// <param name="cancellation"></param>
+    /// <returns></returns>
+    public async Task<DecodeResult> Infer(bool processAll = true, CancellationToken cancellation = default)
     {
         if (IsDisposed)
             throw new ObjectDisposedException(nameof(BatchedExecutor));
-
-        var status = await Context.DecodeAsync(Batch, cancellation);
-
-        // Only clear the batch if the result was ok. leaving all this state in place means that "Infer" can
-        // be called again after a warning (e.g. NoKvSlot).
-        if (status == DecodeResult.Ok)
+        DecodeResult status = DecodeResult.Ok;
+        await _mutex.WithMutexAsync(async () =>
         {
-            Epoch++;
-            Batch.Clear();
-        }
-
+            if (processAll)
+            {
+                while (_batchQueue.TryPeek(out var batch))
+                {
+                    status = await Context.DecodeAsync(batch, cancellation);
+                    if (status == DecodeResult.NoKvSlot)
+                        break;
+                    if (status == DecodeResult.Ok)
+                    {
+                        Epoch++;
+                        _batchQueue.TryDequeue(out _);
+                        batch.Clear();
+                    }
+                }
+                
+            }
+            else
+            {
+                if (_batchQueue.TryPeek(out var batch))
+                {
+                    var status = await Context.DecodeAsync(batch, cancellation);
+                    if (status == DecodeResult.Ok)
+                    {
+                        Epoch++;
+                        _batchQueue.TryDequeue(out _);
+                        batch.Clear();
+                    }
+                }
+            }
+        });
         return status;
+    }
+
+    /// <summary>
+    /// Add a token to the batch for the given conversation.
+    /// </summary>
+    /// <param name="conversation"></param>
+    /// <param name="token"></param>
+    /// <param name="endIndex"></param>
+    /// <param name="ConversationId"></param>
+    /// <param name="logits"></param>
+    /// <returns></returns>
+    internal (int batchIndex, ulong requiredEpochs) AddTokenToConversation(
+        LLamaToken token, LLamaPos endIndex, LLamaSeqId ConversationId, bool logits)
+    {
+        _mutex.Wait();
+        if (!_batchQueue.TryPeek(out var batch) || batch.TokenCount >= Context.Params.BatchSize)
+        {
+            batch = new LLamaBatch();
+            _batchQueue.Enqueue(batch);
+        }
+        var batchIndex = batch.Add(token, endIndex, ConversationId, logits);
+        var requiredEpochs = (ulong) _batchQueue.Count;
+        _mutex.Release();
+        return (batchIndex, requiredEpochs);
     }
 
     /// <inheritdoc />
@@ -109,7 +206,10 @@ public sealed class BatchedExecutor
         if (IsDisposed)
             return;
         IsDisposed = true;
-
+        foreach (var batch in _batchQueue)
+            batch.Clear();
+        _batchQueue = null;
+        _mutex.Dispose();
         GC.SuppressFinalize(this);
 
         Context.Dispose();
@@ -117,6 +217,8 @@ public sealed class BatchedExecutor
 
     internal LLamaSeqId GetNextSequenceId()
     {
-        return checked((LLamaSeqId)_nextSequenceId++);
+        var id = checked((LLamaSeqId)_nextSequenceId);
+        Interlocked.Increment(ref _nextSequenceId);
+        return id;
     }
 }

--- a/LLama/Batched/Conversation.cs
+++ b/LLama/Batched/Conversation.cs
@@ -122,7 +122,6 @@ public sealed class Conversation
             throw new CannotSampleRequiresInferenceException();
         try
         {
-            Console.WriteLine($"SampleLogits for conversation {ConversationId}");
             return Executor.SampleLogits(ConversationId);
         }
         catch (InvalidOperationException)

--- a/LLama/Batched/Conversation.cs
+++ b/LLama/Batched/Conversation.cs
@@ -122,7 +122,7 @@ public sealed class Conversation
     /// <exception cref="ObjectDisposedException"></exception>
     /// <exception cref="CannotSampleRequiresPromptException">Thrown if this conversation was not prompted before the previous call to infer</exception>
     /// <exception cref="CannotSampleRequiresInferenceException">Thrown if Infer() must be called on the executor</exception>
-    public Span<float> Sample()
+    public float[] Sample()
     {
         AssertNotDisposed();
 
@@ -131,7 +131,7 @@ public sealed class Conversation
         if (_requiredEpoch > Executor.Epoch)
             throw new CannotSampleRequiresInferenceException();
 
-        return Executor.Context.NativeHandle.GetLogitsIth(_batchIndex);
+        return Executor.GetLogits(_requiredEpoch, _batchIndex);
     }
     #endregion
 

--- a/LLama/Batched/Conversation.cs
+++ b/LLama/Batched/Conversation.cs
@@ -169,13 +169,14 @@ public sealed class Conversation
         // No point doing anything if there is no actual prompt!
         if (tokens.Count == 0)
             return;
-
+        ulong requiredEpochs = 0;
         // Add the prompt to the batch
         for (var i = 0; i < tokens.Count; i++)
-            _batchIndex = Executor.Batch.Add(tokens[i], _end++, ConversationId, i == tokens.Count - 1);
+            (_batchIndex, requiredEpochs) = Executor.AddTokenToConversation(
+                tokens[i], _end++, ConversationId, i == tokens.Count - 1);
 
         // Mark this conversation as needing inference/sampling
-        _requiredEpoch = Executor.Epoch + 1;
+        _requiredEpoch = Executor.Epoch + requiredEpochs;
     }
 
     /// <summary>
@@ -190,10 +191,10 @@ public sealed class Conversation
         AssertCanBePrompted();
 
         // Add this token as input
-        _batchIndex = Executor.Batch.Add(token, _end++, ConversationId, true);
+        (_batchIndex, var requiredEpochs) = Executor.AddTokenToConversation(token, _end++, ConversationId, true);
 
         // Mark this conversation as needing inference/sampling
-        _requiredEpoch = Executor.Epoch + 1;
+        _requiredEpoch = Executor.Epoch + requiredEpochs;
     }
     #endregion
 

--- a/LLama/Native/LLamaBatch.cs
+++ b/LLama/Native/LLamaBatch.cs
@@ -44,6 +44,11 @@ public class LLamaBatch
     public bool[] Logits => Array.ConvertAll(_logits, Convert.ToBoolean);
 
     /// <summary>
+    /// Sequence IDs for tokens
+    /// </summary>
+    public LLamaSeqId[][] SequenceIds => _sequenceIds;
+
+    /// <summary>
     /// Create a new batch for submitting inputs to llama.cpp
     /// </summary>
     public LLamaBatch()

--- a/LLama/Native/LLamaBatch.cs
+++ b/LLama/Native/LLamaBatch.cs
@@ -39,6 +39,11 @@ public class LLamaBatch
     public int SequenceCapacity { get; private set; }
 
     /// <summary>
+    /// Compute logits flag for tokens
+    /// </summary>
+    public bool[] Logits => Array.ConvertAll(_logits, Convert.ToBoolean);
+
+    /// <summary>
     /// Create a new batch for submitting inputs to llama.cpp
     /// </summary>
     public LLamaBatch()


### PR DESCRIPTION
Some changes to illustrate my proposal [here](https://github.com/SciSharp/LLamaSharp/discussions/564).
Changes:
- Added a way to handle batch overflow in BatchedExecutor (executor real batch size > params batch size).  
  Basically now BatchedExecutor has internal Queue of batches to process and it adds there a new batch in case of overflow.
- Added some thread safety for BatchedExecutor.

Use case for this is to just run BatchedExecutor on a separate worker thread while using Conversation instances as front-end objects.