### PR TITLE
Updated KernelMemory and SemanticKernel.

### DIFF
--- a/LLama.Examples/Examples/KernelMemorySaveAndLoad.cs
+++ b/LLama.Examples/Examples/KernelMemorySaveAndLoad.cs
@@ -1,10 +1,10 @@
-﻿using LLamaSharp.KernelMemory;
+using LLamaSharp.KernelMemory;
 using Microsoft.KernelMemory;
 using Microsoft.KernelMemory.Configuration;
-using Microsoft.KernelMemory.ContentStorage.DevTools;
 using Microsoft.KernelMemory.FileSystem.DevTools;
 using Microsoft.KernelMemory.MemoryStorage.DevTools;
 using System.Diagnostics;
+using Microsoft.KernelMemory.DocumentStorage.DevTools;
 
 namespace LLama.Examples.Examples;
 

--- a/LLama.Examples/LLama.Examples.csproj
+++ b/LLama.Examples/LLama.Examples.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\LLama\LLamaSharp.Runtime.targets" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Platforms>AnyCPU;x64</Platforms>
@@ -15,8 +15,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-    <PackageReference Include="Microsoft.KernelMemory.Core" Version="0.34.240313.1" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.14.1" />
+    <PackageReference Include="Microsoft.KernelMemory.Core" Version="0.66.240709.1" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.15.1" />
     <PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.6.2-alpha" />
     <PackageReference Include="NAudio" Version="2.2.1" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />

--- a/LLama.KernelMemory/LLamaSharp.KernelMemory.csproj
+++ b/LLama.KernelMemory/LLamaSharp.KernelMemory.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Version>0.13.0</Version>
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.KernelMemory.Abstractions" Version="0.34.240313.1" />
+    <PackageReference Include="Microsoft.KernelMemory.Abstractions" Version="0.66.240709.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LLama.KernelMemory/LlamaSharpTextGenerator.cs
+++ b/LLama.KernelMemory/LlamaSharpTextGenerator.cs
@@ -87,7 +87,7 @@ namespace LLamaSharp.KernelMemory
                     MaxTokens = options.MaxTokens ?? defaultParams.MaxTokens,
                     FrequencyPenalty = options.FrequencyPenalty == defaultParams.FrequencyPenalty ? defaultParams.FrequencyPenalty : (float)options.FrequencyPenalty,
                     PresencePenalty = options.PresencePenalty == defaultParams.PresencePenalty ? defaultParams.PresencePenalty : (float)options.PresencePenalty,
-                    TopP = options.TopP == defaultParams.TopP ? defaultParams.TopP : (float)options.TopP
+                    TopP = options.NucleusSampling == defaultParams.TopP ? defaultParams.TopP : (float)options.NucleusSampling
                 };
             }
             else
@@ -99,7 +99,7 @@ namespace LLamaSharp.KernelMemory
                     MaxTokens = options.MaxTokens ?? 1024,
                     FrequencyPenalty = (float)options.FrequencyPenalty,
                     PresencePenalty = (float)options.PresencePenalty,
-                    TopP = (float)options.TopP,
+                    TopP = (float)options.NucleusSampling,
                 };
             }
         }

--- a/LLama.SemanticKernel/LLamaSharp.SemanticKernel.csproj
+++ b/LLama.SemanticKernel/LLamaSharp.SemanticKernel.csproj
@@ -34,7 +34,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.6.2" />
+		<PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.15.1" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/LLama.Unittest/SemanticKernel/ChatRequestSettingsConverterTests.cs
+++ b/LLama.Unittest/SemanticKernel/ChatRequestSettingsConverterTests.cs
@@ -1,5 +1,4 @@
-﻿using LLamaSharp.SemanticKernel;
-using LLamaSharp.SemanticKernel.ChatCompletion;
+using LLamaSharp.SemanticKernel;
 using System.Text.Json;
 
 namespace LLama.Unittest.SemanticKernel

