### PR TITLE
Update CUDA 12 paths from cu12.1.0 to cu12.2.0

### DIFF
--- a/LLama/LLamaSharp.Runtime.targets
+++ b/LLama/LLamaSharp.Runtime.targets
@@ -24,7 +24,7 @@
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <Link>runtimes/win-x64/native/cuda11/llama.dll</Link>
       </None>
-      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/cu12.1.0/llama.dll">
+      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/cu12.2.0/llama.dll">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <Link>runtimes/win-x64/native/cuda12/llama.dll</Link>
       </None>
@@ -49,7 +49,7 @@
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <Link>runtimes/linux-x64/native/cuda11/libllama.so</Link>
       </None>
-      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/cu12.1.0/libllama.so">
+      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/cu12.2.0/libllama.so">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <Link>runtimes/linux-x64/native/cuda12/libllama.so</Link>
       </None>
@@ -105,7 +105,7 @@
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <Link>runtimes/win-x64/native/cuda11/llava_shared.dll</Link>
       </None>
-      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/cu12.1.0/llava_shared.dll">
+      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/cu12.2.0/llava_shared.dll">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <Link>runtimes/win-x64/native/cuda12/llava_shared.dll</Link>
       </None>
@@ -130,7 +130,7 @@
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <Link>runtimes/linux-x64/native/cuda11/libllava_shared.so</Link>
       </None>
-      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/cu12.1.0/libllava_shared.so">
+      <None Include="$(MSBuildThisFileDirectory)runtimes/deps/cu12.2.0/libllava_shared.so">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <Link>runtimes/linux-x64/native/cuda12/libllava_shared.so</Link>
       </None>

--- a/LLama/runtimes/build/LLamaSharp.Backend.Cuda12.nuspec
+++ b/LLama/runtimes/build/LLamaSharp.Backend.Cuda12.nuspec
@@ -18,11 +18,11 @@
   <files>
     <file src="LLamaSharpBackend.props" target="build/netstandard2.0/LLamaSharp.Backend.Cuda12.props" />
 
-    <file src="runtimes/deps/cu12.1.0/libllava_shared.so" target="runtimes\linux-x64\native\cuda12\libllava_shared.so" />
-    <file src="runtimes/deps/cu12.1.0/llava_shared.dll" target="runtimes\win-x64\native\cuda12\llava_shared.dll" />
+    <file src="runtimes/deps/cu12.2.0/libllava_shared.so" target="runtimes\linux-x64\native\cuda12\libllava_shared.so" />
+    <file src="runtimes/deps/cu12.2.0/llava_shared.dll" target="runtimes\win-x64\native\cuda12\llava_shared.dll" />
     
-    <file src="runtimes/deps/cu12.1.0/llama.dll" target="runtimes\win-x64\native\cuda12\llama.dll" />
-    <file src="runtimes/deps/cu12.1.0/libllama.so" target="runtimes\linux-x64\native\cuda12\libllama.so" />
+    <file src="runtimes/deps/cu12.2.0/llama.dll" target="runtimes\win-x64\native\cuda12\llama.dll" />
+    <file src="runtimes/deps/cu12.2.0/libllama.so" target="runtimes\linux-x64\native\cuda12\libllama.so" />
     
     <file src="icon512.png" target="icon512.png" />
   </files>


### PR DESCRIPTION
I noticed the CUDA 12 paths (in `Update Binaries`) were recently changed from `cu12.1.0` to `cu12.2.0`. This means that starting from the next binary update, the CUDA 12 deps will be built to the `cu12.2.0` folder. However, `LLamaSharp.Runtime.targets` and `LLamaSharp.Backend.Cuda12.nuspec` are still looking for the `cu12.1.0` folder.

This PR updates those paths, and should be merged after the next binary update (because currently, the `cu12.2.0` folder is not yet shipped, so merging now will result in errors when building a fresh project)