### PR TITLE
Removed `ContextSize` from most examples

### DIFF
--- a/LLama.Examples/Examples/ChatChineseGB2312.cs
+++ b/LLama.Examples/Examples/ChatChineseGB2312.cs
@@ -27,7 +27,6 @@ public class ChatChineseGB2312
 
         var parameters = new ModelParams(modelPath)
         {
-            ContextSize = 1024,
             Seed = 1337,
             GpuLayerCount = 5,
             Encoding = Encoding.UTF8

--- a/LLama.Examples/Examples/ChatSessionStripRoleName.cs
+++ b/LLama.Examples/Examples/ChatSessionStripRoleName.cs
@@ -12,7 +12,6 @@ public class ChatSessionStripRoleName
 
         var parameters = new ModelParams(modelPath)
         {
-            ContextSize = 1024,
             Seed = 1337,
             GpuLayerCount = 5
         };

--- a/LLama.Examples/Examples/ChatSessionWithHistory.cs
+++ b/LLama.Examples/Examples/ChatSessionWithHistory.cs
@@ -10,7 +10,6 @@ public class ChatSessionWithHistory
 
         var parameters = new ModelParams(modelPath)
         {
-            ContextSize = 1024,
             Seed = 1337,
             GpuLayerCount = 5
         };

--- a/LLama.Examples/Examples/ChatSessionWithRestart.cs
+++ b/LLama.Examples/Examples/ChatSessionWithRestart.cs
@@ -10,7 +10,6 @@ public class ChatSessionWithRestart
 
         var parameters = new ModelParams(modelPath)
         {
-            ContextSize = 1024,
             Seed = 1337,
             GpuLayerCount = 5
         };

--- a/LLama.Examples/Examples/ChatSessionWithRoleName.cs
+++ b/LLama.Examples/Examples/ChatSessionWithRoleName.cs
@@ -10,7 +10,6 @@ public class ChatSessionWithRoleName
 
         var parameters = new ModelParams(modelPath)
         {
-            ContextSize = 1024,
             Seed = 1337,
             GpuLayerCount = 5
         };

--- a/LLama.Examples/Examples/GrammarJsonResponse.cs
+++ b/LLama.Examples/Examples/GrammarJsonResponse.cs
@@ -14,7 +14,6 @@ namespace LLama.Examples.Examples
 
             var parameters = new ModelParams(modelPath)
             {
-                ContextSize = 1024,
                 Seed = 1337,
                 GpuLayerCount = 5
             };

--- a/LLama.Examples/Examples/InstructModeExecute.cs
+++ b/LLama.Examples/Examples/InstructModeExecute.cs
@@ -13,7 +13,6 @@ namespace LLama.Examples.Examples
 
             var parameters = new ModelParams(modelPath)
             {
-                ContextSize = 1024,
                 Seed = 1337,
                 GpuLayerCount = 5
             };

--- a/LLama.Examples/Examples/InteractiveModeExecute.cs
+++ b/LLama.Examples/Examples/InteractiveModeExecute.cs
@@ -13,7 +13,6 @@ namespace LLama.Examples.Examples
 
             var parameters = new ModelParams(modelPath)
             {
-                ContextSize = 1024,
                 Seed = 1337,
                 GpuLayerCount = 5
             };

--- a/LLama.Examples/Examples/LoadAndSaveSession.cs
+++ b/LLama.Examples/Examples/LoadAndSaveSession.cs
@@ -12,7 +12,6 @@ namespace LLama.Examples.Examples
 
             var parameters = new ModelParams(modelPath)
             {
-                ContextSize = 1024,
                 Seed = 1337,
                 GpuLayerCount = 5
             };

--- a/LLama.Examples/Examples/LoadAndSaveState.cs
+++ b/LLama.Examples/Examples/LoadAndSaveState.cs
@@ -13,7 +13,6 @@ namespace LLama.Examples.Examples
 
             var parameters = new ModelParams(modelPath)
             {
-                ContextSize = 1024,
                 Seed = 1337,
                 GpuLayerCount = 5
             };

--- a/LLama.Examples/Examples/SpeechChat.cs
+++ b/LLama.Examples/Examples/SpeechChat.cs
@@ -50,7 +50,7 @@ NOTE: You may need to poke around with the voice detection threshold, based on y
 
             public LlamaSession_SpeechListener(SpeechRecognitionServer server)
             {
-                var parameters = new ModelParams(UserSettings.GetModelPath()) { ContextSize = 1024, Seed = 1337, GpuLayerCount = 99 };
+                var parameters = new ModelParams(UserSettings.GetModelPath()) { Seed = 1337, GpuLayerCount = 99 };
                 model = LLamaWeights.LoadFromFile(parameters);
                 context = model.CreateContext(parameters);
                 executor = new InteractiveExecutor(context);

--- a/LLama.Examples/Examples/StatelessModeExecute.cs
+++ b/LLama.Examples/Examples/StatelessModeExecute.cs
@@ -11,7 +11,6 @@ namespace LLama.Examples.Examples
 
             var parameters = new ModelParams(modelPath)
             {
-                ContextSize = 1024,
                 Seed = 1337,
                 GpuLayerCount = 5
             };

--- a/LLama.Examples/Examples/TalkToYourself.cs
+++ b/LLama.Examples/Examples/TalkToYourself.cs
@@ -21,7 +21,7 @@ namespace LLama.Examples.Examples
             var bob = new InteractiveExecutor(bobCtx);
 
             // Initial alice prompt
-            var alicePrompt = "Transcript of a dialog, where the Alice interacts a person named Bob. Alice is friendly, kind, honest and good at writing.\nAlice: Hello";
+            var alicePrompt = "Transcript of a dialog, where the Alice interacts with a person named Bob. Alice is friendly, kind, honest and good at writing.\nAlice: Hello";
             var aliceResponse = await Prompt(alice, ConsoleColor.Green, alicePrompt, false, false);
 
             // Initial bob prompt


### PR DESCRIPTION
Removed `ContextSize` from most examples.

If it's not set it's retrieved from the model, which is usually what you want. Leaving it in the examples is just unnecessary complexity.