### PR TITLE
Add LLaMA3 chat session example.

### DIFF
--- a/LLama.Examples/ExampleRunner.cs
+++ b/LLama.Examples/ExampleRunner.cs
@@ -5,6 +5,7 @@ public class ExampleRunner
 {
     private static readonly Dictionary<string, Func<Task>> Examples = new()
     {
+        { "Chat Session: LLama3", LLama3ChatSession.Run },
         { "Chat Session: History", ChatSessionWithHistory.Run },
         { "Chat Session: Role names", ChatSessionWithRoleName.Run },
         { "Chat Session: Role names stripped", ChatSessionStripRoleName.Run },

--- a/LLama.Examples/Examples/LLama3ChatSession.cs
+++ b/LLama.Examples/Examples/LLama3ChatSession.cs
@@ -1,0 +1,126 @@
+﻿using LLama.Abstractions;
+using LLama.Common;
+
+namespace LLama.Examples.Examples;
+
+// When using chatsession, it's a common case that you want to strip the role names
+// rather than display them. This example shows how to use transforms to strip them.
+public class LLama3ChatSession
+{
+    public static async Task Run()
+    {
+        string modelPath = UserSettings.GetModelPath();
+
+        var parameters = new ModelParams(modelPath)
+        {
+            Seed = 1337,
+            GpuLayerCount = 10
+        };
+        using var model = LLamaWeights.LoadFromFile(parameters);
+        using var context = model.CreateContext(parameters);
+        var executor = new InteractiveExecutor(context);
+
+        var chatHistoryJson = File.ReadAllText("Assets/chat-with-bob.json");
+        ChatHistory chatHistory = ChatHistory.FromJson(chatHistoryJson) ?? new ChatHistory();
+
+        ChatSession session = new(executor, chatHistory);
+        session.WithHistoryTransform(new LLama3HistoryTransform());
+        session.WithOutputTransform(new LLamaTransforms.KeywordTextOutputStreamTransform(
+            new string[] { "User:", "Assistant:", "�" },
+            redundancyLength: 5));
+
+        InferenceParams inferenceParams = new InferenceParams()
+        {
+            Temperature = 0.6f,
+            AntiPrompts = new List<string> { "User:" }
+        };
+
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        Console.WriteLine("The chat session has started.");
+
+        // show the prompt
+        Console.ForegroundColor = ConsoleColor.Green;
+        string userInput = Console.ReadLine() ?? "";
+
+        while (userInput != "exit")
+        {
+            await foreach (
+                var text
+                in session.ChatAsync(
+                    new ChatHistory.Message(AuthorRole.User, userInput),
+                    inferenceParams))
+            {
+                Console.ForegroundColor = ConsoleColor.White;
+                Console.Write(text);
+            }
+            Console.WriteLine();
+
+            Console.ForegroundColor = ConsoleColor.Green;
+            userInput = Console.ReadLine() ?? "";
+
+            Console.ForegroundColor = ConsoleColor.White;
+        }
+    }
+
+    class LLama3HistoryTransform : IHistoryTransform
+    {
+        /// <summary>
+        /// Convert a ChatHistory instance to plain text.
+        /// </summary>
+        /// <param name="history">The ChatHistory instance</param>
+        /// <returns></returns>
+        public string HistoryToText(ChatHistory history)
+        {
+            string res = Bos;
+            foreach (var message in history.Messages)
+            {
+                res += EncodeMessage(message);
+            }
+            res += EncodeHeader(new ChatHistory.Message(AuthorRole.Assistant, ""));
+            return res;
+        }
+
+        private string EncodeHeader(ChatHistory.Message message)
+        {
+            string res = StartHeaderId;
+            res += message.AuthorRole.ToString();
+            res += EndHeaderId;
+            res += "\n\n";
+            return res;
+        }
+
+        private string EncodeMessage(ChatHistory.Message message)
+        {
+            string res = EncodeHeader(message);
+            res += message.Content;
+            res += EndofTurn;
+            return res;
+        }
+
+        /// <summary>
+        /// Converts plain text to a ChatHistory instance.
+        /// </summary>
+        /// <param name="role">The role for the author.</param>
+        /// <param name="text">The chat history as plain text.</param>
+        /// <returns>The updated history.</returns>
+        public ChatHistory TextToHistory(AuthorRole role, string text)
+        {
+            return new ChatHistory(new ChatHistory.Message[] { new ChatHistory.Message(role, text) });
+        }
+
+        /// <summary>
+        /// Copy the transform.
+        /// </summary>
+        /// <returns></returns>
+        public IHistoryTransform Clone()
+        {
+            return new LLama3HistoryTransform();
+        }
+
+        private const string StartHeaderId = "<|start_header_id|>";
+        private const string EndHeaderId = "<|end_header_id|>";
+        private const string Bos = "<|begin_of_text|>";
+        private const string Eos = "<|end_of_text|>";
+        private const string EndofTurn = "<|eot_id|>";
+    }
+}

--- a/LLama/LLamaTransforms.cs
+++ b/LLama/LLamaTransforms.cs
@@ -235,7 +235,7 @@ namespace LLama
                     var current = string.Join("", window);
                     if (_keywords.Any(x => current.Contains(x)))
                     {
-                        var matchedKeyword = _keywords.First(x => current.Contains(x));
+                        var matchedKeywords = _keywords.Where(x => current.Contains(x));
                         int total = window.Count;
                         for (int i = 0; i < total; i++)
                         {
@@ -243,7 +243,11 @@ namespace LLama
                         }
                         if (!_removeAllMatchedTokens)
                         {
-                            yield return current.Replace(matchedKeyword, "");
+                            foreach(var keyword in matchedKeywords)
+                            {
+                                current = current.Replace(keyword, "");
+                            }
+                            yield return current;
                         }
                     }
                     if (current.Length >= _maxKeywordLength)


### PR DESCRIPTION
1. Add an example for LLaMA3 chat session. I have to say that the implementation is a bit ugly due to some of unreasonable designs a year ago. We've been aware of it and is on the way to rebuild them and add chat template. Anyway, we have an example that works well with LLaMA3 now!
2. Fix a BUG in `KeywordOutputTransform`. Some tokens were not removed when there're more than one matched tokens appears at the same time.

It works well for me on Windows with CUDA11.

![image](https://github.com/SciSharp/LLamaSharp/assets/47343601/44e7cf6e-d9ba-4b85-8377-b58d573a7204)
