### PR TITLE
BatchedExecutor Save/Load

### DIFF
--- a/LLama.Examples/ExampleRunner.cs
+++ b/LLama.Examples/ExampleRunner.cs
@@ -26,6 +26,7 @@ public class ExampleRunner
         { "Semantic Kernel: Prompt", SemanticKernelPrompt.Run },
         { "Semantic Kernel: Chat", SemanticKernelChat.Run },
         { "Semantic Kernel: Store", SemanticKernelMemory.Run },
+        { "Batched Executor: Save/Load", BatchedExecutorSaveAndLoad.Run },
         { "Batched Executor: Fork", BatchedExecutorFork.Run },
         { "Batched Executor: Rewind", BatchedExecutorRewind.Run },
         { "Batched Executor: Guidance", BatchedExecutorGuidance.Run },

--- a/LLama.Examples/Examples/BatchedExecutorSaveAndLoad.cs
+++ b/LLama.Examples/Examples/BatchedExecutorSaveAndLoad.cs
@@ -1,0 +1,80 @@
+﻿using LLama.Batched;
+using LLama.Common;
+using LLama.Native;
+using LLama.Sampling;
+using Spectre.Console;
+
+namespace LLama.Examples.Examples;
+
+/// <summary>
+/// This demonstrates generating multiple replies to the same prompt, with a shared cache
+/// </summary>
+public class BatchedExecutorSaveAndLoad
+{
+    private const int n_len = 18;
+
+    public static async Task Run()
+    {
+        string modelPath = UserSettings.GetModelPath();
+
+        var parameters = new ModelParams(modelPath);
+        using var model = LLamaWeights.LoadFromFile(parameters);
+
+        var prompt = AnsiConsole.Ask("Prompt (or ENTER for default):", "Not many people know that");
+
+        // Create an executor that can evaluate a batch of conversations together
+        using var executor = new BatchedExecutor(model, parameters);
+
+        // Print some info
+        var name = executor.Model.Metadata.GetValueOrDefault("general.name", "unknown model name");
+        Console.WriteLine($"Created executor with model: {name}");
+
+        // Create a conversation
+        var conversation = executor.Create();
+        conversation.Prompt(prompt);
+
+        // Run inference loop
+        var decoder = new StreamingTokenDecoder(executor.Context);
+        var sampler = new DefaultSamplingPipeline();
+        var lastToken = (LLamaToken)0;
+        for (var i = 0; i < n_len; i++)
+        {
+            await executor.Infer();
+
+            var token = sampler.Sample(executor.Context.NativeHandle, conversation.Sample(), ReadOnlySpan<LLamaToken>.Empty);
+            lastToken = token;
+            decoder.Add(token);
+            conversation.Prompt(token);
+        }
+
+        // Can't save a conversation while RequiresInference is true
+        if (conversation.RequiresInference)
+            await executor.Infer();
+
+        // Save this conversation and dispose it
+        conversation.Save("demo_conversation.state");
+        conversation.Dispose();
+        AnsiConsole.WriteLine($"Saved state: {new FileInfo("demo_conversation.state").Length} bytes");
+
+        // Now create a new conversation by loading that state
+        conversation = executor.Load("demo_conversation.state");
+        AnsiConsole.WriteLine("Loaded state");
+
+        // Prompt it again with the last token, so we can continue generating
+        conversation.Rewind(1);
+        conversation.Prompt(lastToken);
+
+        // Continue generating text
+        for (var i = 0; i < n_len; i++)
+        {
+            await executor.Infer();
+
+            var token = sampler.Sample(executor.Context.NativeHandle, conversation.Sample(), ReadOnlySpan<LLamaToken>.Empty);
+            decoder.Add(token);
+            conversation.Prompt(token);
+        }
+
+        // Display final ouput
+        AnsiConsole.MarkupLine($"[red]{prompt}{decoder.Read()}[/]");
+    }
+}

