### PR TITLE
Remove `Conversation.Prompt(String)`

### DIFF
--- a/LLama.Examples/Examples/BatchedExecutorFork.cs
+++ b/LLama.Examples/Examples/BatchedExecutorFork.cs
@@ -32,7 +32,7 @@ public class BatchedExecutorFork
 
         // Evaluate the initial prompt to create one conversation
         using var start = executor.Create();
-        start.Prompt(prompt);
+        start.Prompt(executor.Context.Tokenize(prompt));
         await executor.Infer();
 
         // Create the root node of the tree

--- a/LLama.Examples/Examples/BatchedExecutorGuidance.cs
+++ b/LLama.Examples/Examples/BatchedExecutorGuidance.cs
@@ -34,9 +34,9 @@ public class BatchedExecutorGuidance
 
         // Load the two prompts into two conversations
         using var guided = executor.Create();
-        guided.Prompt(positivePrompt);
+        guided.Prompt(executor.Context.Tokenize(positivePrompt));
         using var guidance = executor.Create();
-        guidance.Prompt(negativePrompt);
+        guidance.Prompt(executor.Context.Tokenize(negativePrompt));
 
         // Run inference to evaluate prompts
         await AnsiConsole

--- a/LLama.Examples/Examples/BatchedExecutorRewind.cs
+++ b/LLama.Examples/Examples/BatchedExecutorRewind.cs
@@ -33,7 +33,7 @@ public class BatchedExecutorRewind
 
         // Evaluate the initial prompt to create one conversation
         using var conversation = executor.Create();
-        conversation.Prompt(prompt);
+        conversation.Prompt(executor.Context.Tokenize(prompt));
         
         // Create the start node wrapping the conversation
         var node = new Node(executor.Context);

--- a/LLama.Examples/Examples/BatchedExecutorSaveAndLoad.cs
+++ b/LLama.Examples/Examples/BatchedExecutorSaveAndLoad.cs
@@ -31,7 +31,7 @@ public class BatchedExecutorSaveAndLoad
 
         // Create a conversation
         var conversation = executor.Create();
-        conversation.Prompt(prompt);
+        conversation.Prompt(executor.Context.Tokenize(prompt));
 
         // Run inference loop
         var decoder = new StreamingTokenDecoder(executor.Context);

--- a/LLama/Batched/BatchedExecutor.cs
+++ b/LLama/Batched/BatchedExecutor.cs
@@ -56,23 +56,6 @@ public sealed class BatchedExecutor
     }
 
     /// <summary>
-    /// Start a new <see cref="Conversation"/> with the given prompt
-    /// </summary>
-    /// <param name="prompt"></param>
-    /// <returns></returns>
-    [Obsolete("Use BatchedExecutor.Create instead")]
-    public Conversation Prompt(string prompt)
-    {
-        if (IsDisposed)
-            throw new ObjectDisposedException(nameof(BatchedExecutor));
-
-        var conversation = Create();
-        conversation.Prompt(prompt);
-
-        return conversation;
-    }
-
-    /// <summary>
     /// Start a new <see cref="Conversation"/>
     /// </summary>
     /// <returns></returns>

--- a/LLama/Batched/Conversation.cs
+++ b/LLama/Batched/Conversation.cs
@@ -166,11 +166,12 @@ public sealed class Conversation
     /// </summary>
     /// <param name="input"></param>
     /// <returns></returns>
-    public void Prompt(string input)
+    [Obsolete("Tokenize the text and pass the tokens instead")]
+    public void Prompt(string input, bool addBos, bool special)
     {
         AssertCanBePrompted();
 
-        Prompt(Executor.Context.Tokenize(input));
+        Prompt(Executor.Context.Tokenize(input, addBos, special));
     }
 
     /// <summary>


### PR DESCRIPTION
Removed (marked as obsolete) prompting with a string for `Conversation`. Tokenization requires extra parameters (e.g. addBos, special) which require special considersation. For now it's better to tokenize using other tools and pass the tokens directly. Once templating and tokenization are more complete we can come back and look at how best to integrate them into `Conversation` (if at all).