### PR TITLE
Fix possible file locks due to race conditions during build & test

### DIFF
--- a/LLama.Unittest/LLama.Unittest.csproj
+++ b/LLama.Unittest/LLama.Unittest.csproj
@@ -27,13 +27,39 @@
     </PackageReference>
   </ItemGroup>
 
-  <Target Name="DownloadContentFiles" BeforeTargets="Build">
-    <DownloadFile SourceUrl="https://huggingface.co/TheBloke/Llama-2-7b-Chat-GGUF/resolve/main/llama-2-7b-chat.Q3_K_S.gguf" DestinationFolder="Models" DestinationFileName="llama-2-7b-chat.Q3_K_S.gguf" SkipUnchangedFiles="true"></DownloadFile>
-    <DownloadFile SourceUrl="https://huggingface.co/cjpais/llava-1.6-mistral-7b-gguf/resolve/main/llava-v1.6-mistral-7b.Q3_K_XS.gguf" DestinationFolder="Models" DestinationFileName="llava-v1.6-mistral-7b.Q3_K_XS.gguf" SkipUnchangedFiles="true"></DownloadFile>
-    <DownloadFile SourceUrl="https://huggingface.co/cjpais/llava-1.6-mistral-7b-gguf/resolve/main/mmproj-model-f16.gguf" DestinationFolder="Models" DestinationFileName="mmproj-model-f16.gguf" SkipUnchangedFiles="true"></DownloadFile>
-    <DownloadFile SourceUrl="https://huggingface.co/leliuga/all-MiniLM-L12-v2-GGUF/resolve/main/all-MiniLM-L12-v2.Q8_0.gguf" DestinationFolder="Models" DestinationFileName="all-MiniLM-L12-v2.Q8_0.gguf" SkipUnchangedFiles="true"></DownloadFile>
-
+  <Target Name="DownloadContentFilesInner">
+  
+    <DownloadFile
+		SourceUrl="https://huggingface.co/TheBloke/Llama-2-7b-Chat-GGUF/resolve/main/llama-2-7b-chat.Q3_K_S.gguf"
+		DestinationFolder="Models"
+		DestinationFileName="llama-2-7b-chat.Q3_K_S.gguf"
+		SkipUnchangedFiles="true">
+	</DownloadFile>
     
+	<DownloadFile
+		SourceUrl="https://huggingface.co/cjpais/llava-1.6-mistral-7b-gguf/resolve/main/llava-v1.6-mistral-7b.Q3_K_XS.gguf"
+		DestinationFolder="Models" DestinationFileName="llava-v1.6-mistral-7b.Q3_K_XS.gguf"
+		SkipUnchangedFiles="true">
+	</DownloadFile>
+    
+	<DownloadFile
+		SourceUrl="https://huggingface.co/cjpais/llava-1.6-mistral-7b-gguf/resolve/main/mmproj-model-f16.gguf"
+		DestinationFolder="Models"
+		DestinationFileName="mmproj-model-f16.gguf"
+		SkipUnchangedFiles="true">
+	</DownloadFile>
+    
+	<DownloadFile
+		SourceUrl="https://huggingface.co/leliuga/all-MiniLM-L12-v2-GGUF/resolve/main/all-MiniLM-L12-v2.Q8_0.gguf"
+		DestinationFolder="Models"
+		DestinationFileName="all-MiniLM-L12-v2.Q8_0.gguf"
+		SkipUnchangedFiles="true">
+	</DownloadFile>
+
+  </Target>
+  
+  <Target Name="DownloadContentFiles" BeforeTargets="DispatchToInnerBuilds;BeforeBuild">
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="DownloadContentFilesInner" Properties="TargetFramework=once" />
   </Target>
 
   <ItemGroup>

--- a/LLama/LLamaSharp.csproj
+++ b/LLama/LLamaSharp.csproj
@@ -52,26 +52,28 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
   </ItemGroup>
 
-
+  <Target Name="DownloadReleaseBinariesInner">
     <PropertyGroup>
         <BinaryReleaseId>1c5eba6f8e62</BinaryReleaseId>
     </PropertyGroup>
+	<Message Importance="High" Text="Download '$(BinaryReleaseId)/deps.zip' to 'runtimes'" />
+	<DownloadFile
+		SourceUrl="https://github.com/martindevans/LLamaSharpBinaries/releases/download/$(BinaryReleaseId)/deps.zip"
+		DestinationFolder="runtimes"
+		DestinationFileName="deps.zip"
+		SkipUnchangedFiles="true"
+	/>
 
-    <Target Name="DownloadReleaseBinaries" BeforeTargets="DispatchToInnerBuilds">
-        <Message Importance="High" Text="Download '$(BinaryReleaseId)/deps.zip' to 'runtimes'" />
-        <DownloadFile
-            SourceUrl="https://github.com/martindevans/LLamaSharpBinaries/releases/download/$(BinaryReleaseId)/deps.zip"
-            DestinationFolder="runtimes"
-            DestinationFileName="deps.zip"
-            SkipUnchangedFiles="true"
-        />
-
-        <Message Importance="High" Text="Unzip '$(BinaryReleaseId)/deps.zip'" />
-        <Unzip
-            SourceFiles="runtimes/deps.zip"
-            DestinationFolder="runtimes/deps/"
-            OverwriteReadOnlyFiles="false"
-            Include="*.dll;*.so;*.dylib;*.metal;"
-        />
-    </Target>
+	<Message Importance="High" Text="Unzip '$(BinaryReleaseId)/deps.zip'" />
+	<Unzip
+		SourceFiles="runtimes/deps.zip"
+		DestinationFolder="runtimes/deps/"
+		OverwriteReadOnlyFiles="false"
+		Include="*.dll;*.so;*.dylib;*.metal;"
+	/>
+  </Target>
+  <Target Name="DownloadReleaseBinaries" BeforeTargets="DispatchToInnerBuilds;BeforeBuild">
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="DownloadReleaseBinariesInner" Properties="TargetFramework=once" />
+  </Target>
+  
 </Project>


### PR DESCRIPTION
Fixes an edge case where downloading the deps/models were sometimes causing file locks due to race conditions when building and testing the project. After applying the fixes, I have not been able to reproduce the issue.

It affects both the build targets for `LLamaSharp` (downloading the deps) and `LLama.Unittest` (downloading the models).

Note: this is based on, and will merge (after more testing) into `july-2024-binaries`