### PR TITLE
LLava API Improvements

### DIFF
--- a/LLama/LLavaWeights.cs
+++ b/LLama/LLavaWeights.cs
@@ -21,7 +21,8 @@ public sealed class LLavaWeights : IDisposable
     {
         NativeHandle = weights;
     }
-    
+
+    #region load
     /// <summary>
     /// Load weights into memory
     /// </summary>
@@ -43,7 +44,9 @@ public sealed class LLavaWeights : IDisposable
     {
         return Task.Run(() => LoadFromFile(mmProject), token);
     }
+    #endregion
 
+    #region embed
     /// <summary>
     /// Create the Image Embeddings from the bytes of an image.
     /// </summary>
@@ -57,9 +60,20 @@ public sealed class LLavaWeights : IDisposable
     /// </list>
     /// </param>
     /// <returns></returns>
-    public SafeLlavaImageEmbedHandle CreateImageEmbeddings(LLamaContext ctxLlama, byte[] image )
+    public SafeLlavaImageEmbedHandle CreateImageEmbeddings(LLamaContext ctxLlama, byte[] image)
     {
-        return NativeHandle.CreateImageEmbeddings(ctxLlama, image  );
+        return NativeHandle.CreateImageEmbeddings(ctxLlama, image);
+    }
+    
+    /// <summary>
+    /// Create the Image Embeddings.
+    /// </summary>
+    /// <param name="image">Image in binary format (it supports jpeg  format only)</param>
+    /// <param name="threads">Number of threads to use</param>
+    /// <returns>return the SafeHandle of these embeddings</returns>
+    public SafeLlavaImageEmbedHandle CreateImageEmbeddings(byte[] image, int threads = -1)
+    {
+        return NativeHandle.CreateImageEmbeddings(image, threads);
     }
 
     /// <summary>
@@ -76,10 +90,30 @@ public sealed class LLavaWeights : IDisposable
     /// </param>
     /// <returns></returns>
     /// <exception cref="InvalidOperationException"></exception> 
-    public SafeLlavaImageEmbedHandle CreateImageEmbeddings(LLamaContext ctxLlama, string image )
+    public SafeLlavaImageEmbedHandle CreateImageEmbeddings(LLamaContext ctxLlama, string image)
     {
-        return NativeHandle.CreateImageEmbeddings(ctxLlama, image  );
+        return NativeHandle.CreateImageEmbeddings(ctxLlama, image);
     }
+    
+    /// <summary>
+    /// Create the Image Embeddings from the bytes of an image.
+    /// </summary>
+    /// <param name="image">Path to the image file. Supported formats:
+    /// <list type="bullet">
+    ///     <item>JPG</item>
+    ///     <item>PNG</item>
+    ///     <item>BMP</item>
+    ///     <item>TGA</item>
+    /// </list>
+    /// </param>
+    /// <param name="threads"></param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception> 
+    public SafeLlavaImageEmbedHandle CreateImageEmbeddings(string image, int threads = -1)
+    {
+        return NativeHandle.CreateImageEmbeddings(image, threads);
+    }
+    #endregion
 
     /// <summary>
     /// Eval the image embeddings

--- a/LLama/Native/LLavaImageEmbed.cs
+++ b/LLama/Native/LLavaImageEmbed.cs
@@ -5,8 +5,9 @@ namespace LLama.Native;
 /// <summary>
 /// LLaVa Image embeddings 
 /// </summary>
+/// <remarks>llava_image_embed</remarks>
 [StructLayout(LayoutKind.Sequential)]
-unsafe public struct LLavaImageEmbed
+public unsafe struct LLavaImageEmbed
 {
     public float* embed;
     public int n_image_pos;


### PR DESCRIPTION
 - Added new ways to create an image embedding which don't require a context
 - Added a way to get the embedding data directly from an image embed (one embedding vector at a time)

These are a couple of things that I've added while working on embeddings prompting support for the `BatchedExecutor`.