### PR TITLE
Llava Initial approach to clear images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
             os: ubuntu-latest
             config: release
           - build: osx-release
-            os: macos-latest-xlarge
+            os: macos-latest
             config: release
           - build: windows-release
             os: windows-2019

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
             os: ubuntu-latest
             config: release
           - build: osx-release
-            os: macos-latest
+            os: macos-latest-xlarge
             config: release
           - build: windows-release
             os: windows-2019

--- a/LLama.Examples/Examples/LlavaInteractiveModeExecute.cs
+++ b/LLama.Examples/Examples/LlavaInteractiveModeExecute.cs
@@ -1,8 +1,6 @@
 ﻿using System.Text.RegularExpressions;
-using LLama.Batched;
 using LLama.Common;
 using Spectre.Console;
-using LLama.Abstractions;
 using LLama.Native;
 
 namespace LLama.Examples.Examples
@@ -20,9 +18,8 @@ namespace LLama.Examples.Examples
 
             var prompt = $"{{{modelImage}}}\nUSER:\nProvide a full description of the image.\nASSISTANT:\n";
 
-            var parameters = new ModelParams(modelPath)
-            {
-            };
+            var parameters = new ModelParams(modelPath);
+
             using var model = LLamaWeights.LoadFromFile(parameters);
             using var context = model.CreateContext(parameters);
             
@@ -45,16 +42,16 @@ namespace LLama.Examples.Examples
                 var imageMatches = Regex.Matches(prompt, "{([^}]*)}").Select(m => m.Value);
                 var imageCount = imageMatches.Count();
                 var hasImages = imageCount > 0;
-                byte[][] imageBytes = null;
 
                 if (hasImages)
                 {
                     var imagePathsWithCurlyBraces = Regex.Matches(prompt, "{([^}]*)}").Select(m => m.Value);
-                    var imagePaths = Regex.Matches(prompt, "{([^}]*)}").Select(m => m.Groups[1].Value);
+                    var imagePaths = Regex.Matches(prompt, "{([^}]*)}").Select(m => m.Groups[1].Value).ToList();
 
+                    List<byte[]> imageBytes;
                     try
                     {
-                        imageBytes = imagePaths.Select(File.ReadAllBytes).ToArray();
+                        imageBytes = imagePaths.Select(File.ReadAllBytes).ToList();
                     }
                     catch (IOException exception)
                     {
@@ -77,10 +74,7 @@ namespace LLama.Examples.Examples
                     foreach (var path in imagePathsWithCurlyBraces)
                     {
                         // First image replace to tag <image, the rest of the images delete the tag
-                        if (index++ == 0)
-                            prompt = prompt.Replace(path, "<image>");
-                        else
-                            prompt = prompt.Replace(path, "");
+                        prompt = prompt.Replace(path, index++ == 0 ? "<image>" : "");
                     }
 
                   
@@ -105,7 +99,7 @@ namespace LLama.Examples.Examples
                     //
                     foreach (var image in imagePaths)
                     {
-                        ex.Images.Add(File.ReadAllBytes(image));
+                        ex.Images.Add(await File.ReadAllBytesAsync(image));
                     }
                 }
 
@@ -121,7 +115,7 @@ namespace LLama.Examples.Examples
                 
                 // let the user finish with exit
                 //
-                if (prompt.Equals("/exit", StringComparison.OrdinalIgnoreCase))
+                if (prompt != null && prompt.Equals("/exit", StringComparison.OrdinalIgnoreCase))
                     break;
 
             }

--- a/LLama.Examples/Examples/LlavaInteractiveModeExecute.cs
+++ b/LLama.Examples/Examples/LlavaInteractiveModeExecute.cs
@@ -3,6 +3,7 @@ using LLama.Batched;
 using LLama.Common;
 using Spectre.Console;
 using LLama.Abstractions;
+using LLama.Native;
 
 namespace LLama.Examples.Examples
 {
@@ -21,9 +22,6 @@ namespace LLama.Examples.Examples
 
             var parameters = new ModelParams(modelPath)
             {
-                ContextSize = 4096,
-                Seed = 1337,
-                GpuLayerCount = 10
             };
             using var model = LLamaWeights.LoadFromFile(parameters);
             using var context = model.CreateContext(parameters);
@@ -69,6 +67,9 @@ namespace LLama.Examples.Examples
                         break;
                     }
 
+                    // Each prompt with images we clear cache
+                    // When the prompt contains images we clear KV_CACHE to restart conversation
+                    ex.Context.NativeHandle.KvCacheRemove( LLamaSeqId.Zero, -1, -1 );
 
                     int index = 0;
                     foreach (var path in imagePathsWithCurlyBraces)

--- a/LLama.Examples/Examples/LlavaInteractiveModeExecute.cs
+++ b/LLama.Examples/Examples/LlavaInteractiveModeExecute.cs
@@ -69,6 +69,8 @@ namespace LLama.Examples.Examples
 
                     // Each prompt with images we clear cache
                     // When the prompt contains images we clear KV_CACHE to restart conversation
+                    // See:
+                    // https://github.com/ggerganov/llama.cpp/discussions/3620
                     ex.Context.NativeHandle.KvCacheRemove( LLamaSeqId.Zero, -1, -1 );
 
                     int index = 0;

