### PR TITLE
feat: separate the sequence and conversation.

### DIFF
--- a/LLama/Batched/Sequence.cs
+++ b/LLama/Batched/Sequence.cs
@@ -1,0 +1,52 @@
+using LLama.Native;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace LLama.Batched
+{
+    /// <summary>
+    /// Stores the data, status, and other information of a sequence when inference the LLM.
+    /// </summary>
+    internal class Sequence
+    {
+        private LLamaPos _end;
+        private bool _forked;
+
+        /// <summary>
+        /// Whether the sequence is a forked one.
+        /// </summary>
+        public bool Forked
+        {
+            get => _forked;
+            internal set => _forked = value;
+        }
+
+        /// <summary>
+        /// Unique ID for this conversation
+        /// </summary>
+        public LLamaSeqId Id { get; }
+
+        /// <summary>
+        /// Total number of tokens in this conversation, cannot exceed the context length.
+        /// </summary>
+        public LLamaPos TokenCount
+        {
+            get => _end.Value;
+            internal set => _end = value;
+        }
+
+        internal Sequence(LLamaSeqId id, bool forked)
+        {
+            Id = id;
+            _forked = forked;
+        }
+
+        internal Sequence(LLamaSeqId id, bool forked, LLamaPos tokensCount)
+        {
+            Id = id;
+            _forked = forked;
+            _end = tokensCount;
+        }
+    }
+}


### PR DESCRIPTION
This PR separates `Sequence` from `Conversation`. It introduces no change from the user's view but only change the internal implementation.

In llama.cpp APIs, the sequence is only a concept. There isn't any struct named Sequence, nor any method named *_sequence_*. The only major binding struct related to batched inference is `llama_batch`. Therefore I believe we should not make `Sequence` something that directly interop with llama.cpp native APIs. Instead, it's better to consider it as a container for the data and status during the inference. Thus it will be more extensible. For example, we could switch a sequence in the conversation. 

In this PR, to avoid break change, the id of `Sequence` and `Conversation` are both that llama.cpp `seq_id`. In the future it will be better to separate them. 