### PR TITLE
Fixed Minor Issues With Model Loading

### DIFF
--- a/LLama/Native/SafeLlamaModelHandle.cs
+++ b/LLama/Native/SafeLlamaModelHandle.cs
@@ -121,7 +121,7 @@ namespace LLama.Native
                     throw new InvalidOperationException($"Model file '{modelPath}' is not readable");
 
             return llama_load_model_from_file(modelPath, lparams)
-                ?? throw new LoadWeightsFailedException($"Failed to load model {modelPath}.");
+                ?? throw new LoadWeightsFailedException(modelPath);
         }
 
         #region native API

--- a/LLama/Native/SafeLlavaModelHandle.cs
+++ b/LLama/Native/SafeLlavaModelHandle.cs
@@ -53,7 +53,7 @@ namespace LLama.Native
                     throw new InvalidOperationException($"Llava MMP Model file '{modelPath}' is not readable");
           
             return clip_model_load(modelPath, verbosity)
-                ?? throw new RuntimeError($"Failed to load LLaVa model {modelPath}.");          
+                ?? throw new LoadWeightsFailedException(modelPath);
         }
 
         /// <summary>


### PR DESCRIPTION
 - Using more specific `LoadWeightsFailedException` when a llava model fails to load instead of generic `RuntimeError`
 - Passing model path, instead of a message, to `LoadWeightsFailedException` constructor in llama model handle