### PR TITLE
General Code Cleanup

### DIFF
--- a/LLama/Abstractions/IModelParams.cs
+++ b/LLama/Abstractions/IModelParams.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -214,7 +213,7 @@ namespace LLama.Abstractions
         /// <inheritdoc/>
         public override TensorSplitsCollection Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            var arr = JsonSerializer.Deserialize<float[]>(ref reader, options) ?? Array.Empty<float>();
+            var arr = JsonSerializer.Deserialize<float[]>(ref reader, options) ?? [ ];
             return new TensorSplitsCollection(arr);
         }
 

--- a/LLama/Abstractions/INativeLibrary.cs
+++ b/LLama/Abstractions/INativeLibrary.cs
@@ -1,7 +1,5 @@
-﻿using LLama.Native;
-using System;
+using LLama.Native;
 using System.Collections.Generic;
-using System.Text;
 
 namespace LLama.Abstractions
 {

--- a/LLama/Abstractions/INativeLibrarySelectingPolicy.cs
+++ b/LLama/Abstractions/INativeLibrarySelectingPolicy.cs
@@ -1,7 +1,5 @@
-﻿using LLama.Native;
-using System;
+using LLama.Native;
 using System.Collections.Generic;
-using System.Text;
 
 namespace LLama.Abstractions
 {

--- a/LLama/ChatSession.cs
+++ b/LLama/ChatSession.cs
@@ -624,7 +624,7 @@ public record SessionState
     /// <summary>
     /// The input transform pipeline used in this session.
     /// </summary>
-    public ITextTransform[] InputTransformPipeline { get; set; } = Array.Empty<ITextTransform>();
+    public ITextTransform[] InputTransformPipeline { get; set; } = [ ];
 
     /// <summary>
     /// The output transform used in this session.
@@ -639,7 +639,7 @@ public record SessionState
     /// <summary>
     /// The the chat history messages for this session.
     /// </summary>
-    public ChatHistory.Message[] History { get; set; } = Array.Empty<ChatHistory.Message>();
+    public ChatHistory.Message[] History { get; set; } = [ ];
 
     /// <summary>
     /// Create a new session state.
@@ -741,7 +741,7 @@ public record SessionState
             inputTransforms = File.Exists(inputTransformFilepath) ? 
                 (JsonSerializer.Deserialize<ITextTransform[]>(File.ReadAllText(inputTransformFilepath))
                 ?? throw new ArgumentException("Input transform file is invalid", nameof(path)))
-                : Array.Empty<ITextTransform>();
+                : [ ];
         }
         catch (JsonException)
         {

--- a/LLama/Common/PolymorphicJSONConverter.cs
+++ b/LLama/Common/PolymorphicJSONConverter.cs
@@ -1,9 +1,6 @@
-﻿using LLama.Abstractions;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 

--- a/LLama/Extensions/EncodingExtensions.cs
+++ b/LLama/Extensions/EncodingExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text;
 
 namespace LLama.Extensions;

--- a/LLama/Extensions/IReadOnlyListExtensions.cs
+++ b/LLama/Extensions/IReadOnlyListExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Buffers;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Text;

--- a/LLama/Grammars/GBNFGrammarParser.cs
+++ b/LLama/Grammars/GBNFGrammarParser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -19,7 +19,7 @@ namespace LLama.Grammars
         // copied from llama.cpp
         private static uint DecodeUTF8(ref ReadOnlySpan<byte> src)
         {
-            int[] lookup = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 3, 4 };
+            Span<int> lookup = [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 3, 4 ];
 
             byte firstByte = src[0];
             byte highbits = (byte)(firstByte >> 4);

--- a/LLama/Grammars/GrammarRule.cs
+++ b/LLama/Grammars/GrammarRule.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using LLama.Exceptions;
 using LLama.Native;

--- a/LLama/LLamaContext.cs
+++ b/LLama/LLamaContext.cs
@@ -7,13 +7,11 @@ using System.Text;
 using System.IO;
 using System.IO.MemoryMappedFiles;
 using LLama.Common;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using LLama.Abstractions;
 using LLama.Sampling;
 using Microsoft.Extensions.Logging;
 using System.Threading;
-using System.Security.Cryptography;
 
 namespace LLama
 {

--- a/LLama/LLamaEmbedder.cs
+++ b/LLama/LLamaEmbedder.cs
@@ -105,7 +105,7 @@ namespace LLama
                     embeddings = NativeApi.llama_get_embeddings_seq(Context.NativeHandle, LLamaSeqId.Zero);
 
                 if (embeddings == null)
-                    return Array.Empty<float>();
+                    return [ ];
 
                 return new Span<float>(embeddings, Context.EmbeddingSize).ToArray();
             }

--- a/LLama/LLamaInstructExecutor.cs
+++ b/LLama/LLamaInstructExecutor.cs
@@ -9,7 +9,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using LLama.Exceptions;
-using LLama.Extensions;
 using Microsoft.Extensions.Logging;
 
 namespace LLama
@@ -119,7 +118,7 @@ namespace LLama
         /// <inheritdoc />
         protected override Task PreprocessInputs(string text, InferStateArgs args)
         {
-            args.Antiprompts ??= new List<string>();
+            args.Antiprompts ??= [ ];
             args.Antiprompts.Add(_instructionPrefix);
             if (_is_prompt_run)
             {

--- a/LLama/LLamaInteractExecutor.cs
+++ b/LLama/LLamaInteractExecutor.cs
@@ -9,7 +9,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using LLama.Exceptions;
-using LLama.Extensions;
 using Microsoft.Extensions.Logging;
 
 

--- a/LLama/LLamaStatelessExecutor.cs
+++ b/LLama/LLamaStatelessExecutor.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading;
 using LLama.Exceptions;
 using LLama.Native;
@@ -27,9 +26,6 @@ namespace LLama
         
         // LLava Section
         public bool IsMultiModal => false;
-
-        /// <inheritdoc />
-        public bool MultiModalProject { get;  }
 
         /// <inheritdoc />
         public LLavaWeights? ClipModel { get;  }

--- a/LLama/LLamaTemplate.cs
+++ b/LLama/LLamaTemplate.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;

--- a/LLama/LLamaTransforms.cs
+++ b/LLama/LLamaTransforms.cs
@@ -1,4 +1,4 @@
-﻿using LLama.Abstractions;
+using LLama.Abstractions;
 using LLama.Common;
 using System.Collections.Generic;
 using System.Linq;
@@ -196,7 +196,7 @@ namespace LLama
                 int maxKeywordLength,
                 bool removeAllMatchedTokens)
             {
-                _keywords = new(keywords);
+                _keywords = [ ..keywords ];
                 _maxKeywordLength = maxKeywordLength;
                 _removeAllMatchedTokens = removeAllMatchedTokens;
             }
@@ -212,7 +212,7 @@ namespace LLama
             /// <param name="removeAllMatchedTokens">If set to true, when getting a matched keyword, all the related tokens will be removed. Otherwise only the part of keyword will be removed.</param>
             public KeywordTextOutputStreamTransform(IEnumerable<string> keywords, int redundancyLength = 3, bool removeAllMatchedTokens = false)
             {
-                _keywords = new(keywords);
+                _keywords = [ ..keywords ];
                 _maxKeywordLength = _keywords.Max(x => x.Length) + redundancyLength;
                 _maxKeywordLength = _keywords.Select(x => x.Length).Max() + redundancyLength;
                 _removeAllMatchedTokens = removeAllMatchedTokens;

--- a/LLama/Native/GroupDisposable.cs
+++ b/LLama/Native/GroupDisposable.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Buffers;
+using System;
 using System.Collections.Generic;
 
 namespace LLama.Native;

--- a/LLama/Native/LLamaBatch.cs
+++ b/LLama/Native/LLamaBatch.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace LLama.Native;
 

--- a/LLama/Native/LLamaBatchEmbeddings.cs
+++ b/LLama/Native/LLamaBatchEmbeddings.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace LLama.Native;
 

--- a/LLama/Native/LLamaChatMessage.cs
+++ b/LLama/Native/LLamaChatMessage.cs
@@ -1,5 +1,3 @@
-using System.Runtime.InteropServices;
-
 namespace LLama.Native;
 
 /// <summary>

--- a/LLama/Native/LLamaContextParams.cs
+++ b/LLama/Native/LLamaContextParams.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.InteropServices;
 
 namespace LLama.Native
 {

--- a/LLama/Native/LLamaGrammarElement.cs
+++ b/LLama/Native/LLamaGrammarElement.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 
 namespace LLama.Native
 {

--- a/LLama/Native/LLamaKvCacheView.cs
+++ b/LLama/Native/LLamaKvCacheView.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.InteropServices;
 
 namespace LLama.Native;
 

--- a/LLama/Native/LLamaModelMetadataOverride.cs
+++ b/LLama/Native/LLamaModelMetadataOverride.cs
@@ -1,5 +1,3 @@
-﻿using System.Runtime.InteropServices;
-
 namespace LLama.Native;
 
 /// <summary>

--- a/LLama/Native/LLamaModelParams.cs
+++ b/LLama/Native/LLamaModelParams.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.InteropServices;
 
 namespace LLama.Native
 {

--- a/LLama/Native/LLamaModelQuantizeParams.cs
+++ b/LLama/Native/LLamaModelQuantizeParams.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.InteropServices;
+using System;
 
 namespace LLama.Native
 {

--- a/LLama/Native/LLamaNativeBatch.cs
+++ b/LLama/Native/LLamaNativeBatch.cs
@@ -1,5 +1,3 @@
-﻿using System.Runtime.InteropServices;
-
 namespace LLama.Native;
 
 /// <summary>

--- a/LLama/Native/LLamaPos.cs
+++ b/LLama/Native/LLamaPos.cs
@@ -1,5 +1,3 @@
-﻿using System.Runtime.InteropServices;
-
 namespace LLama.Native;
 
 /// <summary>

--- a/LLama/Native/LLamaSeqId.cs
+++ b/LLama/Native/LLamaSeqId.cs
@@ -1,5 +1,3 @@
-using System.Runtime.InteropServices;
-
 namespace LLama.Native;
 
 /// <summary>

--- a/LLama/Native/LLamaTimings.cs
+++ b/LLama/Native/LLamaTimings.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.InteropServices;
 
 namespace LLama.Native;
 

--- a/LLama/Native/LLamaToken.cs
+++ b/LLama/Native/LLamaToken.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 
 namespace LLama.Native;
 

--- a/LLama/Native/LLamaTokenData.cs
+++ b/LLama/Native/LLamaTokenData.cs
@@ -1,5 +1,3 @@
-﻿using System.Runtime.InteropServices;
-
 namespace LLama.Native;
 
 /// <summary>

--- a/LLama/Native/LLamaTokenDataArray.cs
+++ b/LLama/Native/LLamaTokenDataArray.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Buffers;
-using System.Runtime.InteropServices;
 
 namespace LLama.Native
 {

--- a/LLama/Native/LLavaImageEmbed.cs
+++ b/LLama/Native/LLavaImageEmbed.cs
@@ -1,5 +1,3 @@
-using System.Runtime.InteropServices;
-
 namespace LLama.Native;
 
 /// <summary>

--- a/LLama/Native/Load/DefaultNativeLibrarySelectingPolicy.cs
+++ b/LLama/Native/Load/DefaultNativeLibrarySelectingPolicy.cs
@@ -1,6 +1,5 @@
-﻿using LLama.Abstractions;
+using LLama.Abstractions;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace LLama.Native
 {

--- a/LLama/Native/Load/NativeLibraryUtils.cs
+++ b/LLama/Native/Load/NativeLibraryUtils.cs
@@ -1,9 +1,8 @@
-﻿using LLama.Abstractions;
+using LLama.Abstractions;
 using LLama.Exceptions;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace LLama.Native
 {

--- a/LLama/Native/Load/NativeLibraryWithAvx.cs
+++ b/LLama/Native/Load/NativeLibraryWithAvx.cs
@@ -1,6 +1,5 @@
-﻿using LLama.Abstractions;
+using LLama.Abstractions;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace LLama.Native
 {

--- a/LLama/Native/Load/NativeLibraryWithCuda.cs
+++ b/LLama/Native/Load/NativeLibraryWithCuda.cs
@@ -1,6 +1,5 @@
-﻿using LLama.Abstractions;
+using LLama.Abstractions;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace LLama.Native
 {

--- a/LLama/Native/Load/NativeLibraryWithMacOrFallback.cs
+++ b/LLama/Native/Load/NativeLibraryWithMacOrFallback.cs
@@ -1,6 +1,5 @@
-﻿using LLama.Abstractions;
+using LLama.Abstractions;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace LLama.Native
 {

--- a/LLama/Native/Load/NativeLibraryWithVulkan.cs
+++ b/LLama/Native/Load/NativeLibraryWithVulkan.cs
@@ -1,6 +1,5 @@
-﻿using LLama.Abstractions;
+using LLama.Abstractions;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace LLama.Native
 {

--- a/LLama/Native/Load/SystemInfo.cs
+++ b/LLama/Native/Load/SystemInfo.cs
@@ -1,7 +1,6 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 
@@ -170,10 +169,10 @@ namespace LLama.Native
             {
                 // List of default cuda paths
                 string[] defaultCudaPaths =
-                {
+                [
                     "/usr/local/bin/cuda",
                     "/usr/local/cuda",
-                };
+                ];
                 
                 // Loop through every default path to find the version
                 foreach (var path in defaultCudaPaths)

--- a/LLama/Native/Load/UnknownNativeLibrary.cs
+++ b/LLama/Native/Load/UnknownNativeLibrary.cs
@@ -1,9 +1,6 @@
-﻿using LLama.Abstractions;
+using LLama.Abstractions;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace LLama.Native
 {

--- a/LLama/Native/NativeApi.Grammar.cs
+++ b/LLama/Native/NativeApi.Grammar.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.InteropServices;
 
 namespace LLama.Native
 {

--- a/LLama/Native/NativeApi.LLava.cs
+++ b/LLama/Native/NativeApi.LLava.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Runtime.InteropServices;
 
 namespace LLama.Native;
 
-using clip_ctx = IntPtr;
 public static unsafe partial class NativeApi
 {
     /// <summary>

--- a/LLama/Native/NativeApi.Load.cs
+++ b/LLama/Native/NativeApi.Load.cs
@@ -1,6 +1,5 @@
 using LLama.Exceptions;
 using System;
-using System.Runtime.InteropServices;
 using LLama.Abstractions;
 
 namespace LLama.Native

--- a/LLama/Native/NativeApi.Quantize.cs
+++ b/LLama/Native/NativeApi.Quantize.cs
@@ -1,5 +1,3 @@
-﻿using System.Runtime.InteropServices;
-
 namespace LLama.Native
 {
     public static partial class NativeApi

--- a/LLama/Native/NativeApi.Sampling.cs
+++ b/LLama/Native/NativeApi.Sampling.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.InteropServices;
+using System;
 
 namespace LLama.Native
 {

--- a/LLama/Native/NativeApi.cs
+++ b/LLama/Native/NativeApi.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.InteropServices;
 
 #pragma warning disable IDE1006 // Naming Styles
 

--- a/LLama/Native/NativeLogConfig.cs
+++ b/LLama/Native/NativeLogConfig.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using Microsoft.Extensions.Logging;

--- a/LLama/Native/SafeLLamaContextHandle.cs
+++ b/LLama/Native/SafeLLamaContextHandle.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using System.Text;
 using LLama.Exceptions;
 

--- a/LLama/Native/SafeLLamaGrammarHandle.cs
+++ b/LLama/Native/SafeLLamaGrammarHandle.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/LLama/Native/SafeLLamaHandleBase.cs
+++ b/LLama/Native/SafeLLamaHandleBase.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.InteropServices;
+using System;
 
 namespace LLama.Native
 {

--- a/LLama/Native/SafeLlamaModelHandle.cs
+++ b/LLama/Native/SafeLlamaModelHandle.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Text;
 using LLama.Exceptions;
 

--- a/LLama/Native/SafeLlavaModelHandle.cs
+++ b/LLama/Native/SafeLlavaModelHandle.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Runtime.InteropServices;
 using LLama.Exceptions;
 
 

--- a/LLama/Sampling/DefaultSamplingPipeline.cs
+++ b/LLama/Sampling/DefaultSamplingPipeline.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using LLama.Extensions;
 using LLama.Native;
 
 namespace LLama.Sampling;

--- a/LLama/Sampling/ISamplingPipeline.cs
+++ b/LLama/Sampling/ISamplingPipeline.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Buffers;
+using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using LLama.Native;
 
 namespace LLama.Sampling;

--- a/LLama/Sampling/Mirostat2SamplingPipeline.cs
+++ b/LLama/Sampling/Mirostat2SamplingPipeline.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using LLama.Native;
 
 namespace LLama.Sampling;
@@ -6,7 +6,7 @@ namespace LLama.Sampling;
 /// <summary>
 /// A sampling pipeline which uses mirostat (v2) to select tokens
 /// </summary>
-public class Mirostate2SamplingPipeline
+public class Mirostat2SamplingPipeline
     : BaseSamplingPipeline
 {
     private const float DEFAULT_TAU = 5;
@@ -58,7 +58,7 @@ public class Mirostate2SamplingPipeline
     /// <inheritdoc />
     public override ISamplingPipeline Clone()
     {
-        return new Mirostate2SamplingPipeline
+        return new Mirostat2SamplingPipeline
         {
             Grammar = Grammar?.Clone(),
 

--- a/LLama/Sampling/MirostatSamplingPipeline.cs
+++ b/LLama/Sampling/MirostatSamplingPipeline.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using LLama.Native;
 
 namespace LLama.Sampling;
@@ -6,7 +6,7 @@ namespace LLama.Sampling;
 /// <summary>
 /// A sampling pipeline which uses mirostat (v1) to select tokens
 /// </summary>
-public class MirostateSamplingPipeline
+public class MirostatSamplingPipeline
     : BaseSamplingPipeline
 {
     private const int MIROSTAT_M = 100;
@@ -59,7 +59,7 @@ public class MirostateSamplingPipeline
     /// <inheritdoc />
     public override ISamplingPipeline Clone()
     {
-        return new MirostateSamplingPipeline
+        return new MirostatSamplingPipeline
         {
             Grammar = Grammar?.Clone(),
 

--- a/LLama/StreamingTokenDecoder.cs
+++ b/LLama/StreamingTokenDecoder.cs
@@ -1,4 +1,3 @@
-using System.Buffers;
 using System.Diagnostics;
 using System;
 using System.Collections.Generic;

--- a/LLama/Transformers/PromptTemplateTransformer.cs
+++ b/LLama/Transformers/PromptTemplateTransformer.cs
@@ -1,5 +1,3 @@
-﻿using System;
-using System.Text;
 using LLama.Abstractions;
 using LLama.Common;
 
@@ -56,12 +54,7 @@ public class PromptTemplateTransformer(LLamaWeights model,
         var templateBuffer = template.Apply();
 
         // convert the resulting buffer to a string
-#if NET6_0_OR_GREATER
-        return LLamaTemplate.Encoding.GetString(templateBuffer);
-#endif
-
-        // need the ToArray call for netstandard -- avoided in newer runtimes
-        return LLamaTemplate.Encoding.GetString(templateBuffer.ToArray());
+        return LLamaTemplate.Encoding.GetStringFromSpan(templateBuffer);
     }
-    #endregion utils
+#endregion utils
 }

--- a/LLama/Usings.cs
+++ b/LLama/Usings.cs
@@ -1,1 +1,3 @@
-﻿global using LLama.Extensions;
+global using LLama.Extensions;
+global using System.Buffers;
+global using System.Runtime.InteropServices;


### PR DESCRIPTION
 - Removed unused field from StatelessExecutor
 - Renamed `Mirostat` (from `Mirostate`)
 - Removed unnecessary temporary array allocation in `Conversation.Prompt`
 - Removed all unused `using` statements
   - Moved some common usings to `global using`
 - Used [ collection expressions ] where possible