### PR TITLE
Logging interceptor

### DIFF
--- a/LLama.Examples/Program.cs
+++ b/LLama.Examples/Program.cs
@@ -28,7 +28,7 @@ NativeLibraryConfig
    .WithLogCallback((level, message) =>
     {
         if (showLLamaCppLogs)
-            Console.WriteLine($"[llama {level}]: {message}");
+            Console.WriteLine($"[llama {level}]: {message.TrimEnd('\n')}");
     });
 
 // Calling this method forces loading to occur now.

--- a/LLama.Examples/Program.cs
+++ b/LLama.Examples/Program.cs
@@ -20,7 +20,14 @@ AnsiConsole.MarkupLineInterpolated(
 NativeLibraryConfig
    .Instance
    .WithCuda()
-   .WithLogs(LLamaLogLevel.Info);
+   .WithLogs(LLamaLogLevel.Debug)
+   .WithLogCallback((level, message) =>
+    {
+        var bg = Console.BackgroundColor;
+        Console.BackgroundColor = ConsoleColor.Magenta;
+        Console.WriteLine($"[{level}]: {message}");
+        Console.BackgroundColor = bg;
+    });
 
 // Calling this method forces loading to occur now.
 NativeApi.llama_empty_call();

--- a/LLama.Examples/Program.cs
+++ b/LLama.Examples/Program.cs
@@ -16,17 +16,19 @@ AnsiConsole.MarkupLineInterpolated(
 
     """);
 
-// Configure native library to use
+// Configure native library to use. This must be done before any other llama.cpp methods are called!
 NativeLibraryConfig
    .Instance
-   .WithCuda()
-   .WithLogs(LLamaLogLevel.Debug)
+   .WithCuda();
+
+// Configure logging. Change this to `true` to see log messages from llama.cpp
+var showLLamaCppLogs = false;
+NativeLibraryConfig
+   .Instance
    .WithLogCallback((level, message) =>
     {
-        var bg = Console.BackgroundColor;
-        Console.BackgroundColor = ConsoleColor.Magenta;
-        Console.WriteLine($"[{level}]: {message}");
-        Console.BackgroundColor = bg;
+        if (showLLamaCppLogs)
+            Console.WriteLine($"[llama {level}]: {message}");
     });
 
 // Calling this method forces loading to occur now.

--- a/LLama/GlobalSuppressions.cs
+++ b/LLama/GlobalSuppressions.cs
@@ -8,3 +8,5 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Interoperability", "CA1401:P/Invokes should not be visible", Justification = "LLamaSharp intentionally exports the native llama.cpp API")]
 
 [assembly: SuppressMessage("Style", "IDE0070:Use 'System.HashCode'", Justification = "Not compatible with netstandard2.0")]
+
+[assembly: SuppressMessage("Interoperability", "SYSLIB1054:Use 'LibraryImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time", Justification = "Not compatible with netstandard2.0")]

--- a/LLama/Native/LLamaLogLevel.cs
+++ b/LLama/Native/LLamaLogLevel.cs
@@ -1,8 +1,11 @@
-﻿namespace LLama.Native
-{   
-     /// <summary>
-     /// Severity level of a log message
-     /// </summary>
+﻿using System;
+using Microsoft.Extensions.Logging;
+
+namespace LLama.Native
+{
+    /// <summary>
+    /// Severity level of a log message
+    /// </summary>
     public enum LLamaLogLevel
     {
         /// <summary>
@@ -24,5 +27,20 @@
         /// Logs that are used for interactive investigation during development.
         /// </summary>
         Debug = 5,
+    }
+
+    internal static class LLamaLogLevelExtensions
+    {
+        public static LogLevel ToLogLevel(this LLamaLogLevel llama)
+        {
+            return (llama) switch
+            {
+                LLamaLogLevel.Error => LogLevel.Error,
+                LLamaLogLevel.Warning => LogLevel.Warning,
+                LLamaLogLevel.Info => LogLevel.Information,
+                LLamaLogLevel.Debug => LogLevel.Debug,
+                _ => throw new ArgumentOutOfRangeException(nameof(llama), llama, null)
+            };
+        }
     }
 }

--- a/LLama/Native/NativeApi.Load.cs
+++ b/LLama/Native/NativeApi.Load.cs
@@ -36,6 +36,15 @@ namespace LLama.Native
 
             // Init llama.cpp backend
             llama_backend_init();
+
+            // Set flag to indicate that this has been done. No native library config can be done after this point.
+            NativeLibraryConfig.LibraryHasLoaded = true;
+
+            // Now that the "loaded" flag is set, configure logging in llama.cpp
+            if (NativeLibraryConfig.Instance.LogCallback != null)
+                NativeLogConfig.llama_log_set(NativeLibraryConfig.Instance.LogCallback);
+            if (NativeLibraryConfig.Instance.LoggerCallback != null)
+                NativeLogConfig.llama_log_set(NativeLibraryConfig.Instance.LoggerCallback);
         }
 
 #if NET5_0_OR_GREATER

--- a/LLama/Native/NativeApi.Load.cs
+++ b/LLama/Native/NativeApi.Load.cs
@@ -87,6 +87,9 @@ namespace LLama.Native
 
         private static void Log(string message, LLamaLogLevel level)
         {
+            if (!message.EndsWith("\n"))
+                message += "\n";
+
             NativeLibraryConfig.Instance.LogCallback?.Invoke(level, message);
         }
 

--- a/LLama/Native/NativeApi.Load.cs
+++ b/LLama/Native/NativeApi.Load.cs
@@ -18,6 +18,9 @@ namespace LLama.Native
             // which llama.dll is used.
             SetDllImportResolver();
 
+            // Set flag to indicate that this point has been passed. No native library config can be done after this point.
+            NativeLibraryConfig.LibraryHasLoaded = true;
+
             // Immediately make a call which requires loading the llama DLL. This method call
             // can't fail unless the DLL hasn't been loaded.
             try
@@ -35,17 +38,14 @@ namespace LLama.Native
                     "to specify it at the very beginning of your code. For more informations about compilation, please refer to LLamaSharp repo on github.\n");
             }
 
-            // Init llama.cpp backend
-            llama_backend_init();
-
-            // Set flag to indicate that this has been done. No native library config can be done after this point.
-            NativeLibraryConfig.LibraryHasLoaded = true;
-
-            // Now that the "loaded" flag is set, configure logging in llama.cpp
+            // Now that the "loaded" flag is set configure logging in llama.cpp
             if (NativeLibraryConfig.Instance.LogCallback != null)
                 NativeLogConfig.llama_log_set(NativeLibraryConfig.Instance.LogCallback);
             if (NativeLibraryConfig.Instance.LoggerCallback != null)
                 NativeLogConfig.llama_log_set(NativeLibraryConfig.Instance.LoggerCallback);
+
+            // Init llama.cpp backend
+            llama_backend_init();
         }
 
 #if NET5_0_OR_GREATER

--- a/LLama/Native/NativeApi.cs
+++ b/LLama/Native/NativeApi.cs
@@ -6,13 +6,6 @@ using System.Runtime.InteropServices;
 namespace LLama.Native
 {
     /// <summary>
-    /// Callback from llama.cpp with log messages
-    /// </summary>
-    /// <param name="level"></param>
-    /// <param name="message"></param>
-	public delegate void LLamaLogCallback(LLamaLogLevel level, string message);
-
-    /// <summary>
     /// Direct translation of the llama.cpp API
     /// </summary>
 	public static partial class NativeApi
@@ -364,8 +357,11 @@ namespace LLama.Native
         /// Register a callback to receive llama log messages
         /// </summary>
         /// <param name="logCallback"></param>
-		[DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
-		public static extern void llama_log_set(LLamaLogCallback logCallback);
+        [Obsolete("Use `NativeLogConfig.llama_log_set` instead")]
+        public static void llama_log_set(NativeLogConfig.LLamaLogCallback logCallback)
+        {
+            NativeLogConfig.llama_log_set(logCallback);
+        }
 
         /// <summary>
         /// Clear the KV cache

--- a/LLama/Native/NativeLibraryConfig.cs
+++ b/LLama/Native/NativeLibraryConfig.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 
 namespace LLama.Native
 {
@@ -9,18 +10,8 @@ namespace LLama.Native
     /// Allows configuration of the native llama.cpp libraries to load and use.
     /// All configuration must be done before using **any** other LLamaSharp methods!
     /// </summary>
-    public sealed class NativeLibraryConfig
+    public sealed partial class NativeLibraryConfig
     {
-        /// <summary>
-        /// Get the config instance
-        /// </summary>
-        public static NativeLibraryConfig Instance { get; } = new();
-
-        /// <summary>
-        /// Check if the native library has already been loaded. Configuration cannot be modified if this is true.
-        /// </summary>
-        public static bool LibraryHasLoaded { get; internal set; } = false;
-
         private string? _libraryPath;
         private string? _libraryPathLLava;
 
@@ -35,12 +26,6 @@ namespace LLama.Native
         /// search directory -> priority level, 0 is the lowest.
         /// </summary>
         private readonly List<string> _searchDirectories = new List<string>();
-
-        private static void ThrowIfLoaded()
-        {
-            if (LibraryHasLoaded)
-                throw new InvalidOperationException("NativeLibraryConfig must be configured before using **any** other LLamaSharp methods!");
-        }
 
         #region configurators
         /// <summary>
@@ -308,6 +293,56 @@ namespace LLama.Native
         }
     }
 #endif
+
+    public sealed partial class NativeLibraryConfig
+    {
+        /// <summary>
+        /// Get the config instance
+        /// </summary>
+        public static NativeLibraryConfig Instance { get; } = new();
+
+        /// <summary>
+        /// Check if the native library has already been loaded. Configuration cannot be modified if this is true.
+        /// </summary>
+        public static bool LibraryHasLoaded { get; internal set; }
+
+        internal NativeLogConfig.LLamaLogCallback? LogCallback;
+        internal ILogger? LoggerCallback;
+
+        private static void ThrowIfLoaded()
+        {
+            if (LibraryHasLoaded)
+                throw new InvalidOperationException("NativeLibraryConfig must be configured before using **any** other LLamaSharp methods!");
+        }
+
+        /// <summary>
+        /// Set the log callback that will be used for all llama.cpp log messages
+        /// </summary>
+        /// <param name="callback"></param>
+        /// <exception cref="NotImplementedException"></exception>
+        public NativeLibraryConfig WithLogCallback(NativeLogConfig.LLamaLogCallback? callback)
+        {
+            ThrowIfLoaded();
+
+            LogCallback = callback;
+            LoggerCallback = null;
+            return this;
+        }
+
+        /// <summary>
+        /// Set the log callback that will be used for all llama.cpp log messages
+        /// </summary>
+        /// <param name="logger"></param>
+        /// <exception cref="NotImplementedException"></exception>
+        public NativeLibraryConfig WithLogCallback(ILogger? logger)
+        {
+            ThrowIfLoaded();
+
+            LogCallback = null;
+            LoggerCallback = logger;
+            return this;
+        }
+    }
 
     internal enum LibraryName
     {

--- a/LLama/Native/NativeLogConfig.cs
+++ b/LLama/Native/NativeLogConfig.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
+
+namespace LLama.Native;
+
+/// <summary>
+/// Methods for configuring llama.cpp logging
+/// </summary>
+public class NativeLogConfig
+{
+    /// <summary>
+    /// Callback from llama.cpp with log messages
+    /// </summary>
+    /// <param name="level"></param>
+    /// <param name="message"></param>
+    public delegate void LLamaLogCallback(LLamaLogLevel level, string message);
+
+    /// <summary>
+    /// Register a callback to receive llama log messages
+    /// </summary>
+    /// <param name="logCallback"></param>
+    [DllImport(NativeApi.libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "llama_log_set")]
+    private static extern void native_llama_log_set(LLamaLogCallback? logCallback);
+
+    /// <summary>
+    /// Register a callback to receive llama log messages
+    /// </summary>
+    /// <param name="logCallback"></param>
+#pragma warning disable IDE1006 // Naming Styles (name imitates llama.cpp)
+    public static void llama_log_set(LLamaLogCallback? logCallback)
+#pragma warning restore IDE1006 // Naming Styles
+    {
+        if (NativeLibraryConfig.LibraryHasLoaded)
+        {
+            // The library is loaded, just pass the callback directly to llama.cpp
+            native_llama_log_set(logCallback);
+        }
+        else
+        {
+            // We can't set the log method yet since that would cause the llama.dll to load.
+            // Instead configure it to be set when the native library loading is done
+            NativeLibraryConfig.Instance.WithLogCallback(logCallback);
+        }
+    }
+
+    /// <summary>
+    /// Register a callback to receive llama log messages
+    /// </summary>
+    /// <param name="logger"></param>
+#pragma warning disable IDE1006 // Naming Styles (name imitates llama.cpp)
+    public static void llama_log_set(ILogger? logger)
+#pragma warning restore IDE1006 // Naming Styles
+    {
+        // Clear the logger
+        if (logger == null)
+        {
+            llama_log_set((LLamaLogCallback?)null);
+            return;
+        }
+
+        // Bind a function that converts into the correct log level
+        llama_log_set((level, message) =>
+        {
+            switch (level)
+            {
+                case LLamaLogLevel.Error:
+                    logger.LogError("(llama.cpp): {message}", message);
+                    break;
+                case LLamaLogLevel.Warning:
+                    logger.LogWarning("(llama.cpp): {message}", message);
+                    break;
+                case LLamaLogLevel.Info:
+                    logger.LogInformation("(llama.cpp): {message}", message);
+                    break;
+                case LLamaLogLevel.Debug:
+                    logger.LogDebug("(llama.cpp): {message}", message);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(level), level, null);
+            }
+        });
+    }
+}

--- a/LLama/Native/NativeLogConfig.cs
+++ b/LLama/Native/NativeLogConfig.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
 
 namespace LLama.Native;
 
 /// <summary>
-/// Methods for configuring llama.cpp logging
+/// Configure llama.cpp logging
 /// </summary>
 public class NativeLogConfig
 {
@@ -62,23 +61,7 @@ public class NativeLogConfig
         // Bind a function that converts into the correct log level
         llama_log_set((level, message) =>
         {
-            switch (level)
-            {
-                case LLamaLogLevel.Error:
-                    logger.LogError("(llama.cpp): {message}", message);
-                    break;
-                case LLamaLogLevel.Warning:
-                    logger.LogWarning("(llama.cpp): {message}", message);
-                    break;
-                case LLamaLogLevel.Info:
-                    logger.LogInformation("(llama.cpp): {message}", message);
-                    break;
-                case LLamaLogLevel.Debug:
-                    logger.LogDebug("(llama.cpp): {message}", message);
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(level), level, null);
-            }
+            logger.Log(level.ToLogLevel(), "(llama.cpp): {message}", message);
         });
     }
 }

--- a/LLama/Native/NativeLogConfig.cs
+++ b/LLama/Native/NativeLogConfig.cs
@@ -72,7 +72,7 @@ public static class NativeLogConfig
         // Bind a function that converts into the correct log level
         llama_log_set((level, message) =>
         {
-            logger.Log(level.ToLogLevel(), "(llama.cpp): {message}", message);
+            logger.Log(level.ToLogLevel(), "{message}", message);
         });
     }
 }

--- a/LLama/Native/NativeLogConfig.cs
+++ b/LLama/Native/NativeLogConfig.cs
@@ -6,7 +6,7 @@ namespace LLama.Native;
 /// <summary>
 /// Configure llama.cpp logging
 /// </summary>
-public class NativeLogConfig
+public static class NativeLogConfig
 {
     /// <summary>
     /// Callback from llama.cpp with log messages
@@ -23,6 +23,11 @@ public class NativeLogConfig
     private static extern void native_llama_log_set(LLamaLogCallback? logCallback);
 
     /// <summary>
+    /// A GC handle for the current log callback to ensure the callback is not collected
+    /// </summary>
+    private static GCHandle? _currentLogCallbackHandle;
+
+    /// <summary>
     /// Register a callback to receive llama log messages
     /// </summary>
     /// <param name="logCallback"></param>
@@ -34,6 +39,12 @@ public class NativeLogConfig
         {
             // The library is loaded, just pass the callback directly to llama.cpp
             native_llama_log_set(logCallback);
+
+            // Save a GC handle, to ensure the callback is not collected
+            _currentLogCallbackHandle?.Free();
+            _currentLogCallbackHandle = null;
+            if (logCallback != null)
+                _currentLogCallbackHandle = GCHandle.Alloc(logCallback);
         }
         else
         {


### PR DESCRIPTION
Rewritten logging callbacks so it can be configured without touching native methods. This allows it to be used before llama.cpp dll is loaded.

Resolves #645 