### PR TITLE
Fix cublas build action

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -121,6 +121,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ggerganov/llama.cpp
+          ref: '${{ github.event.inputs.llama_cpp_commit }}'
       - name: Download dependencies - Linux
         if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: |


### PR DESCRIPTION
Fixed cublas action always compiling `master` instead of the specified commit