### PR TITLE
Use the correct lib prefix for GGML dependency on Linux / OSX

### DIFF
--- a/LLama/Native/Load/NativeLibraryUtils.cs
+++ b/LLama/Native/Load/NativeLibraryUtils.cs
@@ -55,7 +55,7 @@ namespace LLama.Native
                         if (libraryDirectory != null)
                         {
                             // Construct the dependency (libggml) path
-                            string dependencyPath = Path.Combine(libraryDirectory, $"libggml{ext}");
+                            string dependencyPath = Path.Combine(libraryDirectory, $"{libPrefix}ggml{ext}");
                         
                             // Try to load the dependency
                             var dependencyResult = TryLoad(dependencyPath, description.SearchDirectories, config.LogCallback);


### PR DESCRIPTION
Updates the `NativeLibraryUtils` to use the correct lib prefix (from `GetPlatformPathParts`) for loading the GGML dependency on Linux / OSX.

Tests are passing locally.