### PR TITLE
Fixed spelling in `TemplateTests`

### DIFF
--- a/LLama.Unittest/TemplateTests.cs
+++ b/LLama.Unittest/TemplateTests.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using LLama.Common;
-using LLama.Extensions;
 
 namespace LLama.Unittest;
 
@@ -244,7 +243,7 @@ public sealed class TemplateTests
         const string userData = nameof(userData);
         templater.Add("user", userData);
 
-        // Generte the template string
+        // Generate the template string
         var dest = templater.Apply();
         var templateResult = Encoding.UTF8.GetString(dest);
 


### PR DESCRIPTION
Fixed spelling in `TemplateTests`, this was breaking CI