### PR TITLE
CI: make unzip target depend on download target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,4 @@ site/
 **/appsettings.Local.json
 /LLama/runtimes/deps
 /LLama/runtimes/deps.zip
+/LLama/runtimes/version.txt

--- a/.gitignore
+++ b/.gitignore
@@ -352,4 +352,4 @@ site/
 **/appsettings.Local.json
 /LLama/runtimes/deps
 /LLama/runtimes/deps.zip
-/LLama/runtimes/version.txt
+/LLama/runtimes/release_id.txt

--- a/LLama/LLamaSharp.csproj
+++ b/LLama/LLamaSharp.csproj
@@ -60,12 +60,14 @@
     <PropertyGroup>
         <BinaryReleaseId>1c5eba6f8e62</BinaryReleaseId>
     </PropertyGroup>
+      
 	<Message Importance="High" Text="Download '$(BinaryReleaseId)/deps.zip' to 'runtimes'" />
 	<DownloadFile
 		SourceUrl="https://github.com/SciSharp/LLamaSharpBinaries/releases/download/$(BinaryReleaseId)/deps.zip"
 		DestinationFolder="runtimes"
 		DestinationFileName="deps.zip"
 		SkipUnchangedFiles="true"
+        Retries="3"
 	/>
   </Target>
 
@@ -81,7 +83,7 @@
   </Target>
     
   <Target Name="PrepareReleaseBinaries" BeforeTargets="DispatchToInnerBuilds;BeforeBuild">
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="UnzipReleaseBinaries" />
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="UnzipReleaseBinaries" Properties="TargetFramework=once" />
   </Target>
   
 </Project>

--- a/LLama/LLamaSharp.csproj
+++ b/LLama/LLamaSharp.csproj
@@ -68,8 +68,8 @@
   </Target>
 
   <Target Name="UnzipReleaseBinaries" DependsOnTargets="DownloadReleaseBinaries">
-	<Message Importance="High" Text="Zip file was found before starting unzip." Condition="Exists('$(BinaryReleaseId)/deps.zip')" />
-	<Message Importance="High" Text="Zip file was NOT found before starting unzip!" Condition="!Exists('$(BinaryReleaseId)/deps.zip')" />
+	<Message Importance="High" Text="Zip file was found before starting unzip." Condition="Exists('runtimes/deps.zip')" />
+	<Message Importance="High" Text="Zip file was NOT found before starting unzip!" Condition="!Exists('runtimes/deps.zip')" />
 	<Message Importance="High" Text="Unzip '$(BinaryReleaseId)/deps.zip'" />
 	<Unzip
 		SourceFiles="runtimes/deps.zip"

--- a/LLama/LLamaSharp.csproj
+++ b/LLama/LLamaSharp.csproj
@@ -57,7 +57,6 @@
   </PropertyGroup>
 
   <Target Name="DownloadReleaseBinaries">
-      
 	<Message Importance="High" Text="Download '$(BinaryReleaseId)/deps.zip' to 'runtimes'" />
 	<DownloadFile
 		SourceUrl="https://github.com/SciSharp/LLamaSharpBinaries/releases/download/$(BinaryReleaseId)/deps.zip"

--- a/LLama/LLamaSharp.csproj
+++ b/LLama/LLamaSharp.csproj
@@ -74,13 +74,14 @@
 	<Unzip
 		SourceFiles="runtimes/deps.zip"
 		DestinationFolder="runtimes/deps/"
+        SkipUnchangedFiles="true"
         OverwriteReadOnlyFiles="true"
 		Include="*.dll;*.so;*.dylib;*.metal;"
 	/>
   </Target>
     
   <Target Name="PrepareReleaseBinaries" BeforeTargets="DispatchToInnerBuilds;BeforeBuild">
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="UnzipReleaseBinaries" Properties="TargetFramework=once" />
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="UnzipReleaseBinaries" />
   </Target>
   
 </Project>

--- a/LLama/LLamaSharp.csproj
+++ b/LLama/LLamaSharp.csproj
@@ -68,8 +68,8 @@
   </Target>
 
   <Target Name="UnzipReleaseBinaries" DependsOnTargets="DownloadReleaseBinaries">
