### PR TITLE
BatchedExecutor Fixed Forking

### DIFF
--- a/LLama/Batched/BatchedExecutor.cs
+++ b/LLama/Batched/BatchedExecutor.cs
@@ -89,7 +89,7 @@ public sealed class BatchedExecutor
         if (IsDisposed)
             throw new ObjectDisposedException(nameof(BatchedExecutor));
 
-        return new Conversation(this, GetNextSequenceId(), 0);
+        return new Conversation(this, GetNextSequenceId());
     }
 
     /// <summary>

--- a/LLama/Batched/BatchedExecutor.cs
+++ b/LLama/Batched/BatchedExecutor.cs
@@ -56,14 +56,6 @@ public sealed class BatchedExecutor
     }
 
     /// <summary>
-    /// Finalizer for BatchedExecutor
-    /// </summary>
-    ~BatchedExecutor()
-    {
-        Dispose();
-    }
-
-    /// <summary>
     /// Start a new <see cref="Conversation"/> with the given prompt
     /// </summary>
     /// <param name="prompt"></param>
@@ -122,8 +114,6 @@ public sealed class BatchedExecutor
         if (IsDisposed)
             return;
         IsDisposed = true;
-
-        GC.SuppressFinalize(this);
 
         Context.Dispose();
     }


### PR DESCRIPTION
Previously when a conversation was forked this would result in both the parent and the child sharing exactly the same logits.

Since sampling is allowed to modify logits this _could_ lead to issues in sampling. For example the first conversation samplied modifies the logits to apply a logit bias, the second conversation sampled will implicitly have the same bias!

Fixed this by setting a "forked" flag, logits are copied if this flag is set. Flag is cleared next time the conversation is prompted so this extra copying only happens once after a fork occurs.