--- a/LLama/Abstractions/ILLamaExecutor.cs
+++ b/LLama/Abstractions/ILLamaExecutor.cs
@@ -25,7 +25,7 @@ namespace LLama.Abstractions
         public LLavaWeights? ClipModel { get;  }
 
         /// <summary>
-        /// List of images: Image filen path, uri or image byte array. See ImageData.
+        /// List of images: List of images in byte array format.
         /// </summary>
         public List<byte[]> Images { get; }
 

--- a/LLama/LLamaExecutorBase.cs
+++ b/LLama/LLamaExecutorBase.cs
@@ -79,7 +79,7 @@ namespace LLama
         public LLavaWeights? ClipModel { get;  }
 
         /// <inheritdoc />
-        public List<byte[]> Images { get; set; }
+        public List<byte[]> Images { get; }
 
         /// <summary>
         /// Current "mu" value for mirostat sampling

--- a/docs/Examples/LLavaInteractiveModeExecute.md
+++ b/docs/Examples/LLavaInteractiveModeExecute.md
@@ -2,9 +2,9 @@
 
 ```cs
 using System.Text.RegularExpressions;
-using LLama.Batched;
 using LLama.Common;
 using Spectre.Console;
+using LLama.Native;
 
 namespace LLama.Examples.Examples
 {
@@ -21,11 +21,8 @@ namespace LLama.Examples.Examples
 
             var prompt = $"{{{modelImage}}}\nUSER:\nProvide a full description of the image.\nASSISTANT:\n";
 
-            var parameters = new ModelParams(modelPath)
-            {
-                ContextSize = 4096,
-                Seed = 1337,
-            };
+            var parameters = new ModelParams(modelPath);
+
             using var model = LLamaWeights.LoadFromFile(parameters);
             using var context = model.CreateContext(parameters);
             
@@ -48,16 +45,16 @@ namespace LLama.Examples.Examples
                 var imageMatches = Regex.Matches(prompt, "{([^}]*)}").Select(m => m.Value);
                 var imageCount = imageMatches.Count();
                 var hasImages = imageCount > 0;
-                byte[][] imageBytes = null;
 
                 if (hasImages)
                 {
                     var imagePathsWithCurlyBraces = Regex.Matches(prompt, "{([^}]*)}").Select(m => m.Value);
-                    var imagePaths = Regex.Matches(prompt, "{([^}]*)}").Select(m => m.Groups[1].Value);
+                    var imagePaths = Regex.Matches(prompt, "{([^}]*)}").Select(m => m.Groups[1].Value).ToList();
 
+                    List<byte[]> imageBytes;
                     try
                     {
-                        imageBytes = imagePaths.Select(File.ReadAllBytes).ToArray();
+                        imageBytes = imagePaths.Select(File.ReadAllBytes).ToList();
                     }
                     catch (IOException exception)
                     {
@@ -70,15 +67,17 @@ namespace LLama.Examples.Examples
                         break;
                     }
 
+                    // Each prompt with images we clear cache
+                    // When the prompt contains images we clear KV_CACHE to restart conversation
+                    // See:
+                    // https://github.com/ggerganov/llama.cpp/discussions/3620
+                    ex.Context.NativeHandle.KvCacheRemove( LLamaSeqId.Zero, -1, -1 );
 
                     int index = 0;
                     foreach (var path in imagePathsWithCurlyBraces)
                     {
                         // First image replace to tag <image, the rest of the images delete the tag
-                        if (index++ == 0)
-                            prompt = prompt.Replace(path, "<image>");
-                        else
-                            prompt = prompt.Replace(path, "");
+                        prompt = prompt.Replace(path, index++ == 0 ? "<image>" : "");
                     }
 
                   
@@ -101,7 +100,10 @@ namespace LLama.Examples.Examples
 
                     // Initilize Images in executor
                     //
-                    ex.ImagePaths = imagePaths.ToList();
+                    foreach (var image in imagePaths)
+                    {
+                        ex.Images.Add(await File.ReadAllBytesAsync(image));
+                    }
                 }
 
                 Console.ForegroundColor = Color.White;
@@ -116,7 +118,7 @@ namespace LLama.Examples.Examples
                 
                 // let the user finish with exit
                 //
-                if (prompt.Equals("/exit", StringComparison.OrdinalIgnoreCase))
+                if (prompt != null && prompt.Equals("/exit", StringComparison.OrdinalIgnoreCase))
                     break;
 
             }

--- a/docs/Tutorials/Executors.md
+++ b/docs/Tutorials/Executors.md
@@ -28,9 +28,9 @@ public interface ILLamaExecutor
     public LLavaWeights? ClipModel { get;  }        
 
     /// <summary>
-    /// List of images: Image filename and path (jpeg images).
+    /// List of images: List of images in byte array format.
     /// </summary>
-    public List<string> ImagePaths { get; set; }
+    public List<byte[]> Images { get; }
 
 
     /// <summary>


### PR DESCRIPTION
This changes the Interactive executor to be able to continue the conversation including new images. The example (outside the executor) clears the KV_CACHE to reset the previous images.