### PR TITLE
LLaVa Vulkan build actions

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -158,20 +158,30 @@ jobs:
                 # if we ever want to pull libvulkan.so back into the packages, just uncomment this line, and the one below for the upload
                 # cp $(ldconfig -p | grep libvulkan.so | tail -n 1 | cut -d ' ' -f 4) ./
                 ls -R
-          - name: Upload artifacts (Windows)
+          - name: Upload llama artifacts (Windows)
             if: ${{ matrix.os == 'windows-latest' }}
             uses: actions/upload-artifact@v4
             with:
-                path: |
-                    .\build\bin\Release\llama.dll
+                path: .\build\bin\Release\llama.dll
                 name: llama-bin-win-vulkan-x64.dll
-          - name: Upload artifacts (linux)
+          - name: Upload llava artifacts (Windows)
+            if: ${{ matrix.os == 'windows-latest' }}
+            uses: actions/upload-artifact@v4
+            with:
+                path: .\build\bin\Release\llava_shared.dll
+                name: llama-bin-win-vulkan-x64.dll
+          - name: Upload llama artifacts (Linux)
             if: ${{ matrix.os == 'ubuntu-22.04' }}
             uses: actions/upload-artifact@v4
             with:
-                path: |
-                    ./build/libllama.so
+                path: ./build/libllama.so
                 name: llama-bin-linux-vulkan-x64.so
+          - name: Upload llava artifacts (Linux)
+            if: ${{ matrix.os == 'ubuntu-22.04' }}
+            uses: actions/upload-artifact@v4
+            with:
+                path: ./build/examples/llava/libllava_shared.so
+                name: llama-bin-win-vulkan-x64.dll
                 
   compile-cublas:
     name: Compile (cublas)
@@ -353,8 +363,11 @@ jobs:
           cp artifacts/llama-bin-linux-cublas-cu12.2.0-x64.so/libllama.so deps/cu12.2.0/libllama.so
           cp artifacts/llava-bin-linux-cublas-cu12.2.0-x64.so/libllava_shared.so deps/cu12.2.0/libllava_shared.so
 
-          cp artifacts/llama-bin-win-vulkan-x64.dll/llama.dll deps/vulkan/
-          cp artifacts/llama-bin-linux-vulkan-x64.so/libllama.so deps/vulkan/
+          cp artifacts/llama-bin-win-vulkan-x64.dll/llama.dll deps/vulkan/llama.dll
+          cp artifacts/llama-bin-win-vulkan-x64.dll/llava_shared.dll deps/vulkan/llava_shared.dll
+            
+          cp artifacts/llama-bin-linux-vulkan-x64.so/libllama.so deps/vulkan/libllama.so
+          cp artifacts/llama-bin-linux-vulkan-x64.so/libllava_shared.so deps/vulkan/libllava_shared.so
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -169,7 +169,7 @@ jobs:
             uses: actions/upload-artifact@v4
             with:
                 path: .\build\bin\Release\llava_shared.dll
-                name: llama-bin-win-vulkan-x64.dll
+                name: llava-bin-win-vulkan-x64.dll
           - name: Upload llama artifacts (Linux)
             if: ${{ matrix.os == 'ubuntu-22.04' }}
             uses: actions/upload-artifact@v4
@@ -181,7 +181,7 @@ jobs:
             uses: actions/upload-artifact@v4
             with:
                 path: ./build/examples/llava/libllava_shared.so
-                name: llama-bin-win-vulkan-x64.dll
+                name: llava-bin-win-vulkan-x64.dll
                 
   compile-cublas:
     name: Compile (cublas)
@@ -364,10 +364,10 @@ jobs:
           cp artifacts/llava-bin-linux-cublas-cu12.2.0-x64.so/libllava_shared.so deps/cu12.2.0/libllava_shared.so
 
           cp artifacts/llama-bin-win-vulkan-x64.dll/llama.dll deps/vulkan/llama.dll
-          cp artifacts/llama-bin-win-vulkan-x64.dll/llava_shared.dll deps/vulkan/llava_shared.dll
+          cp artifacts/llava-bin-win-vulkan-x64.dll/llava_shared.dll deps/vulkan/llava_shared.dll
             
           cp artifacts/llama-bin-linux-vulkan-x64.so/libllama.so deps/vulkan/libllama.so
-          cp artifacts/llama-bin-linux-vulkan-x64.so/libllava_shared.so deps/vulkan/libllava_shared.so
+          cp artifacts/llava-bin-linux-vulkan-x64.so/libllava_shared.so deps/vulkan/libllava_shared.so
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -142,11 +142,6 @@ jobs:
                 cd build
                 cmake .. ${{ env.COMMON_DEFINE }} -DLLAMA_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_VULKAN=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_PREFIX_PATH="$env:RUNNER_TEMP/vulkan"
                 cmake --build . --config Release -j ${env:NUMBER_OF_PROCESSORS}
-                #copy $env:RUNNER_TEMP/clblast/lib/clblast.dll .\bin\Release\clblast.dll
-                # # We should probably generate a sha256 sum in a file, and use that.
-                # echo "78a8c98bcb2efe1a63318d901ab204d9ba96c3b29707b4ce0c4240bdcdc698d6  ./bin/Release/clblast.dll" >> tmp
-                # sha256sum -c tmp || exit 255
-                # rm tmp
                 ls -R
           - name: Build
             if: ${{ matrix.os == 'ubuntu-22.04' }}
@@ -155,8 +150,6 @@ jobs:
                 cd build
                 cmake .. ${{ env.COMMON_DEFINE }} -DLLAMA_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_VULKAN=ON -DBUILD_SHARED_LIBS=ON
                 cmake --build . --config Release -j ${env:NUMBER_OF_PROCESSORS}
-                # if we ever want to pull libvulkan.so back into the packages, just uncomment this line, and the one below for the upload
-                # cp $(ldconfig -p | grep libvulkan.so | tail -n 1 | cut -d ' ' -f 4) ./
                 ls -R
           - name: Upload llama artifacts (Windows)
             if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -181,7 +181,7 @@ jobs:
             uses: actions/upload-artifact@v4
             with:
                 path: ./build/examples/llava/libllava_shared.so
-                name: llava-bin-win-vulkan-x64.dll
+                name: llava-bin-linux-vulkan-x64.so
                 
   compile-cublas:
     name: Compile (cublas)


### PR DESCRIPTION
This PR adds the Vulkan build actions for `llava_shared.dll` and `libllava_shared.so`.
I ran a `Update Binaries` test run in my fork, which completed succesfully.