-	<Error Condition="!Exists('$(BinaryReleaseId)/deps.zip')" Text="Zip file was NOT found before starting unzip!" />
 	<Message Importance="High" Text="Zip file was found before starting unzip." Condition="Exists('$(BinaryReleaseId)/deps.zip')" />
+	<Message Importance="High" Text="Zip file was NOT found before starting unzip!" Condition="!Exists('$(BinaryReleaseId)/deps.zip')" />
 	<Message Importance="High" Text="Unzip '$(BinaryReleaseId)/deps.zip'" />
 	<Unzip
 		SourceFiles="runtimes/deps.zip"

--- a/LLama/LLamaSharp.csproj
+++ b/LLama/LLamaSharp.csproj
@@ -72,11 +72,8 @@
         Retries="3"
 	/>
   </Target>
-
-  <!-- This automatically runs after CheckReleaseBinaries has completed, but only if SkipDownloadReleaseBinaries is not true -->
-  <Target Name="UnzipReleaseBinaries" DependsOnTargets="DownloadReleaseBinaries" AfterTargets="CheckReleaseBinaries" Condition="'$(SkipDownloadReleaseBinaries)' != 'true'">
-	<Message Importance="High" Text="Zip file was found before starting unzip." Condition="Exists('runtimes/deps.zip')" />
-	<Message Importance="High" Text="Zip file was NOT found before starting unzip!" Condition="!Exists('runtimes/deps.zip')" />
+    
+  <Target Name="UnzipReleaseBinaries" DependsOnTargets="DownloadReleaseBinaries">
 	<Message Importance="High" Text="Unzip '$(BinaryReleaseId)/deps.zip'" />
 	<Unzip
 		SourceFiles="runtimes/deps.zip"
@@ -85,34 +82,10 @@
         OverwriteReadOnlyFiles="true"
 		Include="*.dll;*.so;*.dylib;*.metal;"
 	/>
-	<WriteLinesToFile
-		File="runtimes/version.txt"
-		Lines="$(BinaryReleaseId)"
-		Overwrite="true"
-    />
   </Target>
     
-  <Target Name="CheckReleaseBinaries">
-    <!-- First, we read the previous binary release id from disk -->    
-    <ReadLinesFromFile File="runtimes/version.txt">
-		<Output TaskParameter="Lines" ItemName="PreviousBinaryReleaseId" />
-    </ReadLinesFromFile>
-        
-    <!-- Log it to console -->
-    <Message Importance="High" Text="PreviousBinaryReleaseId: %(PreviousBinaryReleaseId.Identity), CurrentBinaryReleaseId: $(BinaryReleaseId)" />
-        
-    <!-- If the previous binary release id is the same as the current one (which we define at the top of this file), we skip the download -->
-    <PropertyGroup>
-		<SkipDownloadReleaseBinaries Condition="'%(PreviousBinaryReleaseId.Identity)' == '$(BinaryReleaseId)'">true</SkipDownloadReleaseBinaries>
-    </PropertyGroup>
-        
-    <!-- Log it to console -->
-    <Message Importance="High" Text="SkipDownloadReleaseBinaries: $(SkipDownloadReleaseBinaries)" />
-  </Target>
-
-  <!-- This always gets called before the build -->
   <Target Name="PrepareReleaseBinaries" BeforeTargets="DispatchToInnerBuilds;BeforeBuild">
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="CheckReleaseBinaries" Properties="TargetFramework=$(FirstTargetFramework)" />
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="UnzipReleaseBinaries" Properties="TargetFramework=$(FirstTargetFramework)" />
   </Target>
     
 </Project>

--- a/LLama/LLamaSharp.csproj
+++ b/LLama/LLamaSharp.csproj
@@ -72,8 +72,9 @@
         Retries="3"
 	/>
   </Target>