--- a/LLama/Batched/BatchedExecutor.cs
+++ b/LLama/Batched/BatchedExecutor.cs
@@ -102,6 +102,22 @@ public sealed class BatchedExecutor
     }
 
     /// <summary>
+    /// Load a conversation that was previously saved into memory. Once loaded the conversation will need to be prompted.
+    /// </summary>
+    /// <param name="state"></param>
+    /// <returns></returns>
+    /// <exception cref="ObjectDisposedException"></exception>
+    public Conversation Load(Conversation.State state)
+    {
+        if (IsDisposed)
+            throw new ObjectDisposedException(nameof(BatchedExecutor));
+
+        var conversation = Create();
+        conversation.Load(state);
+        return conversation;
+    }
+
+    /// <summary>
     /// Run inference for all conversations in the batch which have pending tokens.
     ///
     /// If the result is `NoKvSlot` then there is not enough memory for inference, try disposing some conversation

--- a/LLama/Batched/BatchedExecutor.cs
+++ b/LLama/Batched/BatchedExecutor.cs
@@ -85,6 +85,23 @@ public sealed class BatchedExecutor
     }
 
     /// <summary>
+    /// Load a conversation that was previously saved to a file. Once loaded the conversation will
+    /// need to be prompted.
+    /// </summary>
+    /// <param name="filepath"></param>
+    /// <returns></returns>
+    /// <exception cref="ObjectDisposedException"></exception>
+    public Conversation Load(string filepath)
+    {
+        if (IsDisposed)
+            throw new ObjectDisposedException(nameof(BatchedExecutor));
+
+        var conversation = Create();
+        conversation.Load(filepath);
+        return conversation;
+    }
+
+    /// <summary>
     /// Run inference for all conversations in the batch which have pending tokens.
     ///
     /// If the result is `NoKvSlot` then there is not enough memory for inference, try disposing some conversation

--- a/LLama/Batched/Exceptions.cs
+++ b/LLama/Batched/Exceptions.cs
@@ -57,18 +57,6 @@ public class CannotSampleRequiresPromptException
 }
 
 /// <summary>
-/// This exception is thrown when <see cref="Conversation.Fork"/> is called when <see cref="Conversation.RequiresInference"/> = true
-/// </summary>
-public class CannotForkWhileRequiresInferenceException
-    : ExperimentalBatchedExecutorException
-{
-    internal CannotForkWhileRequiresInferenceException()
-        : base("Cannot `Fork()` a conversation while RequiresInference is true")
-    {
-    }
-}
-
-/// <summary>
 /// This exception is thrown when <see cref="Conversation.Modify"/> is called when <see cref="Conversation.RequiresInference"/> = true
 /// </summary>
 public class CannotModifyWhileRequiresInferenceException
@@ -76,6 +64,20 @@ public class CannotModifyWhileRequiresInferenceException
 {
     internal CannotModifyWhileRequiresInferenceException()
         : base("Cannot `Modify()` a conversation while RequiresInference is true")
+    {
+    }
+}
+
+/// <summary>
+/// This exception is thrown when "Save()" is called on a <see cref="Conversation"/> which has
+/// already been prompted and before "Infer()" has been called.
+/// <see cref="BatchedExecutor"/>.
+/// </summary>
+public class CannotSaveWhileRequiresInferenceException
+    : ExperimentalBatchedExecutorException
+{
+    internal CannotSaveWhileRequiresInferenceException()
+        : base("Must call `Infer()` before saving this Conversation")
     {
     }
 }

