### PR TITLE
Batch Queueing

### DIFF
--- a/LLama/Batched/BatchedExecutor.cs
+++ b/LLama/Batched/BatchedExecutor.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using LLama.Abstractions;
@@ -13,13 +15,15 @@ public sealed class BatchedExecutor
     : IDisposable
 {
     private int _nextSequenceId;
+    private readonly List<LLamaBatch> _batchQueue = [ ];
     
-    private LLamaBatch _promptingBatch = new();
-    private LLamaBatch _nextBatch = new();
-    internal LLamaBatch Batch => _promptingBatch;
+    /// <summary>
+    /// Held while inference is running
+    /// </summary>
+    private readonly object _inferenceLock = new();
 
     /// <summary>
-    /// Epoch is incremented every time Infer is called. Conversations can use this to keep track of
+    /// Epoch is incremented twice every time Infer is called. Conversations can use this to keep track of
     /// whether they're waiting for inference, or can be sampled.
     /// </summary>
     internal ulong Epoch { get; private set; }
@@ -33,11 +37,11 @@ public sealed class BatchedExecutor
     /// The <see cref="LLamaWeights"/> this executor is using
     /// </summary>
     public LLamaWeights Model { get; }
-
+    
     /// <summary>
     /// Get the number of tokens in the batch, waiting for <see cref="Infer"/> to be called
     /// </summary>
-    public int BatchedTokenCount => Batch.TokenCount;
+    public int BatchedTokenCount => _batchQueue.Sum(a => a.TokenCount);
 
     /// <summary>
     /// Check if this executor has been disposed.
@@ -112,26 +116,53 @@ public sealed class BatchedExecutor
         if (IsDisposed)
             throw new ObjectDisposedException(nameof(BatchedExecutor));
         
-        // Swap over batches. This means the next batch can be filled with
-        // tokens while inference is still running for the previous one.
-        var batch = _promptingBatch;
-        (_promptingBatch, _nextBatch) = (_nextBatch, _promptingBatch);
-
-        var status = await Context.DecodeAsync(batch, cancellation);
+        // If there's no work to do then we successfully completed all available work! immediately exit.
+        var next = GetNextBatch();
+        if (next == null)
+            return DecodeResult.Ok;
         
-        // If there was an error swap the previous batch back into place. This allows infer to be called again
-        // after the issue has been fixed (e.g. some KV cache space has been freed) to "retry" this operation.
-        if (status != DecodeResult.Ok)
+        // Take the inference lock, if this fails it's because inference is already running.
+        if (!Monitor.TryEnter(_inferenceLock))
+            throw new InvalidOperationException("Cannot start inference while it is already running");
+        try
         {
-            (_promptingBatch, _nextBatch) = (_nextBatch, _promptingBatch);
+            // Advance epoch by one. This ensures that _nothing_ can be sampled while inference is running.
+            // Only do this if the epoch is odd. If it's even that means it was previously advanced by another
+            // inference run, and this run is a retry.
+            if ((Epoch & 1) == 1)
+                Epoch++;
+
+            // Run the actual inference. This is the slow bit!
+            var status = await Context.DecodeAsync(next, cancellation);
+
+            // If there was an error then early exit without incrementing the epoch. This allows infer to be called
+            // again after the issue has been fixed (e.g. some KV cache space has been freed) to retry this operation.
+            if (status != DecodeResult.Ok)
+            {
+                _batchQueue.Insert(0, next);
+                return status;
+            }
+            
+            // Everything was ok, advance the epoch and clear the batch we just ran inference for.
+            Epoch++;
+            next.Clear();
+            
             return status;
         }
+        finally
+        {
+            Monitor.Exit(_inferenceLock);
+        }
         
-        // Everything was ok, advance the epoch and clear the batch we just ran inference for.
-        Epoch++;
-        batch.Clear();
-        
-        return status;
+        LLamaBatch? GetNextBatch()
+        {
+            if (_batchQueue.Count == 0)
+                return null;
+            
+            var nextBatch = _batchQueue[0];
+            _batchQueue.RemoveAt(0);
+            return nextBatch;
+        }
     }
 
     /// <inheritdoc />