-    
-  <Target Name="UnzipReleaseBinaries" DependsOnTargets="DownloadReleaseBinaries">
+
+  <!-- This automatically runs after CheckReleaseBinaries has completed, but only if SkipDownloadReleaseBinaries is not true -->
+  <Target Name="UnzipReleaseBinaries" DependsOnTargets="DownloadReleaseBinaries" AfterTargets="CheckReleaseBinaries" Condition="'$(SkipDownloadReleaseBinaries)' != 'true'">
 	<Message Importance="High" Text="Unzip '$(BinaryReleaseId)/deps.zip'" />
 	<Unzip
 		SourceFiles="runtimes/deps.zip"
@@ -82,10 +83,28 @@
         OverwriteReadOnlyFiles="true"
 		Include="*.dll;*.so;*.dylib;*.metal;"
 	/>
+	<WriteLinesToFile
+		File="runtimes/version.txt"
+		Lines="$(BinaryReleaseId)"
+		Overwrite="true"
+    />
   </Target>
     
+  <Target Name="CheckReleaseBinaries">
+    <!-- First, we read the previous binary release id from disk -->    
+    <ReadLinesFromFile File="runtimes/version.txt">
+		<Output TaskParameter="Lines" ItemName="PreviousBinaryReleaseId" />
+    </ReadLinesFromFile>
+        
+    <!-- If the previous binary release id is the same as the current one (which we define at the top of this file), we skip the download -->
+    <PropertyGroup>
+		<SkipDownloadReleaseBinaries Condition="'%(PreviousBinaryReleaseId.Identity)' == '$(BinaryReleaseId)'">true</SkipDownloadReleaseBinaries>
+    </PropertyGroup>
+  </Target>
+
+  <!-- This always gets called before the build -->
   <Target Name="PrepareReleaseBinaries" BeforeTargets="DispatchToInnerBuilds;BeforeBuild">
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="UnzipReleaseBinaries" Properties="TargetFramework=$(FirstTargetFramework)" />
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="CheckReleaseBinaries" Properties="TargetFramework=$(FirstTargetFramework)" />
   </Target>
     
 </Project>

--- a/LLama/LLamaSharp.csproj
+++ b/LLama/LLamaSharp.csproj
@@ -56,6 +56,7 @@
     <BinaryReleaseId>1c5eba6f8e62</BinaryReleaseId>
   </PropertyGroup>
 
+  <!-- When UnzipReleaseBinaries is called, this will run first, as UnzipReleaseBinaries depends on it (check DependsOnTargets of UnzipReleaseBinaries) -->
   <Target Name="DownloadReleaseBinaries">
 	<Message Importance="High" Text="Download '$(BinaryReleaseId)/deps.zip' to 'runtimes'" />
 	<DownloadFile
@@ -67,7 +68,8 @@
 	/>
   </Target>
 
-  <Target Name="UnzipReleaseBinaries" DependsOnTargets="DownloadReleaseBinaries">
+  <!-- This automatically runs after CheckReleaseBinaries has completed, but only if SkipDownloadReleaseBinaries is not true -->
+  <Target Name="UnzipReleaseBinaries" DependsOnTargets="DownloadReleaseBinaries" AfterTargets="CheckReleaseBinaries" Condition="'$(SkipDownloadReleaseBinaries)' != 'true'">
 	<Message Importance="High" Text="Zip file was found before starting unzip." Condition="Exists('runtimes/deps.zip')" />
 	<Message Importance="High" Text="Zip file was NOT found before starting unzip!" Condition="!Exists('runtimes/deps.zip')" />
 	<Message Importance="High" Text="Unzip '$(BinaryReleaseId)/deps.zip'" />
@@ -78,10 +80,34 @@
         OverwriteReadOnlyFiles="true"
 		Include="*.dll;*.so;*.dylib;*.metal;"
 	/>
+	<WriteLinesToFile
+		File="runtimes/version.txt"
+		Lines="$(BinaryReleaseId)"
+		Overwrite="true"
+    />
   </Target>
     
