### PR TITLE
Add llama_cpp_commit to Vulkan build and remove double params

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -118,6 +118,8 @@ jobs:
             uses: actions/checkout@v4
             with:
                 repository: ggerganov/llama.cpp
+                fetch-depth: 0
+                ref: '${{ github.event.inputs.llama_cpp_commit }}'
 
           - name: Download dependencies - Linux
             if: ${{ matrix.os == 'ubuntu-22.04' }}
@@ -140,7 +142,7 @@ jobs:
             run: |
                 mkdir build
                 cd build
-                cmake .. ${{ env.COMMON_DEFINE }} -DLLAMA_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_VULKAN=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_PREFIX_PATH="$env:RUNNER_TEMP/vulkan"
+                cmake .. ${{ env.COMMON_DEFINE }} -DLLAMA_VULKAN=ON
                 cmake --build . --config Release -j ${env:NUMBER_OF_PROCESSORS}
                 ls -R
           - name: Build
@@ -148,7 +150,7 @@ jobs:
             run: |
                 mkdir build
                 cd build
-                cmake .. ${{ env.COMMON_DEFINE }} -DLLAMA_NATIVE=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_VULKAN=ON -DBUILD_SHARED_LIBS=ON
+                cmake .. ${{ env.COMMON_DEFINE }} -DLLAMA_VULKAN=ON
                 cmake --build . --config Release -j ${env:NUMBER_OF_PROCESSORS}
                 ls -R
           - name: Upload llama artifacts (Windows)


### PR DESCRIPTION
This PR adds the missing `llama_cpp_commit` param to the Vulkan build workflow, and cleans up some double params that were already present in `COMMON_DEFINE`.

Build action completed succesfully on my fork and binaries were tested locally (including running the unit tests) without issues:
https://github.com/m0nsky/LLamaSharp/actions/runs/9598690516

This fix is required before the upcoming binary update. After the next binary update, we can merge Vulkan support (#797) and the new CUDA12 paths (#800).