### PR TITLE
Manually load GGML dependency for Linux/OSX

### DIFF
--- a/LLama/Native/Load/NativeLibraryUtils.cs
+++ b/LLama/Native/Load/NativeLibraryUtils.cs
@@ -41,46 +41,37 @@ namespace LLama.Native
             {
                 // Prepare the local library file and get the path.
                 var paths = library.Prepare(systemInfo, config.LogCallback);
+                
                 foreach (var path in paths)
                 {
                     Log($"Got relative library path '{path}' from local with {library.Metadata}, trying to load it...", LLamaLogLevel.Debug, config.LogCallback);
                     
-                    // If we are on linux/OSX, we need to manually load the GGML dependency
-                    if (systemInfo.OSPlatform == OSPlatform.Linux)
+                    // If we are on Linux / OSX, we need to manually load the GGML dependency
+                    if (systemInfo.OSPlatform == OSPlatform.Linux || systemInfo.OSPlatform == OSPlatform.OSX)
                     {
-                        // We can't use UseDllDirectoryForDependencies because it doesn't work on linux, and we can't use LD_LIBRARY_PATH because it has to be set before the application starts.
+                        // Get the directory of the library
+                        string? libraryDirectory = Path.GetDirectoryName(path);
                         
-                        // Construct the dependency (libggml.so) path
-                        string dependencyPath = Path.Combine(Path.GetFullPath(Path.GetDirectoryName(path)), "libggml.so");
+                        if (libraryDirectory != null)
+                        {
+                            // Construct the dependency (libggml) path
+                            string dependencyPath = Path.Combine(libraryDirectory, $"libggml{ext}");
                         
-                        // Load the dependency
-                        if (NativeLibrary.TryLoad(dependencyPath, out var dependencyHandle))
-                        {
-                            Log($"Successfully loaded dependency '{dependencyPath}'", LLamaLogLevel.Info, config.LogCallback);
-                        }
-                        else
-                        {
-                            Log($"Failed loading dependency '{dependencyPath}'", LLamaLogLevel.Info, config.LogCallback);
+                            // Try to load the dependency
+                            var dependencyResult = TryLoad(dependencyPath, description.SearchDirectories, config.LogCallback);
+                        
+                            // If we successfully loaded the library, return the handle
+                            if (dependencyResult == IntPtr.Zero)
+                            {
+                                Log($"Successfully loaded dependency '{dependencyPath}'", LLamaLogLevel.Info, config.LogCallback);
+                            }
+                            else
+                            {
+                                Log($"Failed loading dependency '{dependencyPath}'", LLamaLogLevel.Info, config.LogCallback);
+                            }
                         }
                     }
                     
-                    // We need to do the same for OSX, where the dependency is called libggml.dylib
-                    if (systemInfo.OSPlatform == OSPlatform.OSX)
-                    {
-                        // Construct the dependency (libggml.dylib) path
-                        string dependencyPath = Path.Combine(Path.GetFullPath(Path.GetDirectoryName(path)), "libggml.dylib");
-                        
-                        // Load the dependency
-                        if (NativeLibrary.TryLoad(dependencyPath, out var dependencyHandle))
-                        {
-                            Log($"Successfully loaded dependency '{dependencyPath}'", LLamaLogLevel.Info, config.LogCallback);
-                        }
-                        else
-                        {
-                            Log($"Failed loading dependency '{dependencyPath}'", LLamaLogLevel.Info, config.LogCallback);
-                        }
-                    }
-
                     // Try to load the library
                     var result = TryLoad(path, description.SearchDirectories, config.LogCallback);
                     

--- a/LLama/Native/Load/NativeLibraryUtils.cs
+++ b/LLama/Native/Load/NativeLibraryUtils.cs
@@ -60,7 +60,7 @@ namespace LLama.Native
                             // Try to load the dependency
                             var dependencyResult = TryLoad(dependencyPath, description.SearchDirectories, config.LogCallback);
                         
-                            // If we successfully loaded the library, return the handle
+                            // If we successfully loaded the library, log it
                             if (dependencyResult == IntPtr.Zero)
                             {
                                 Log($"Successfully loaded dependency '{dependencyPath}'", LLamaLogLevel.Info, config.LogCallback);

--- a/LLama/Native/Load/NativeLibraryUtils.cs
+++ b/LLama/Native/Load/NativeLibraryUtils.cs
@@ -61,7 +61,7 @@ namespace LLama.Native
                             var dependencyResult = TryLoad(dependencyPath, description.SearchDirectories, config.LogCallback);
                         
                             // If we successfully loaded the library, log it
-                            if (dependencyResult == IntPtr.Zero)
+                            if (dependencyResult != IntPtr.Zero)
                             {
                                 Log($"Successfully loaded dependency '{dependencyPath}'", LLamaLogLevel.Info, config.LogCallback);
                             }


### PR DESCRIPTION
After the introduction of the GGML dependency in the July 2024 binary update, the tests for Linux/OSX were failing because the NativeLibrary failed to load the GGML dependency.

There were two ways to tackle the issue:
- Specify `UseDllDirectoryForDependencies` in `NativeLibrary.TryLoad`, however, this does not seem to help on Linux / OSX
- Set the `LD_LIBRARY_PATH` environment variable to the current runtime directory, however, the `LD_LIBRARY_PATH` environment variable has to be set before the application starts, making it unusable in most cases, and incompatible with attempting to load multiple libraries

This PR introduces manually resolving the `GGML` dependency in `TryLoadLibrary` before loading the main library, for Linux & OSX.

I have ran the unit tests locally on Ubuntu 22.04 and they are now passing, and have also confirmed that building a standalone application where the `.so` files are placed in the same directory as the executable still work correctly.

I haven't ran the tests for OSX because I don't have access to it, but I hope those tests will also pass now, as they were reporting the same error. Maybe we can do this through GitHub?

Note: this is based on, and will merge into `july-2024-binaries`