### PR TITLE
Fix context params defaults

### DIFF
--- a/LLama.Web/Common/ModelOptions.cs
+++ b/LLama.Web/Common/ModelOptions.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using LLama.Abstractions;
 using LLama.Native;
 
@@ -32,7 +32,7 @@ namespace LLama.Web.Common
         public uint SeqMax { get; }
 
         /// <inheritdoc />
-        public uint Seed { get; set; } = 1686349486;
+        public uint? Seed { get; set; } = 1686349486;
 
         public bool Embeddings { get; }
 
@@ -109,7 +109,7 @@ namespace LLama.Web.Common
         public bool VocabOnly { get; set; }
 
         /// <inheritdoc />
-        public float DefragThreshold { get; set; }
+        public float? DefragThreshold { get; set; }
 
         /// <inheritdoc />
         public LLamaPoolingType PoolingType { get; set; }

--- a/LLama/Abstractions/IContextParams.cs
+++ b/LLama/Abstractions/IContextParams.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using LLama.Native;
 
 namespace LLama.Abstractions;
@@ -31,7 +31,7 @@ public interface IContextParams
     /// <summary>
     /// Seed for the random number generator (seed)
     /// </summary>
-    uint Seed { get; }
+    uint? Seed { get; }
 
     /// <summary>
     /// If true, extract embeddings (together with logits).
@@ -109,9 +109,9 @@ public interface IContextParams
     bool NoKqvOffload { get; }
 
     /// <summary>
-    /// defragment the KV cache if holes/size &gt; defrag_threshold, Set to &lt; 0 to disable (default)
+    /// defragment the KV cache if holes/size &gt; defrag_threshold, Set to <see langword="null"/> or &lt; 0 to disable (default)
     /// </summary>
-    float DefragThreshold { get; }
+    float? DefragThreshold { get; }
 
     /// <summary>
     /// How to pool (sum) embedding results by sequence id (ignored if no pooling layer)

--- a/LLama/Common/ModelParams.cs
+++ b/LLama/Common/ModelParams.cs
@@ -1,4 +1,4 @@
-﻿using LLama.Abstractions;
+using LLama.Abstractions;
 using System.Text;
 using System.Text.Json.Serialization;
 using LLama.Native;
@@ -28,7 +28,7 @@ namespace LLama.Common
         public uint SeqMax { get; set; } = 1;
 
         /// <inheritdoc />
-        public uint Seed { get; set; } = 0xFFFFFFFF;
+        public uint? Seed { get; set; }
 
         /// <inheritdoc />
         public bool UseMemorymap { get; set; } = true;
@@ -100,7 +100,7 @@ namespace LLama.Common
         public bool NoKqvOffload { get; set; }
 
         /// <inheritdoc />
-        public float DefragThreshold { get; set; }
+        public float? DefragThreshold { get; set; }
 
         /// <inheritdoc />
         public LLamaPoolingType PoolingType { get; set; } = LLamaPoolingType.Unspecified;

--- a/LLama/Extensions/IContextParamsExtensions.cs
+++ b/LLama/Extensions/IContextParamsExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using LLama.Abstractions;
 using LLama.Native;
@@ -26,7 +26,7 @@ namespace LLama.Extensions
             result.n_batch = @params.BatchSize;
             result.n_ubatch = @params.UBatchSize;
             result.n_seq_max = @params.SeqMax;
-            result.seed = @params.Seed;
+            result.seed = @params.Seed ?? 0xFFFFFFFF;
             result.embeddings = @params.Embeddings;
             result.rope_freq_base = @params.RopeFrequencyBase ?? 0;
             result.rope_freq_scale = @params.RopeFrequencyScale ?? 0;
@@ -39,7 +39,7 @@ namespace LLama.Extensions
             result.yarn_orig_ctx = @params.YarnOriginalContext ?? 0;
             result.rope_scaling_type = @params.YarnScalingType ?? RopeScalingType.Unspecified;
 
-            result.defrag_threshold = @params.DefragThreshold;
+            result.defrag_threshold = @params.DefragThreshold ?? -1;
 
             result.cb_eval = IntPtr.Zero;
             result.cb_eval_user_data = IntPtr.Zero;


### PR DESCRIPTION
fixes #716 

- DefragThreshold is nullable now and disabled by default
- Seed is nullable now

There is also a possibility that the user will use special values directly instead of null. For example 0xFFFFFFFF for seed and it will lead to the same behavior as null (random seed). May not be obvious, but not sure what wee can do with that.