-  <Target Name="PrepareReleaseBinaries" BeforeTargets="DispatchToInnerBuilds;BeforeBuild">
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="UnzipReleaseBinaries" Properties="TargetFramework=once" />
+  <Target Name="CheckReleaseBinaries">
+    <!-- First, we read the previous binary release id from disk -->
+    <ReadLinesFromFile File="runtimes/version.txt">
+		<Output TaskParameter="Lines" ItemName="PreviousBinaryReleaseId" />
+    </ReadLinesFromFile>
+        
+    <!-- Log it to console -->
+    <Message Importance="High" Text="PreviousBinaryReleaseId: %(PreviousBinaryReleaseId.Identity), CurrentBinaryReleaseId: $(BinaryReleaseId)" />
+        
+    <!-- If the previous binary release id is the same as the current one (which we define at the top of this file), we skip the download -->
+    <PropertyGroup>
+		<SkipDownloadReleaseBinaries Condition="'%(PreviousBinaryReleaseId.Identity)' == '$(BinaryReleaseId)'">true</SkipDownloadReleaseBinaries>
+    </PropertyGroup>
+        
+    <!-- Log it to console -->
+    <Message Importance="High" Text="SkipDownloadReleaseBinaries: $(SkipDownloadReleaseBinaries)" />
   </Target>
-  
+
+  <!-- This always gets called before the build -->
+  <Target Name="PrepareReleaseBinaries" BeforeTargets="DispatchToInnerBuilds;BeforeBuild">
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="CheckReleaseBinaries" Properties="TargetFramework=once" />
+  </Target>
+    
 </Project>

--- a/LLama/LLamaSharp.csproj
+++ b/LLama/LLamaSharp.csproj
@@ -52,7 +52,11 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
   </ItemGroup>
 
-  <Target Name="DownloadReleaseBinariesInner">
+  <PropertyGroup>
+    <BinaryReleaseId>1c5eba6f8e62</BinaryReleaseId>
+  </PropertyGroup>
+
+  <Target Name="DownloadReleaseBinaries">
     <PropertyGroup>
         <BinaryReleaseId>1c5eba6f8e62</BinaryReleaseId>
     </PropertyGroup>
@@ -63,17 +67,20 @@
 		DestinationFileName="deps.zip"
 		SkipUnchangedFiles="true"
 	/>
+  </Target>
 
+  <Target Name="UnzipReleaseBinaries" DependsOnTargets="DownloadReleaseBinaries">
 	<Message Importance="High" Text="Unzip '$(BinaryReleaseId)/deps.zip'" />
 	<Unzip
 		SourceFiles="runtimes/deps.zip"
 		DestinationFolder="runtimes/deps/"
-		OverwriteReadOnlyFiles="false"
+        OverwriteReadOnlyFiles="true"
 		Include="*.dll;*.so;*.dylib;*.metal;"
 	/>
   </Target>
-  <Target Name="DownloadReleaseBinaries" BeforeTargets="DispatchToInnerBuilds;BeforeBuild">
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="DownloadReleaseBinariesInner" Properties="TargetFramework=once" />
+    
+  <Target Name="PrepareReleaseBinaries" BeforeTargets="DispatchToInnerBuilds;BeforeBuild">
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="UnzipReleaseBinaries" Properties="TargetFramework=once" />
   </Target>
   
 </Project>

--- a/LLama/LLamaSharp.csproj
+++ b/LLama/LLamaSharp.csproj
@@ -84,7 +84,7 @@
 		Include="*.dll;*.so;*.dylib;*.metal;"
 	/>
 	<WriteLinesToFile
-		File="runtimes/version.txt"
+		File="runtimes/release_id.txt"
 		Lines="$(BinaryReleaseId)"
 		Overwrite="true"
     />
@@ -92,7 +92,7 @@
     
   <Target Name="CheckReleaseBinaries">
     <!-- First, we read the previous binary release id from disk -->    
-    <ReadLinesFromFile File="runtimes/version.txt">
+    <ReadLinesFromFile File="runtimes/release_id.txt">
 		<Output TaskParameter="Lines" ItemName="PreviousBinaryReleaseId" />
     </ReadLinesFromFile>
         

--- a/LLama/LLamaSharp.csproj
+++ b/LLama/LLamaSharp.csproj
@@ -68,6 +68,8 @@
   </Target>
 
   <Target Name="UnzipReleaseBinaries" DependsOnTargets="DownloadReleaseBinaries">