--- a/LLama/Batched/LLamaContextExtensions.cs
+++ b/LLama/Batched/LLamaContextExtensions.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Buffers.Binary;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using LLama.Native;
+
+namespace LLama.Batched;
+
+internal static class LLamaContextExtensions
+{
+    private const uint FileHeaderMagic = 3430400180;
+
+    /// <summary>
+    /// Save the state of a particular sequence to specified path. Also save some extra data which will be returned when loading.
+    /// Data saved with this method <b>must</b> be saved with <see cref="LoadState(LLamaContext, string, LLamaSeqId, out byte[])"/>
+    /// </summary>
+    /// <param name="context"></param>
+    /// <param name="filename"></param>
+    /// <param name="sequence"></param>
+    /// <param name="header"></param>
+    internal static void SaveState(this LLamaContext context, string filename, LLamaSeqId sequence, ReadOnlySpan<byte> header)
+    {
+        // Delete that file before overwriting it
+        if (File.Exists(filename))
+            File.Delete(filename);
+
+        // Estimate size of state to write to disk, this is always equal to or greater than the actual size
+        var estimatedStateSize = checked((long)context.NativeHandle.GetStateSize(sequence));
+
+        // Space for "extra" byte plus a 8 byte header
+        var prefixSize = header.Length + 8;
+
+        // Add enough space for the "extra" data and a 6 byte header
+        var totalFileSize = prefixSize + estimatedStateSize;
+
+        // Map the file and write the bytes directly to it.
+        long writtenBytes = 0;
+        using (var file = MemoryMappedFile.CreateFromFile(filename, FileMode.Create, null, totalFileSize))
+        {
+            using (var view = file.CreateViewAccessor(0, totalFileSize))
+            {
+                unsafe
+                {
+                    byte* ptr = null;
+                    view.SafeMemoryMappedViewHandle.AcquirePointer(ref ptr);
+                    try
+                    {
+                        // Write prefix data
+                        BinaryPrimitives.WriteUInt32BigEndian(new Span<byte>(ptr + writtenBytes, 4), FileHeaderMagic);
+                        writtenBytes += 4;
+                        BinaryPrimitives.WriteUInt32BigEndian(new Span<byte>(ptr + writtenBytes, 4), (uint)header.Length);
+                        writtenBytes += 4;
+                        header.CopyTo(new Span<byte>(ptr + writtenBytes, header.Length));
+                        writtenBytes += header.Length;
+
+                        // Write state data
+                        writtenBytes += (long)context.NativeHandle.GetState(ptr + writtenBytes, (ulong)estimatedStateSize, sequence);
+                    }
+                    finally
+                    {
+                        view.SafeMemoryMappedViewHandle.ReleasePointer();
+                    }
+                }
+            }
+        }
+
+        // Truncate the file to the actual size of data that was written
+        using (var fileStream = new FileStream(filename, FileMode.Open))
+            fileStream.SetLength(writtenBytes);
+    }
+
+    /// <summary>
+    /// Load the state from the specified path into a particular sequence. Also reading header data. Must only be used with
+    /// data previously saved with <see cref="SaveState(LLamaContext, string, LLamaSeqId, ReadOnlySpan{byte})"/>
+    /// </summary>
+    /// <param name="context"></param>
+    /// <param name="filename"></param>
+    /// <param name="sequence"></param>
+    /// <param name="header"></param>
+    /// <exception cref="InvalidOperationException"></exception>
+    internal static void LoadState(this LLamaContext context, string filename, LLamaSeqId sequence, out byte[] header)
+    {
+        // Map state file into memory and pass that pointer directly to `llama_set_state_data` to load from
+        using (var file = MemoryMappedFile.CreateFromFile(filename, FileMode.Open, null))
+        using (var view = file.CreateViewAccessor())
+        {
+            unsafe
+            {
+                byte* ptr = null;
+                view.SafeMemoryMappedViewHandle.AcquirePointer(ref ptr);
+                try
+                {
+                    var readBytes = 0;
+
+                    // Read header
+                    var magic = BinaryPrimitives.ReadUInt32BigEndian(new ReadOnlySpan<byte>(ptr + readBytes, 4));
+                    readBytes += 4;
+                    if (magic != FileHeaderMagic)
+                        throw new InvalidOperationException("Invalid file header");
+
+                    var headerLength = checked((int)BinaryPrimitives.ReadUInt32BigEndian(new ReadOnlySpan<byte>(ptr + readBytes, 4)));
+                    readBytes += 4;
+
+                    header = new byte[headerLength];
+                    new Span<byte>(ptr + readBytes, headerLength).CopyTo(header);
+                    readBytes += headerLength;
+
+                    context.NativeHandle.SetState(ptr + readBytes, sequence);
+                }
+                finally
+                {
+                    view.SafeMemoryMappedViewHandle.ReleasePointer();
+                }
+            }
+        }
+    }
+}

