### PR TITLE
Removed Unnecessary Constructor From Safe Handles

### DIFF
--- a/LLama/Native/NativeApi.Grammar.cs
+++ b/LLama/Native/NativeApi.Grammar.cs
@@ -13,7 +13,7 @@ namespace LLama.Native
 		/// <param name="start_rule_index"></param>
 		/// <returns></returns>
         [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern unsafe IntPtr llama_grammar_init(LLamaGrammarElement** rules, ulong n_rules, ulong start_rule_index);
+        public static extern unsafe SafeLLamaGrammarHandle llama_grammar_init(LLamaGrammarElement** rules, ulong n_rules, ulong start_rule_index);
 
         /// <summary>
         /// Free all memory from the given SafeLLamaGrammarHandle
@@ -28,7 +28,7 @@ namespace LLama.Native
 		/// <param name="grammar"></param>
 		/// <returns></returns>
         [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr llama_grammar_copy(SafeLLamaGrammarHandle grammar);
+        public static extern SafeLLamaGrammarHandle llama_grammar_copy(SafeLLamaGrammarHandle grammar);
 
 		/// <summary>
 		/// Apply constraints from grammar

--- a/LLama/Native/SafeLLamaGrammarHandle.cs
+++ b/LLama/Native/SafeLLamaGrammarHandle.cs
@@ -16,15 +16,6 @@ namespace LLama.Native
         : SafeLLamaHandleBase
     {
         #region construction/destruction
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="handle"></param>
-        internal SafeLLamaGrammarHandle(IntPtr handle)
-            : base(handle, true)
-        {
-        }
-
         /// <inheritdoc />
         protected override bool ReleaseHandle()
         {
@@ -97,11 +88,11 @@ namespace LLama.Native
         /// <exception cref="RuntimeError"></exception>
         public static unsafe SafeLLamaGrammarHandle Create(LLamaGrammarElement** rules, ulong nrules, ulong start_rule_index)
         {
-            var grammar_ptr = NativeApi.llama_grammar_init(rules, nrules, start_rule_index);
-            if (grammar_ptr == IntPtr.Zero)
+            var grammar = NativeApi.llama_grammar_init(rules, nrules, start_rule_index);
+            if (grammar == null)
                 throw new RuntimeError("Failed to create grammar from rules");
 
-            return new(grammar_ptr);
+            return grammar;
         }
         #endregion
 
@@ -111,7 +102,7 @@ namespace LLama.Native
         /// <returns></returns>
         public SafeLLamaGrammarHandle Clone()
         {
-            return new SafeLLamaGrammarHandle(NativeApi.llama_grammar_copy(this));
+            return NativeApi.llama_grammar_copy(this);
         }
 
         /// <summary>

--- a/LLama/Native/SafeLLamaGrammarHandle.cs
+++ b/LLama/Native/SafeLLamaGrammarHandle.cs
@@ -89,7 +89,7 @@ namespace LLama.Native
         public static unsafe SafeLLamaGrammarHandle Create(LLamaGrammarElement** rules, ulong nrules, ulong start_rule_index)
         {
             var grammar = NativeApi.llama_grammar_init(rules, nrules, start_rule_index);
-            if (grammar == null)
+            if (grammar is null)
                 throw new RuntimeError("Failed to create grammar from rules");
 
             return grammar;

--- a/LLama/Native/SafeLlavaImageEmbedHandle.cs
+++ b/LLama/Native/SafeLlavaImageEmbedHandle.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using LLama;
-using LLama.Exceptions;
 
 
 namespace LLama.Native
@@ -15,15 +10,6 @@ namespace LLama.Native
     public sealed class SafeLlavaImageEmbedHandle
         : SafeLLamaHandleBase
     {
-
-        private SafeLlavaImageEmbedHandle(IntPtr handle)
-            : base(handle, true)
-        {
-        }
-        
-        private SafeLlavaImageEmbedHandle()
-        {}
-
         /// <summary>
         /// Create an image embed from an image file
         /// </summary>

--- a/LLama/Native/SafeLlavaModelHandle.cs
+++ b/LLama/Native/SafeLlavaModelHandle.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using LLama;
 using LLama.Exceptions;
 
 
@@ -16,15 +12,6 @@ namespace LLama.Native
     public sealed class SafeLlavaModelHandle
         : SafeLLamaHandleBase
     {
-
-        private SafeLlavaModelHandle(IntPtr handle)
-            : base(handle, true)
-        {
-        }
-
-        private SafeLlavaModelHandle()
-        {}
-        
         /// <inheritdoc />
         protected override bool ReleaseHandle()
         {


### PR DESCRIPTION
 - Removed unnecessary constructors from safe handles
 - Returning `SafeLLamaGrammarHandle` directly from `llama_grammar_init` and `llama_grammar_copy` instead of raw `IntPtr`