### PR TITLE
Include debug symbols with NuGet packages

### DIFF
--- a/.github/prepare_release.sh
+++ b/.github/prepare_release.sh
@@ -65,9 +65,9 @@ fi
 
 cd ..
 # pack the main package
-dotnet pack ./LLama/LLamaSharp.csproj -c Release -o ./temp/ /p:PackageVersion=$updated_version /p:Version=$updated_version;
-dotnet pack ./LLama.SemanticKernel/LLamaSharp.SemanticKernel.csproj -c Release -o ./temp/ /p:PackageVersion=$updated_version /p:Version=$updated_version;
-dotnet pack ./LLama.KernelMemory/LLamaSharp.KernelMemory.csproj -c Release -o ./temp/ /p:PackageVersion=$updated_version /p:Version=$updated_version;
+dotnet pack ./LLama/LLamaSharp.csproj -c Release -o ./temp/ /p:PackageVersion=$updated_version /p:Version=$updated_version /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg;
+dotnet pack ./LLama.SemanticKernel/LLamaSharp.SemanticKernel.csproj -c Release -o ./temp/ /p:PackageVersion=$updated_version /p:Version=$updated_version /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg;
+dotnet pack ./LLama.KernelMemory/LLamaSharp.KernelMemory.csproj -c Release -o ./temp/ /p:PackageVersion=$updated_version /p:Version=$updated_version /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg;
 
 # pack the backends
 cd temp


### PR DESCRIPTION
Just adding symbols [per the docs](https://learn.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg) so users can step into the code more reliably.