+	<Error Condition="!Exists('$(BinaryReleaseId)/deps.zip')" Text="Zip file was NOT found before starting unzip!" />
+	<Message Importance="High" Text="Zip file was found before starting unzip." Condition="Exists('$(BinaryReleaseId)/deps.zip')" />
 	<Message Importance="High" Text="Unzip '$(BinaryReleaseId)/deps.zip'" />
 	<Unzip
 		SourceFiles="runtimes/deps.zip"

--- a/LLama/LLamaSharp.csproj
+++ b/LLama/LLamaSharp.csproj
@@ -56,6 +56,11 @@
     <BinaryReleaseId>1c5eba6f8e62</BinaryReleaseId>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <FirstTargetFramework Condition=" '$(TargetFrameworks)' == '' ">$(TargetFramework)</FirstTargetFramework>
+    <FirstTargetFramework Condition=" '$(FirstTargetFrameworks)' == '' ">$(TargetFrameworks.Split(';')[0])</FirstTargetFramework>
+  </PropertyGroup>
+
   <!-- When UnzipReleaseBinaries is called, this will run first, as UnzipReleaseBinaries depends on it (check DependsOnTargets of UnzipReleaseBinaries) -->
   <Target Name="DownloadReleaseBinaries">
 	<Message Importance="High" Text="Download '$(BinaryReleaseId)/deps.zip' to 'runtimes'" />
@@ -88,7 +93,7 @@
   </Target>
     
   <Target Name="CheckReleaseBinaries">
-    <!-- First, we read the previous binary release id from disk -->
+    <!-- First, we read the previous binary release id from disk -->    
     <ReadLinesFromFile File="runtimes/version.txt">
 		<Output TaskParameter="Lines" ItemName="PreviousBinaryReleaseId" />
     </ReadLinesFromFile>
@@ -106,8 +111,8 @@
   </Target>
 
   <!-- This always gets called before the build -->
-  <Target Name="PrepareReleaseBinaries" BeforeTargets="BeforeBuild">
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="CheckReleaseBinaries" />
+  <Target Name="PrepareReleaseBinaries" BeforeTargets="DispatchToInnerBuilds;BeforeBuild">
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="CheckReleaseBinaries" Properties="TargetFramework=$(FirstTargetFramework)" />
   </Target>
     
 </Project>

--- a/LLama/LLamaSharp.csproj
+++ b/LLama/LLamaSharp.csproj
@@ -106,8 +106,8 @@
   </Target>
 
   <!-- This always gets called before the build -->
-  <Target Name="PrepareReleaseBinaries" BeforeTargets="DispatchToInnerBuilds;BeforeBuild">
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="CheckReleaseBinaries" Properties="TargetFramework=once" />
+  <Target Name="PrepareReleaseBinaries" BeforeTargets="BeforeBuild">
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="CheckReleaseBinaries" />
   </Target>
     
 </Project>

--- a/LLama/LLamaSharp.csproj
+++ b/LLama/LLamaSharp.csproj
@@ -57,9 +57,6 @@
   </PropertyGroup>
 
   <Target Name="DownloadReleaseBinaries">
-    <PropertyGroup>
-        <BinaryReleaseId>1c5eba6f8e62</BinaryReleaseId>
-    </PropertyGroup>
       
 	<Message Importance="High" Text="Download '$(BinaryReleaseId)/deps.zip' to 'runtimes'" />
 	<DownloadFile


### PR DESCRIPTION
Attempt to fix CI randomly failing due to "because the file does not exist or is inaccessible" when trying to unzip the deps from `LLamaBinaries`.

Microsoft [mentions](https://learn.microsoft.com/en-us/visualstudio/msbuild/target-build-order?view=vs-2022) the following for the target build order:

`In general, you shouldn't depend on the declaration order to specify what tasks run before other tasks.`

This PR splits up the download & unzip targets and makes the unzip target depend on the download target, so that they can never be executed in the wrong order, and adds download retries so that the build does not fail if there is a temporary issue when downloading the file.