--- a/LLama.Unittest/SemanticKernel/ExtensionMethodsTests.cs
+++ b/LLama.Unittest/SemanticKernel/ExtensionMethodsTests.cs
@@ -1,19 +1,6 @@
-using Xunit;
-using LLama;
-using LLama.Abstractions;
-using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.Services;
-using System;
-using System.IO;
-using System.Runtime.CompilerServices;
-using System.Text;
-using static LLama.LLamaTransforms;
-using System.Threading.Tasks;
-using System.Collections.Generic;
-using System.Threading;
-using LLamaSharp.SemanticKernel.ChatCompletion;
+using LLamaSharp.SemanticKernel;
 
-namespace LLamaSharp.SemanticKernel.Tests
+namespace LLama.Unittest.SemanticKernel
 {
     public class ExtensionMethodsTests
     {

--- a/LLama.Unittest/SemanticKernel/LLamaSharpChatCompletionTests.cs
+++ b/LLama.Unittest/SemanticKernel/LLamaSharpChatCompletionTests.cs
@@ -1,20 +1,10 @@
-using Xunit;
-using Moq;
-using LLama;
 using LLama.Abstractions;
+using LLamaSharp.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
-using Microsoft.SemanticKernel.Services;
-using System;
-using System.IO;
-using System.Runtime.CompilerServices;
-using System.Text;
-using static LLama.LLamaTransforms;
-using System.Threading.Tasks;
-using System.Collections.Generic;
-using System.Threading;
+using Moq;
 
-namespace LLamaSharp.SemanticKernel.ChatCompletion.Tests
+namespace LLama.Unittest.SemanticKernel
 {
     public class LLamaSharpChatCompletionTests
     {

--- a/LLama.Unittest/SemanticKernel/LLamaSharpTextCompletionTests.cs
+++ b/LLama.Unittest/SemanticKernel/LLamaSharpTextCompletionTests.cs
@@ -1,47 +1,38 @@
-using Xunit;
-using Moq;
-using LLama;
 using LLama.Abstractions;
+using LLamaSharp.SemanticKernel.TextCompletion;
 using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.Services;
-using System;
-using System.IO;
-using System.Runtime.CompilerServices;
-using System.Text;
-using static LLama.LLamaTransforms;
-using System.Threading.Tasks;
-using System.Collections.Generic;
-using System.Threading;
+using Moq;
 
-namespace LLamaSharp.SemanticKernel.TextCompletion.Tests
+namespace LLama.Unittest.SemanticKernel
 {
-    public class LLamaSharpTextCompletionTests : IDisposable
+    public sealed class LLamaSharpTextCompletionTests
+        : IDisposable
     {
         private MockRepository mockRepository;
         private Mock<ILLamaExecutor> mockExecutor;
 
         public LLamaSharpTextCompletionTests()
         {
-            this.mockRepository = new MockRepository(MockBehavior.Strict);
-            this.mockExecutor = this.mockRepository.Create<ILLamaExecutor>();
+            mockRepository = new MockRepository(MockBehavior.Strict);
+            mockExecutor = mockRepository.Create<ILLamaExecutor>();
         }
 
         public void Dispose()
         {
-            this.mockRepository.VerifyAll();
+            mockRepository.VerifyAll();
         }
 
         private LLamaSharpTextCompletion CreateLLamaSharpTextCompletion()
         {
             return new LLamaSharpTextCompletion(
-                this.mockExecutor.Object);
+                mockExecutor.Object);
         }
 
         [Fact]
         public async Task GetTextContentsAsync_StateUnderTest_ExpectedBehavior()
         {
             // Arrange
-            var unitUnderTest = this.CreateLLamaSharpTextCompletion();
+            var unitUnderTest = CreateLLamaSharpTextCompletion();
             string prompt = "Test";
             PromptExecutionSettings? executionSettings = null;
             Kernel? kernel = null;
@@ -64,7 +55,7 @@ namespace LLamaSharp.SemanticKernel.TextCompletion.Tests
         public async Task GetStreamingTextContentsAsync_StateUnderTest_ExpectedBehavior()
         {
             // Arrange
-            var unitUnderTest = this.CreateLLamaSharpTextCompletion();
+            var unitUnderTest = CreateLLamaSharpTextCompletion();
             string prompt = "Test";
             PromptExecutionSettings? executionSettings = null;
             Kernel? kernel = null;


### PR DESCRIPTION
Updated KernelMemory and SemanticKernel.

Removed net6 from example project because KernelMemory no longer supports net6.