### PR TITLE
Fix CUDA detection on WSL

### DIFF
--- a/LLama/Native/Load/SystemInfo.cs
+++ b/LLama/Native/Load/SystemInfo.cs
@@ -69,7 +69,7 @@ namespace LLama.Native
                 string[] defaultCudaPaths =
                 {
                     "/usr/local/bin/cuda",
-                    "/usr/local/cuda/bin",
+                    "/usr/local/cuda",
                     // "/usr/local/cuda-11/bin",
                     // "/usr/local/cuda-12/bin",
                 };

--- a/LLama/Native/Load/SystemInfo.cs
+++ b/LLama/Native/Load/SystemInfo.cs
@@ -65,9 +65,26 @@ namespace LLama.Native
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                // Try the default first
-                cudaPath = "/usr/local/bin/cuda";
-                version = GetCudaVersionFromPath(cudaPath);
+                // List of default cuda paths
+                string[] defaultCudaPaths =
+                {
+                    "/usr/local/bin/cuda",
+                    "/usr/local/cuda/bin",
+                    // "/usr/local/cuda-11/bin",
+                    // "/usr/local/cuda-12/bin",
+                };
+                
+                // Loop through every default path to find the version
+                foreach (var path in defaultCudaPaths)
+                {
+                    // Attempt to get the version from the path
+                    version = GetCudaVersionFromPath(path);
+                    
+                    // If a CUDA version is found, break the loop
+                    if (!string.IsNullOrEmpty(version))
+                        break;
+                }
+                
                 if (string.IsNullOrEmpty(version))
                 {
                     cudaPath = Environment.GetEnvironmentVariable("LD_LIBRARY_PATH");

--- a/LLama/Native/Load/SystemInfo.cs
+++ b/LLama/Native/Load/SystemInfo.cs
@@ -70,8 +70,6 @@ namespace LLama.Native
                 {
                     "/usr/local/bin/cuda",
                     "/usr/local/cuda",
-                    // "/usr/local/cuda-11/bin",
-                    // "/usr/local/cuda-12/bin",
                 };
                 
                 // Loop through every default path to find the version


### PR DESCRIPTION
I noticed that CUDA was working fine on WSL if the libs were put in the executable (root) dir of the application, but CUDA was not getting automatically selected if multiple runtimes were provided. It turns out that `SystemInfo` was unable to detect the CUDA version on WSL because the default directory is `/usr/local/cuda` instead of `/usr/local/bin/cuda`.

This PR introduces multiple default CUDA paths for Linux to detect the CUDA version.