### PR TITLE
Slightly Safer Quantize Params

### DIFF
--- a/LLama/LLamaQuantizer.cs
+++ b/LLama/LLamaQuantizer.cs
@@ -34,12 +34,12 @@ namespace LLama
             quantizeParams.nthread = nthread;
             quantizeParams.allow_requantize = allowRequantize;
             quantizeParams.quantize_output_tensor = quantizeOutputTensor;
-            //todo: fill in other quantize params fields.
 
-            unsafe
-            {
-                return NativeApi.llama_model_quantize(srcFileName, dstFilename, &quantizeParams) == 0;
-            }
+            // todo: fill in other quantize params fields.
+            // This method could probably do with a redesign - passing in a config object (maybe directly
+            // expose `LLamaModelQuantizeParams`) instead of an ever growing list of method parameters!
+
+            return NativeApi.llama_model_quantize(srcFileName, dstFilename, ref quantizeParams) == 0;
         }
 
         /// <summary>

--- a/LLama/Native/NativeApi.Quantize.cs
+++ b/LLama/Native/NativeApi.Quantize.cs
@@ -12,6 +12,6 @@ namespace LLama.Native
         /// <param name="param"></param>
         /// <returns>Returns 0 on success</returns>
         [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern unsafe uint llama_model_quantize(string fname_inp, string fname_out, LLamaModelQuantizeParams* param);
+        public static extern uint llama_model_quantize(string fname_inp, string fname_out, ref LLamaModelQuantizeParams param);
     }
 }


### PR DESCRIPTION
Modified `llama_model_quantize` to accept argument by `ref` instead of pointer. One less `unsafe` required.