### PR TITLE
KernelMemory bug fix

### DIFF
--- a/LLama.KernelMemory/BuilderExtensions.cs
+++ b/LLama.KernelMemory/BuilderExtensions.cs
@@ -81,15 +81,15 @@ namespace LLamaSharp.KernelMemory
         {
             var parameters = new ModelParams(config.ModelPath)
             {
-                ContextSize = config?.ContextSize ?? 2048,
-                Seed = config?.Seed ?? 0,
-                GpuLayerCount = config?.GpuLayerCount ?? 20,
+                ContextSize = config.ContextSize ?? 2048,
+                Seed = config.Seed ?? 0,
+                GpuLayerCount = config.GpuLayerCount ?? 20,
                 Embeddings = true,
-                MainGpu = config?.MainGpu ?? 0,
-                SplitMode = config?.SplitMode ?? GPUSplitMode.None,
+                MainGpu = config.MainGpu,
+                SplitMode = config.SplitMode
             };
 
-            if (weights == null)
+            if (weights == null || context == null)
             {
                 weights = LLamaWeights.LoadFromFile(parameters);
                 context = weights.CreateContext(parameters);

--- a/LLama.KernelMemory/BuilderExtensions.cs
+++ b/LLama.KernelMemory/BuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.KernelMemory;
+using Microsoft.KernelMemory;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -96,8 +96,7 @@ namespace LLamaSharp.KernelMemory
             }
 
             var executor = new StatelessExecutor(weights, parameters);
-            var embedder = new LLamaEmbedder(weights, parameters);
-            builder.WithLLamaSharpTextEmbeddingGeneration(new LLamaSharpTextEmbeddingGenerator(embedder));
+            builder.WithLLamaSharpTextEmbeddingGeneration(new LLamaSharpTextEmbeddingGenerator(config, weights));
             builder.WithLLamaSharpTextGeneration(new LlamaSharpTextGenerator(weights, context, executor, config?.DefaultInferenceParams));
             return builder;
         }		

--- a/LLama.KernelMemory/LLamaSharpTextEmbeddingGenerator.cs
+++ b/LLama.KernelMemory/LLamaSharpTextEmbeddingGenerator.cs
@@ -30,12 +30,12 @@ namespace LLamaSharp.KernelMemory
             this._config = config;
             var @params = new ModelParams(_config.ModelPath)
             {
-                ContextSize = config?.ContextSize ?? 2048,
-                Seed = config?.Seed ?? 0,
-                GpuLayerCount = config?.GpuLayerCount ?? 20,
+                ContextSize = config.ContextSize ?? 2048,
+                Seed = config.Seed ?? 0,
+                GpuLayerCount = config.GpuLayerCount ?? 20,
                 Embeddings = true,
-                MainGpu = _config?.MainGpu ?? 0,
-                SplitMode = _config?.SplitMode ?? GPUSplitMode.None
+                MainGpu = _config.MainGpu,
+                SplitMode = _config.SplitMode
             };
             _weights = LLamaWeights.LoadFromFile(@params);
             _embedder = new LLamaEmbedder(_weights, @params);
@@ -53,12 +53,12 @@ namespace LLamaSharp.KernelMemory
             this._config = config;
             var @params = new ModelParams(_config.ModelPath)
             {
-                ContextSize = config?.ContextSize ?? 2048,
-                Seed = config?.Seed ?? 0,
-                GpuLayerCount = config?.GpuLayerCount ?? 20,
+                ContextSize = config.ContextSize ?? 2048,
+                Seed = config.Seed ?? 0,
+                GpuLayerCount = config.GpuLayerCount ?? 20,
                 Embeddings = true,
-                MainGpu = _config?.MainGpu ?? 0,
-                SplitMode = _config?.SplitMode ?? GPUSplitMode.None
+                MainGpu = _config.MainGpu,
+                SplitMode = _config.SplitMode
             };
             _weights = weights;
             _embedder = new LLamaEmbedder(_weights, @params);

--- a/LLama.KernelMemory/LLamaSharpTextEmbeddingGenerator.cs
+++ b/LLama.KernelMemory/LLamaSharpTextEmbeddingGenerator.cs
@@ -1,5 +1,6 @@
-﻿using LLama;
+using LLama;
 using LLama.Common;
+using LLama.Native;
 using Microsoft.KernelMemory;
 using Microsoft.KernelMemory.AI;
 
@@ -29,9 +30,12 @@ namespace LLamaSharp.KernelMemory
             this._config = config;
             var @params = new ModelParams(_config.ModelPath)
             {
+                ContextSize = config?.ContextSize ?? 2048,
+                Seed = config?.Seed ?? 0,
+                GpuLayerCount = config?.GpuLayerCount ?? 20,
                 Embeddings = true,
-                MainGpu = _config.MainGpu,
-                SplitMode = _config.SplitMode
+                MainGpu = _config?.MainGpu ?? 0,
+                SplitMode = _config?.SplitMode ?? GPUSplitMode.None
             };
             _weights = LLamaWeights.LoadFromFile(@params);
             _embedder = new LLamaEmbedder(_weights, @params);
@@ -49,9 +53,12 @@ namespace LLamaSharp.KernelMemory
             this._config = config;
             var @params = new ModelParams(_config.ModelPath)
             {
+                ContextSize = config?.ContextSize ?? 2048,
+                Seed = config?.Seed ?? 0,
+                GpuLayerCount = config?.GpuLayerCount ?? 20,
                 Embeddings = true,
-                MainGpu = _config.MainGpu,
-                SplitMode = _config.SplitMode
+                MainGpu = _config?.MainGpu ?? 0,
+                SplitMode = _config?.SplitMode ?? GPUSplitMode.None
             };
             _weights = weights;
             _embedder = new LLamaEmbedder(_weights, @params);


### PR DESCRIPTION
While using WithLLamaSharpDefaults it was not possible to dispose GPU memory because the embedding was not defined well. This PR fixes that issue and also fixes some small problems with not setting all important model parameters.