--- a/LLama/LLamaContext.cs
+++ b/LLama/LLamaContext.cs
@@ -1,6 +1,7 @@
 ﻿using LLama.Exceptions;
 using LLama.Native;
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -153,6 +154,8 @@ namespace LLama
         }
 
         #region state load/save
+        private const uint FileHeaderMagic = 3430400180;
+
         /// <summary>
         /// Save the state to specified path.
         /// </summary>
@@ -221,6 +224,64 @@ namespace LLama
                     finally
                     {
                         view.SafeMemoryMappedViewHandle.ReleasePointer();
+                    }
+                }
+            }
+
+            // Truncate the file to the actual size of data that was written
+            using (var fileStream = new FileStream(filename, FileMode.Open))
+                fileStream.SetLength(writtenBytes);
+        }
+
+        /// <summary>
+        /// Save the state of a particular sequence to specified path. Also save some extra data which will be returned when loading.
+        /// Data saved with this method <b>must</b> be saved with <see cref="LoadState(string, LLamaSeqId, out byte[])"/>
+        /// </summary>
+        /// <param name="filename"></param>
+        /// <param name="sequence"></param>
+        /// <param name="header"></param>
+        internal void SaveState(string filename, LLamaSeqId sequence, ReadOnlySpan<byte> header)
+        {
+            // Delete that file before overwriting it
+            if (File.Exists(filename))
+                File.Delete(filename);
+
+            // Estimate size of state to write to disk, this is always equal to or greater than the actual size
+            var estimatedStateSize = checked((long)NativeHandle.GetStateSize(sequence));
+
+            // Space for "extra" byte plus a 8 byte header
+            var prefixSize = header.Length + 8;
+
+            // Add enough space for the "extra" data and a 6 byte header
+            var totalFileSize = prefixSize + estimatedStateSize;
+
+            // Map the file and write the bytes directly to it.
+            long writtenBytes = 0;
+            using (var file = MemoryMappedFile.CreateFromFile(filename, FileMode.Create, null, totalFileSize))
+            {
+                using (var view = file.CreateViewAccessor(0, totalFileSize))
+                {
+                    unsafe
+                    {
+                        byte* ptr = null;
+                        view.SafeMemoryMappedViewHandle.AcquirePointer(ref ptr);
+                        try
+                        {
+                            // Write prefix data
+                            BinaryPrimitives.WriteUInt32BigEndian(new Span<byte>(ptr + writtenBytes, 4), FileHeaderMagic);
+                            writtenBytes += 4;
+                            BinaryPrimitives.WriteUInt32BigEndian(new Span<byte>(ptr + writtenBytes, 4), (uint)header.Length);
+                            writtenBytes += 4;
+                            header.CopyTo(new Span<byte>(ptr + writtenBytes, header.Length));
+                            writtenBytes += header.Length;
+
+                            // Write state data
+                            writtenBytes += (long)NativeHandle.GetState(ptr + writtenBytes, (ulong)estimatedStateSize, sequence);
+                        }
+                        finally
+                        {
+                            view.SafeMemoryMappedViewHandle.ReleasePointer();
+                        }
                     }
                 }
             }
@@ -350,6 +411,51 @@ namespace LLama
                     try
                     {
                         NativeHandle.SetState(ptr, sequence);
+                    }
+                    finally
+                    {
+                        view.SafeMemoryMappedViewHandle.ReleasePointer();
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Load the state from the specified path into a particular sequence. Also reading header data. Must only be used with
+        /// data previously saved with <see cref="SaveState(string, LLamaSeqId, ReadOnlySpan&lt;byte&gt;)"/>
+        /// </summary>
+        /// <param name="filename"></param>
+        /// <param name="sequence"></param>
+        /// <param name="header"></param>
+        /// <exception cref="InvalidOperationException"></exception>
+        internal void LoadState(string filename, LLamaSeqId sequence, out byte[] header)
+        {
+            // Map state file into memory and pass that pointer directly to `llama_set_state_data` to load from
+            using (var file = MemoryMappedFile.CreateFromFile(filename, FileMode.Open, null))
+            using (var view = file.CreateViewAccessor())
+            {
+                unsafe
+                {
+                    byte* ptr = null;
+                    view.SafeMemoryMappedViewHandle.AcquirePointer(ref ptr);
+                    try
+                    {
+                        var readBytes = 0;
+
+                        // Read header
+                        var magic = BinaryPrimitives.ReadUInt32BigEndian(new ReadOnlySpan<byte>(ptr + readBytes, 4));
+                        readBytes += 4;
+                        if (magic != FileHeaderMagic)
+                            throw new InvalidOperationException("Invalid file header");
+
+                        var headerLength = checked((int)BinaryPrimitives.ReadUInt32BigEndian(new ReadOnlySpan<byte>(ptr + readBytes, 4)));
+                        readBytes += 4;
+
+                        header = new byte[headerLength];
+                        new Span<byte>(ptr + readBytes, headerLength).CopyTo(header);
+                        readBytes += headerLength;
+
+                        NativeHandle.SetState(ptr + readBytes, sequence);
                     }
                     finally
                     {

--- a/LLama/LLamaContext.cs
+++ b/LLama/LLamaContext.cs
@@ -153,8 +153,6 @@ namespace LLama
         }
 
         #region state load/save
-        
-
         /// <summary>
         /// Save the state to specified path.
         /// </summary>

--- a/LLama/LLamaContext.cs
+++ b/LLama/LLamaContext.cs
@@ -1,7 +1,6 @@
 ﻿using LLama.Exceptions;
 using LLama.Native;
 using System;
-using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -154,7 +153,7 @@ namespace LLama
         }
 
         #region state load/save
-        private const uint FileHeaderMagic = 3430400180;
+        
 
         /// <summary>
         /// Save the state to specified path.
@@ -224,64 +223,6 @@ namespace LLama
                     finally
                     {
                         view.SafeMemoryMappedViewHandle.ReleasePointer();
-                    }
-                }
-            }
-
-            // Truncate the file to the actual size of data that was written
-            using (var fileStream = new FileStream(filename, FileMode.Open))
-                fileStream.SetLength(writtenBytes);
-        }
-
-        /// <summary>
-        /// Save the state of a particular sequence to specified path. Also save some extra data which will be returned when loading.
-        /// Data saved with this method <b>must</b> be saved with <see cref="LoadState(string, LLamaSeqId, out byte[])"/>
-        /// </summary>
-        /// <param name="filename"></param>
-        /// <param name="sequence"></param>
-        /// <param name="header"></param>
-        internal void SaveState(string filename, LLamaSeqId sequence, ReadOnlySpan<byte> header)
-        {
-            // Delete that file before overwriting it
-            if (File.Exists(filename))
-                File.Delete(filename);
-
-            // Estimate size of state to write to disk, this is always equal to or greater than the actual size
-            var estimatedStateSize = checked((long)NativeHandle.GetStateSize(sequence));
-
-            // Space for "extra" byte plus a 8 byte header
-            var prefixSize = header.Length + 8;
-
-            // Add enough space for the "extra" data and a 6 byte header
-            var totalFileSize = prefixSize + estimatedStateSize;
-
-            // Map the file and write the bytes directly to it.
-            long writtenBytes = 0;
-            using (var file = MemoryMappedFile.CreateFromFile(filename, FileMode.Create, null, totalFileSize))
-            {
-                using (var view = file.CreateViewAccessor(0, totalFileSize))
-                {
-                    unsafe
-                    {
-                        byte* ptr = null;
-                        view.SafeMemoryMappedViewHandle.AcquirePointer(ref ptr);
-                        try
-                        {
-                            // Write prefix data
-                            BinaryPrimitives.WriteUInt32BigEndian(new Span<byte>(ptr + writtenBytes, 4), FileHeaderMagic);
-                            writtenBytes += 4;
-                            BinaryPrimitives.WriteUInt32BigEndian(new Span<byte>(ptr + writtenBytes, 4), (uint)header.Length);
-                            writtenBytes += 4;
-                            header.CopyTo(new Span<byte>(ptr + writtenBytes, header.Length));
-                            writtenBytes += header.Length;
-
-                            // Write state data
-                            writtenBytes += (long)NativeHandle.GetState(ptr + writtenBytes, (ulong)estimatedStateSize, sequence);
-                        }
-                        finally
-                        {
-                            view.SafeMemoryMappedViewHandle.ReleasePointer();
-                        }
                     }
                 }
             }
@@ -411,51 +352,6 @@ namespace LLama
                     try
                     {
                         NativeHandle.SetState(ptr, sequence);
-                    }
-                    finally
-                    {
-                        view.SafeMemoryMappedViewHandle.ReleasePointer();
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// Load the state from the specified path into a particular sequence. Also reading header data. Must only be used with
-        /// data previously saved with <see cref="SaveState(string, LLamaSeqId, ReadOnlySpan&lt;byte&gt;)"/>
-        /// </summary>
-        /// <param name="filename"></param>
-        /// <param name="sequence"></param>
-        /// <param name="header"></param>
-        /// <exception cref="InvalidOperationException"></exception>
-        internal void LoadState(string filename, LLamaSeqId sequence, out byte[] header)
-        {
-            // Map state file into memory and pass that pointer directly to `llama_set_state_data` to load from
-            using (var file = MemoryMappedFile.CreateFromFile(filename, FileMode.Open, null))
-            using (var view = file.CreateViewAccessor())
-            {
-                unsafe
-                {
-                    byte* ptr = null;
-                    view.SafeMemoryMappedViewHandle.AcquirePointer(ref ptr);
-                    try
-                    {
-                        var readBytes = 0;
-
-                        // Read header
-                        var magic = BinaryPrimitives.ReadUInt32BigEndian(new ReadOnlySpan<byte>(ptr + readBytes, 4));
-                        readBytes += 4;
-                        if (magic != FileHeaderMagic)
-                            throw new InvalidOperationException("Invalid file header");
-
-                        var headerLength = checked((int)BinaryPrimitives.ReadUInt32BigEndian(new ReadOnlySpan<byte>(ptr + readBytes, 4)));
-                        readBytes += 4;
-
-                        header = new byte[headerLength];
-                        new Span<byte>(ptr + readBytes, headerLength).CopyTo(header);
-                        readBytes += headerLength;
-
-                        NativeHandle.SetState(ptr + readBytes, sequence);
                     }
                     finally
                     {


### PR DESCRIPTION
Added the ability to save and load individual conversations in a batched executor.

 - Added `BatchedExecutor.Load(filepath)` method
 - Added `Conversation.Save(filepath)` method
 - Added new (currently internal) `SaveState`/`LoadState` methods in LLamaContext which can stash some extra binary data in the header. This can be used where other state needs to be saved alongside the raw KV cache.
 - New example showing saving/loading a conversation