@@ -147,5 +178,33 @@ public sealed class BatchedExecutor
     internal LLamaSeqId GetNextSequenceId()
     {
         return checked((LLamaSeqId)_nextSequenceId++);
+    }
+    
+    /// <summary>
+    /// Get a reference to a batch that tokens can be added to.
+    /// </summary>
+    /// <param name="minCapacity"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    internal (LLamaBatch batch, ulong epoch) GetTokenBatch(int minCapacity = 1)
+    {
+        if (minCapacity > Context.BatchSize)
+            throw new ArgumentOutOfRangeException(nameof(minCapacity), $"Request batch capacity must be less than or equal to BatchSize ({Context.BatchSize})");
+
+        // Find a batch with space for at least minCapacity tokens
+        for (var i = 0; i < _batchQueue.Count; i++)
+        {
+            var capacity = Context.BatchSize - _batchQueue[i].TokenCount;
+            if (capacity < minCapacity)
+                continue;
+
+            if (_batchQueue[i].TokenCount < Context.BatchSize)
+                return (_batchQueue[i], Epoch + (uint)(i + 1) * 2);
+        }
+        
+        // Add a new batch to the end of the queue
+        var end = new LLamaBatch();
+        _batchQueue.Add(end);
+        return (end, Epoch + (uint)_batchQueue.Count * 2);
     }
 }

--- a/LLama/Native/LLamaBatch.cs
+++ b/LLama/Native/LLamaBatch.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
@@ -54,20 +54,20 @@ public class LLamaBatch
     public LLamaBatch()
     {
         // These can both be grown later, start off with reasonable numbers.
-        const int n_tokens = 128;
-        const int n_seq_max = 1;
+        const int tokensCapacity = 128;
+        const int seqCapacity = 1;
 
-        SequenceCapacity = n_seq_max;
-        TokenCapacity = n_tokens;
+        SequenceCapacity = seqCapacity;
+        TokenCapacity = tokensCapacity;
 
-        _logits = new byte[n_tokens];
-        _tokens = new LLamaToken[n_tokens];
-        _positions = new LLamaPos[n_tokens];
+        _logits = new byte[tokensCapacity];
+        _tokens = new LLamaToken[tokensCapacity];
+        _positions = new LLamaPos[tokensCapacity];
 
-        _sequenceIdCount = new int[n_tokens];
+        _sequenceIdCount = new int[tokensCapacity];
         _sequenceIdsPtrs = new IntPtr[_sequenceIdCount.Length];
 
-        _sequenceIds = new LLamaSeqId[n_tokens][];
+        _sequenceIds = new LLamaSeqId[tokensCapacity][];
         for (var i = 0; i < _sequenceIds.Length; i++)
             _sequenceIds[i] = new LLamaSeqId[SequenceCapacity];
     }
@@ -75,30 +75,29 @@ public class LLamaBatch
     #region grow
     private void GrowTokenCapacity()
     {
-        var n_tokens = TokenCount * 2;
-        TokenCapacity = n_tokens;
+        var tokenCapacity = TokenCount * 2;
+        TokenCapacity = tokenCapacity;
 
-        Array.Resize(ref _logits, n_tokens);
-        Array.Resize(ref _tokens, n_tokens);
-        Array.Resize(ref _positions, n_tokens);
+        Array.Resize(ref _logits, tokenCapacity);
+        Array.Resize(ref _tokens, tokenCapacity);
+        Array.Resize(ref _positions, tokenCapacity);
 
-        Array.Resize(ref _sequenceIdCount, n_tokens);
-        Array.Resize(ref _sequenceIdsPtrs, n_tokens);
+        Array.Resize(ref _sequenceIdCount, tokenCapacity);
+        Array.Resize(ref _sequenceIdsPtrs, tokenCapacity);
 
-        Array.Resize(ref _sequenceIds, n_tokens);
-        for (int i = 0; i < _sequenceIds.Length; i++)
+        Array.Resize(ref _sequenceIds, tokenCapacity);
+        for (var i = 0; i < _sequenceIds.Length; i++)
         {
             // Growing the array filled elements with null, temporarily violating the nullability contract!
-            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
-            if (_sequenceIds[i] == null)
-                _sequenceIds[i] = new LLamaSeqId[SequenceCapacity];
+            // ReSharper disable once NullCoalescingConditionIsAlwaysNotNullAccordingToAPIContract
+            _sequenceIds[i] ??= new LLamaSeqId[SequenceCapacity];
         }
     }
 
     private void GrowMaxSequences(int atLeast)
     {
-        var n_seq = Math.Max(SequenceCapacity * 2, atLeast);
-        SequenceCapacity = n_seq;
+        var seqCapacity = Math.Max(SequenceCapacity * 2, atLeast);
+        SequenceCapacity = seqCapacity;
 
         for (var i = 0; i < _sequenceIds.Length; i++)
             Array.Resize(ref _sequenceIds[i], SequenceCapacity);


### PR DESCRIPTION
Added a batch queue to `BatchedExecutor`, allowing an arbitrary amount of work to be queued up in the executor and run in batches. This is helpful when prompting with very large numbers of tokens (e.g. a 2000 character system prompt would automatically be queued up in 4x512 batches).

This is a pre-requisite for embeddings prompting (i.e. llava), which needs an entirely new type of item in the batch queue. Embeddings usually also come in large numbers (e.g. one llava image might be hundreds of items), so the ability to queue up lots of work is valuable!