### PR TITLE
Deprecate `InferenceParams` sampler configuration properties

### DIFF
--- a/LLama.Examples/Examples/ChatSessionStripRoleName.cs
+++ b/LLama.Examples/Examples/ChatSessionStripRoleName.cs
@@ -1,4 +1,5 @@
-﻿using LLama.Common;
+using LLama.Common;
+using LLama.Sampling;
 
 namespace LLama.Examples.Examples;
 
@@ -27,9 +28,12 @@ public class ChatSessionStripRoleName
             new string[] { "User:", "Assistant:" },
             redundancyLength: 8));
 
-        InferenceParams inferenceParams = new InferenceParams()
+        var inferenceParams = new InferenceParams
         {
-            Temperature = 0.9f,
+            SamplingPipeline = new DefaultSamplingPipeline
+            {
+                Temperature = 0.9f
+            },
             AntiPrompts = new List<string> { "User:" }
         };
 

--- a/LLama.Examples/Examples/ChatSessionWithHistory.cs
+++ b/LLama.Examples/Examples/ChatSessionWithHistory.cs
@@ -1,4 +1,5 @@
 using LLama.Common;
+using LLama.Sampling;
 
 namespace LLama.Examples.Examples;
 
@@ -39,9 +40,12 @@ public class ChatSessionWithHistory
             new string[] { "User:", "Assistant:" },
             redundancyLength: 8));
 
-        InferenceParams inferenceParams = new InferenceParams()
+        var inferenceParams = new InferenceParams
         {
-            Temperature = 0.9f,
+            SamplingPipeline = new DefaultSamplingPipeline
+            {
+                Temperature = 0.9f
+            },
             AntiPrompts = new List<string> { "User:" }
         };
 

--- a/LLama.Examples/Examples/ChatSessionWithRestart.cs
+++ b/LLama.Examples/Examples/ChatSessionWithRestart.cs
@@ -1,4 +1,5 @@
 using LLama.Common;
+using LLama.Sampling;
 
 namespace LLama.Examples.Examples;
 
@@ -29,9 +30,12 @@ public class ChatSessionWithRestart
         ChatSession session = new ChatSession(executor);
         session.LoadSession(resetState);
 
-        InferenceParams inferenceParams = new InferenceParams()
+        var inferenceParams = new InferenceParams
         {
-            Temperature = 0.9f,
+            SamplingPipeline = new DefaultSamplingPipeline
+            {
+                Temperature = 0.9f
+            },
             AntiPrompts = new List<string> { "User:" }
         };
 

--- a/LLama.Examples/Examples/ChatSessionWithRoleName.cs
+++ b/LLama.Examples/Examples/ChatSessionWithRoleName.cs
@@ -1,4 +1,5 @@
-﻿using LLama.Common;
+using LLama.Common;
+using LLama.Sampling;
 
 namespace LLama.Examples.Examples;
 
@@ -22,9 +23,12 @@ public class ChatSessionWithRoleName
 
         ChatSession session = new(executor, chatHistory);
 
-        InferenceParams inferenceParams = new InferenceParams()
+        var inferenceParams = new InferenceParams
         {
-            Temperature = 0.9f,
+            SamplingPipeline = new DefaultSamplingPipeline
+            {
+                Temperature = 0.9f
+            },
             AntiPrompts = new List<string> { "User:" }
         };
 

--- a/LLama.Examples/Examples/CodingAssistant.cs
+++ b/LLama.Examples/Examples/CodingAssistant.cs
@@ -1,4 +1,6 @@
-﻿namespace LLama.Examples.Examples
+using LLama.Sampling;
+
+namespace LLama.Examples.Examples
 {
     using LLama.Common;
     using System;
@@ -40,9 +42,12 @@
                 "\nWrite 'exit' to exit");
             Console.ForegroundColor = ConsoleColor.White;
 
-            var inferenceParams = new InferenceParams()
+            var inferenceParams = new InferenceParams
             {
-                Temperature = 0.8f,
+                SamplingPipeline = new DefaultSamplingPipeline
+                {
+                    Temperature = 0.8f
+                },
                 MaxTokens = -1,
             };
 

--- a/LLama.Examples/Examples/GetEmbeddings.cs
+++ b/LLama.Examples/Examples/GetEmbeddings.cs
@@ -1,4 +1,4 @@
-﻿using LLama.Common;
+using LLama.Common;
 
 namespace LLama.Examples.Examples
 {

--- a/LLama.Examples/Examples/GrammarJsonResponse.cs
+++ b/LLama.Examples/Examples/GrammarJsonResponse.cs
@@ -1,5 +1,6 @@
-﻿using LLama.Common;
+using LLama.Common;
 using LLama.Grammars;
+using LLama.Sampling;
 
 namespace LLama.Examples.Examples
 {
@@ -27,10 +28,13 @@ namespace LLama.Examples.Examples
             using var grammarInstance = grammar.CreateInstance();
             var inferenceParams = new InferenceParams()
             {
-                Temperature = 0.6f,
+                SamplingPipeline = new DefaultSamplingPipeline
+                {
+                    Temperature = 0.6f,
+                    Grammar = grammarInstance
+                },
                 AntiPrompts = new List<string> { "Question:", "#", "Question: ", ".\n" },
                 MaxTokens = 50,
-                Grammar = grammarInstance
             };
 
             while (true)

--- a/LLama.Examples/Examples/InstructModeExecute.cs
+++ b/LLama.Examples/Examples/InstructModeExecute.cs
@@ -1,4 +1,5 @@
-﻿using LLama.Common;
+using LLama.Common;
+using LLama.Sampling;
 
 namespace LLama.Examples.Examples
 {
@@ -25,7 +26,14 @@ namespace LLama.Examples.Examples
                 "make friend with human, no less than 200 words.\"");
             Console.ForegroundColor = ConsoleColor.White;
 
-            var inferenceParams = new InferenceParams() { Temperature = 0.8f, MaxTokens = 600 };
+            var inferenceParams = new InferenceParams
+            {
+                SamplingPipeline = new DefaultSamplingPipeline
+                {
+                    Temperature = 0.8f
+                },
+                MaxTokens = 600
+            };
 
             while (true)
             {

--- a/LLama.Examples/Examples/LLama3ChatSession.cs
+++ b/LLama.Examples/Examples/LLama3ChatSession.cs
@@ -1,4 +1,5 @@
-﻿using LLama.Common;
+using LLama.Common;
+using LLama.Sampling;
 using LLama.Transformers;
 
 namespace LLama.Examples.Examples;
@@ -37,10 +38,14 @@ public class LLama3ChatSession
             [model.Tokens.EndOfTurnToken!, "�"],
             redundancyLength: 5));
 
-        var inferenceParams = new InferenceParams()
+        var inferenceParams = new InferenceParams
         {
+            SamplingPipeline = new DefaultSamplingPipeline
+            {
+                Temperature = 0.6f
+            },
+
             MaxTokens = -1, // keep generating tokens until the anti prompt is encountered
-            Temperature = 0.6f,
             AntiPrompts = [model.Tokens.EndOfTurnToken!] // model specific end of turn string
         };
 

--- a/LLama.Examples/Examples/LlavaInteractiveModeExecute.cs
+++ b/LLama.Examples/Examples/LlavaInteractiveModeExecute.cs
@@ -1,7 +1,8 @@
-﻿using System.Text.RegularExpressions;
+using System.Text.RegularExpressions;
 using LLama.Common;
 using Spectre.Console;
 using LLama.Native;
+using LLama.Sampling;
 
 namespace LLama.Examples.Examples
 {
@@ -30,9 +31,19 @@ namespace LLama.Examples.Examples
 
             Console.ForegroundColor = ConsoleColor.Yellow;
             Console.WriteLine("The executor has been enabled. In this example, the prompt is printed, the maximum tokens is set to {0} and the context size is {1}.", maxTokens, parameters.ContextSize );
-            Console.WriteLine("To send an image, enter its filename in curly braces, like this {c:/image.jpg}.");  
+            Console.WriteLine("To send an image, enter its filename in curly braces, like this {c:/image.jpg}.");
 
-            var inferenceParams = new InferenceParams() { Temperature = 0.1f, AntiPrompts = new List<string> { "\nUSER:" }, MaxTokens = maxTokens };
+            var inferenceParams = new InferenceParams
+            {
+                SamplingPipeline = new DefaultSamplingPipeline
+                {
+                    Temperature = 0.1f
+                },
+
+                AntiPrompts = new List<string> { "\nUSER:" },
+                MaxTokens = maxTokens
+
+            };
 
             do
             {

--- a/LLama.Examples/Examples/LoadAndSaveSession.cs
+++ b/LLama.Examples/Examples/LoadAndSaveSession.cs
@@ -1,4 +1,5 @@
-﻿using LLama.Common;
+using LLama.Common;
+using LLama.Sampling;
 
 namespace LLama.Examples.Examples
 {
@@ -35,7 +36,10 @@ namespace LLama.Examples.Examples
                         new ChatHistory.Message(AuthorRole.User, prompt),
                         new InferenceParams()
                         {
-                            Temperature = 0.6f,
+                            SamplingPipeline = new DefaultSamplingPipeline
+                            {
+                                Temperature = 0.6f
+                            },
                             AntiPrompts = new List<string> { "User:" }
                         }))
                 {

--- a/LLama.Examples/Examples/LoadAndSaveState.cs
+++ b/LLama.Examples/Examples/LoadAndSaveState.cs
@@ -1,4 +1,5 @@
-﻿using LLama.Common;
+using LLama.Common;
+using LLama.Sampling;
 
 namespace LLama.Examples.Examples
 {
@@ -27,7 +28,15 @@ namespace LLama.Examples.Examples
             Console.ForegroundColor = ConsoleColor.White;
             Console.Write(prompt);
 
-            var inferenceParams = new InferenceParams() { Temperature = 0.6f, AntiPrompts = new List<string> { "User:" } };
+            var inferenceParams = new InferenceParams
+            {
+                SamplingPipeline = new DefaultSamplingPipeline
+                {
+                    Temperature = 0.6f
+                },
+
+                AntiPrompts = new List<string> { "User:" }
+            };
 
             while (true)
             {

--- a/LLama.Examples/Examples/StatelessModeExecute.cs
+++ b/LLama.Examples/Examples/StatelessModeExecute.cs
@@ -1,5 +1,6 @@
-﻿using LLama.Common;
+using LLama.Common;
 using LLama.Examples.Extensions;
+using LLama.Sampling;
 
 namespace LLama.Examples.Examples
 {
@@ -24,7 +25,16 @@ namespace LLama.Examples.Examples
                 "a prompt for it yourself!");
             Console.ForegroundColor = ConsoleColor.White;
 
-            var inferenceParams = new InferenceParams() { Temperature = 0.6f, AntiPrompts = new List<string> { "Question:", "#", "Question: ", ".\n" }, MaxTokens = 50 };
+            var inferenceParams = new InferenceParams
+            {
+                SamplingPipeline = new DefaultSamplingPipeline
+                {
+                    Temperature = 0.6f
+                },
+
+                AntiPrompts = new List<string> { "Question:", "#", "Question: ", ".\n" },
+                MaxTokens = 50
+            };
 
             while (true)
             {

--- a/LLama.Examples/Examples/TalkToYourself.cs
+++ b/LLama.Examples/Examples/TalkToYourself.cs
@@ -1,6 +1,7 @@
-﻿using System.Text;
+using System.Text;
 using LLama.Abstractions;
 using LLama.Common;
+using LLama.Sampling;
 
 namespace LLama.Examples.Examples
 {
@@ -43,11 +44,13 @@ namespace LLama.Examples.Examples
         {
             var inferenceParams = new InferenceParams
             {
-                Temperature = 0.9f,
-                AntiPrompts = new List<string> { "Alice:", "Bob:", "User:" },
+                SamplingPipeline = new Mirostat2SamplingPipeline
+                {
+                    Tau = 10
+                },
+
+                AntiPrompts = [ "Alice:", "Bob:", "User:" ],
                 MaxTokens = 128,
-                Mirostat = MirostatType.Mirostat2,
-                MirostatTau = 10,
             };
 
             Console.ForegroundColor = ConsoleColor.White;

--- a/LLama/Abstractions/IInferenceParams.cs
+++ b/LLama/Abstractions/IInferenceParams.cs
@@ -1,14 +1,15 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using LLama.Common;
 using LLama.Native;
 using LLama.Sampling;
 
 namespace LLama.Abstractions
 {  
-	 /// <summary>
-	 /// The parameters used for inference.
-	 /// </summary>
-	public interface IInferenceParams
+    /// <summary>
+    /// The parameters used for inference.
+    /// </summary>
+    public interface IInferenceParams
     {
 		/// <summary>
 		/// number of tokens to keep from initial prompt
@@ -21,93 +22,110 @@ namespace LLama.Abstractions
 		/// </summary>
 		public int MaxTokens { get; set; }
 
-		/// <summary>
-		/// logit bias for specific tokens
-		/// </summary>
-		public Dictionary<LLamaToken, float>? LogitBias { get; set; }
+        /// <summary>
+        /// logit bias for specific tokens
+        /// </summary>
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. DefaultSamplingPipeline")]
+        public Dictionary<LLamaToken, float>? LogitBias { get; set; }
 
 		/// <summary>
 		/// Sequences where the model will stop generating further tokens.
 		/// </summary>
 		public IReadOnlyList<string> AntiPrompts { get; set; }
 
-		/// <summary>
-		///  0 or lower to use vocab size
-		/// </summary>
-		public int TopK { get; set; }
+        /// <summary>
+        ///  0 or lower to use vocab size
+        /// </summary>
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. DefaultSamplingPipeline")]
+        public int TopK { get; set; }
 
-		/// <summary>
-		/// 1.0 = disabled
-		/// </summary>
-		public float TopP { get; set; }
+        /// <summary>
+        /// 1.0 = disabled
+        /// </summary>
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. DefaultSamplingPipeline")]
+        public float TopP { get; set; }
 
         /// <summary>
         /// 0.0 = disabled
         /// </summary>
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. DefaultSamplingPipeline")]
         public float MinP { get; set; }
 
         /// <summary>
         /// 1.0 = disabled
         /// </summary>
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. DefaultSamplingPipeline")]
         public float TfsZ { get; set; }
 
-		/// <summary>
-		/// 1.0 = disabled
-		/// </summary>
-		public float TypicalP { get; set; }
+        /// <summary>
+        /// 1.0 = disabled
+        /// </summary>
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. DefaultSamplingPipeline")]
+        public float TypicalP { get; set; }
 
-		/// <summary>
-		/// 1.0 = disabled
-		/// </summary>
-		public float Temperature { get; set; }
+        /// <summary>
+        /// 1.0 = disabled
+        /// </summary>
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. DefaultSamplingPipeline")]
+        public float Temperature { get; set; }
 
-		/// <summary>
-		/// 1.0 = disabled
-		/// </summary>
-		public float RepeatPenalty { get; set; }
+        /// <summary>
+        /// 1.0 = disabled
+        /// </summary>
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. DefaultSamplingPipeline")]
+        public float RepeatPenalty { get; set; }
 
-		/// <summary>
-		/// last n tokens to penalize (0 = disable penalty, -1 = context size) (repeat_last_n)
-		/// </summary>
-		public int RepeatLastTokensCount { get; set; }
+        /// <summary>
+        /// last n tokens to penalize (0 = disable penalty, -1 = context size) (repeat_last_n)
+        /// </summary>
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. DefaultSamplingPipeline")]
+        public int RepeatLastTokensCount { get; set; }
 
-		/// <summary>
-		/// frequency penalty coefficient
-		/// 0.0 = disabled
-		/// </summary>
-		public float FrequencyPenalty { get; set; }
+        /// <summary>
+        /// frequency penalty coefficient
+        /// 0.0 = disabled
+        /// </summary>
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. DefaultSamplingPipeline")]
+        public float FrequencyPenalty { get; set; }
 
-		/// <summary>
-		/// presence penalty coefficient
-		/// 0.0 = disabled
-		/// </summary>
-		public float PresencePenalty { get; set; }
+        /// <summary>
+        /// presence penalty coefficient
+        /// 0.0 = disabled
+        /// </summary>
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. DefaultSamplingPipeline")]
+        public float PresencePenalty { get; set; }
 
-		/// <summary>
-		/// Mirostat uses tokens instead of words.
-		/// algorithm described in the paper https://arxiv.org/abs/2007.14966.
-		/// 0 = disabled, 1 = mirostat, 2 = mirostat 2.0
-		/// </summary>
-		public MirostatType Mirostat { get; set; }
+        /// <summary>
+        /// Mirostat uses tokens instead of words.
+        /// algorithm described in the paper https://arxiv.org/abs/2007.14966.
+        /// 0 = disabled, 1 = mirostat, 2 = mirostat 2.0
+        /// </summary>
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. MirostatSamplingPipeline or Mirostat2SamplingPipeline")]
+        public MirostatType Mirostat { get; set; }
 
-		/// <summary>
-		/// target entropy
-		/// </summary>
-		public float MirostatTau { get; set; }
+        /// <summary>
+        /// target entropy
+        /// </summary>
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. MirostatSamplingPipeline or Mirostat2SamplingPipeline")]
+        public float MirostatTau { get; set; }
 
-		/// <summary>
-		/// learning rate
-		/// </summary>
-		public float MirostatEta { get; set; }
+        /// <summary>
+        /// learning rate
+        /// </summary>
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. MirostatSamplingPipeline or Mirostat2SamplingPipeline")]
+        public float MirostatEta { get; set; }
 
-		/// <summary>
-		/// consider newlines as a repeatable token (penalize_nl)
-		/// </summary>
-		public bool PenalizeNL { get; set; }
+        /// <summary>
+        /// consider newlines as a repeatable token (penalize_nl)
+        /// </summary>
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. DefaultSamplingPipeline")]
+        // ReSharper disable once InconsistentNaming (obsolete, will be removed anyway)
+        public bool PenalizeNL { get; set; }
 
 		/// <summary>
 		/// Grammar to constrain possible tokens
 		/// </summary>
+		[Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. DefaultSamplingPipeline")]
 		SafeLLamaGrammarHandle? Grammar { get; set; }
 
 		/// <summary>
@@ -115,4 +133,59 @@ namespace LLama.Abstractions
 		/// </summary>
 		ISamplingPipeline? SamplingPipeline { get; set; }
 	}
+
+    internal static class IInferanceParamsExtensions
+    {
+        public static ISamplingPipeline Create(this IInferenceParams @params, ref ISamplingPipeline? pipeline)
+        {
+            // This method exists to adapt the old style of inference params to the newer sampling pipeline system. It's touching a lot
+            // of obsolete things which we don't really care about, disable the warning.
+            #pragma warning disable CS0618 // Type or member is obsolete
+
+            if (@params.Mirostat == MirostatType.Mirostat)
+            {
+                if (pipeline is not MirostatSamplingPipeline)
+                    pipeline = new MirostatSamplingPipeline();
+
+                var m = (MirostatSamplingPipeline)pipeline;
+                m.Eta = @params.MirostatEta;
+                m.Tau = @params.MirostatTau;
+                return m;
+            }
+
+            if (@params.Mirostat == MirostatType.Mirostat2)
+            {
+                if (pipeline is not Mirostat2SamplingPipeline)
+                    pipeline = new Mirostat2SamplingPipeline();
+
+                var m = (Mirostat2SamplingPipeline)pipeline;
+                m.Eta = @params.MirostatEta;
+                m.Tau = @params.MirostatTau;
+                return m;
+            }
+
+            if (pipeline is not DefaultSamplingPipeline)
+                pipeline = new DefaultSamplingPipeline();
+
+            var d = (DefaultSamplingPipeline)pipeline;
+            d.AlphaPresence = @params.PresencePenalty;
+            d.MinP = @params.MinP;
+            d.PenalizeNewline = @params.PenalizeNL;
+            d.RepeatPenalty = @params.RepeatPenalty;
+            d.TailFreeZ = @params.TfsZ;
+            d.Temperature = @params.Temperature;
+            d.TopK = @params.TopK;
+            d.TopP = @params.TopP;
+            d.AlphaFrequency = @params.FrequencyPenalty;
+            d.TypicalP = @params.TypicalP;
+            d.Grammar = @params.Grammar;
+
+            d.LogitBias.Clear();
+            @params.LogitBias?.CopyTo(d.LogitBias);
+
+            return d;
+
+            #pragma warning restore CS0618 // Type or member is obsolete
+        }
+    }
 }

--- a/LLama/Common/FixedSizeQueue.cs
+++ b/LLama/Common/FixedSizeQueue.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -81,6 +81,19 @@ namespace LLama.Common
         IEnumerator IEnumerable.GetEnumerator()
         {
             return GetEnumerator();
+        }
+
+        internal ReadOnlySpan<T> AsSpan(int count)
+        {
+            // Ensure the request isn't for more tokens than actually exist
+            count = Math.Min(count, Count);
+
+            // Take `count` items from the end
+#if NET8_0_OR_GREATER
+            return CollectionsMarshal.AsSpan(_storage)[^count..];
+#else
+            return _storage.ToArray().AsSpan(_storage.Count - count, count);
+#endif
         }
     }
 }

--- a/LLama/Common/InferenceParams.cs
+++ b/LLama/Common/InferenceParams.cs
@@ -1,7 +1,8 @@
-﻿using LLama.Abstractions;
+using LLama.Abstractions;
 using System.Collections.Generic;
 using LLama.Native;
 using LLama.Sampling;
+using System;
 
 namespace LLama.Common
 {
@@ -25,6 +26,7 @@ namespace LLama.Common
         /// <summary>
         /// logit bias for specific tokens
         /// </summary>
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. DefaultSamplingPipeline")]
         public Dictionary<LLamaToken, float>? LogitBias { get; set; } = null;
 
         /// <summary>
@@ -33,48 +35,63 @@ namespace LLama.Common
         public IReadOnlyList<string> AntiPrompts { get; set; } = [];
 
         /// <inheritdoc />
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. DefaultSamplingPipeline")]
         public int TopK { get; set; } = 40;
 
         /// <inheritdoc />
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. DefaultSamplingPipeline")]
         public float TopP { get; set; } = 0.95f;
 
         /// <inheritdoc />
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. DefaultSamplingPipeline")]
         public float MinP { get; set; } = 0.05f;
 
         /// <inheritdoc />
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. DefaultSamplingPipeline")]
         public float TfsZ { get; set; } = 1.0f;
 
         /// <inheritdoc />
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. DefaultSamplingPipeline")]
         public float TypicalP { get; set; } = 1.0f;
 
         /// <inheritdoc />
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. DefaultSamplingPipeline")]
         public float Temperature { get; set; } = 0.8f;
 
         /// <inheritdoc />
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. DefaultSamplingPipeline")]
         public float RepeatPenalty { get; set; } = 1.1f;
 
         /// <inheritdoc />
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. DefaultSamplingPipeline")]
         public int RepeatLastTokensCount { get; set; } = 64;
 
         /// <inheritdoc />
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. DefaultSamplingPipeline")]
         public float FrequencyPenalty { get; set; } = .0f;
 
         /// <inheritdoc />
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. DefaultSamplingPipeline")]
         public float PresencePenalty { get; set; } = .0f;
 
         /// <inheritdoc />
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. MirostatSamplingPipeline or Mirostat2SamplingPipeline")]
         public MirostatType Mirostat { get; set; } = MirostatType.Disable;
 
         /// <inheritdoc />
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. MirostatSamplingPipeline or Mirostat2SamplingPipeline")]
         public float MirostatTau { get; set; } = 5.0f;
 
         /// <inheritdoc />
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. MirostatSamplingPipeline or Mirostat2SamplingPipeline")]
         public float MirostatEta { get; set; } = 0.1f;
 
         /// <inheritdoc />
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. DefaultSamplingPipeline")]
         public bool PenalizeNL { get; set; } = true;
 
         /// <inheritdoc />
+        [Obsolete("Use the SamplingPipeline property instead with a configured pipeline e.g. DefaultSamplingPipeline")]
         public SafeLLamaGrammarHandle? Grammar { get; set; }
 
         /// <inheritdoc />

--- a/LLama/Extensions/DictionaryExtensions.cs
+++ b/LLama/Extensions/DictionaryExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using LLama.Native;
 
 namespace LLama.Extensions
 {
@@ -17,6 +18,12 @@ namespace LLama.Extensions
         {
             // ReSharper disable once CanSimplifyDictionaryTryGetValueWithGetValueOrDefault (this is a shim for  that method!)
             return dictionary.TryGetValue(key, out var value) ? value : defaultValue;
+        }
+
+        internal static void CopyTo<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> source, IDictionary<TKey, TValue> dest)
+        {
+            foreach (var (k, v) in source)
+                dest[k] = v;
         }
     }
 }

--- a/LLama/LLamaContext.cs
+++ b/LLama/LLamaContext.cs
@@ -2,14 +2,11 @@ using LLama.Exceptions;
 using LLama.Native;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.IO;
 using System.IO.MemoryMappedFiles;
-using LLama.Common;
 using System.Threading.Tasks;
 using LLama.Abstractions;
-using LLama.Sampling;
 using Microsoft.Extensions.Logging;
 using System.Threading;
 
@@ -82,8 +79,6 @@ namespace LLama
         /// </summary>
         public SafeLlamaModelHandle.ModelTokens Tokens { get; }
         
-        private LLamaTokenData[]? _samplingBuffer;
-
         /// <summary>
         /// Create a new LLamaContext for the given LLamaWeights
         /// </summary>
@@ -378,142 +373,6 @@ namespace LLama
             }
         }
         #endregion
-
-        /// <summary>
-        /// Sample a single token from this context, using the given sampling pipeline
-        /// </summary>
-        /// <param name="pipeline">The pipeline to use to process the logits and to select a token</param>
-        /// <param name="lastTokens">The tokens recently returned from the model</param>
-        /// <returns>The selected token</returns>
-        public LLamaToken Sample(ISamplingPipeline pipeline, ReadOnlySpan<LLamaToken> lastTokens)
-        {
-            var token = pipeline.Sample(NativeHandle, NativeHandle.GetLogits(), lastTokens);
-            pipeline.Accept(NativeHandle, token);
-            return token;
-        }
-
-        /// <summary>
-        /// Perform the sampling. Please don't use it unless you fully know what it does.
-        /// </summary>
-        /// <param name="candidates"></param>
-        /// <param name="mirostat_mu"></param>
-        /// <param name="temperature"></param>
-        /// <param name="mirostat"></param>
-        /// <param name="mirostatTau"></param>
-        /// <param name="mirostatEta"></param>
-        /// <param name="topK"></param>
-        /// <param name="topP"></param>
-        /// <param name="tfsZ"></param>
-        /// <param name="typicalP"></param>
-        /// <param name="grammar"></param>
-        /// <param name="minP"></param>
-        /// <returns></returns>
-        public LLamaToken Sample(LLamaTokenDataArray candidates, ref float? mirostat_mu, float temperature, MirostatType mirostat, 
-                                 float mirostatTau, float mirostatEta, int topK, float topP, float tfsZ, float typicalP,
-                                 SafeLLamaGrammarHandle? grammar, float minP)
-        {
-            LLamaToken id;
-
-            if (grammar != null)
-            {
-                candidates.ApplyGrammar(NativeHandle, grammar);
-            }
-
-            if (temperature <= 0)
-            {
-                // Greedy sampling
-                id = candidates.SampleTokenGreedy(NativeHandle);
-            }
-            else
-            {
-                var mu = mirostat_mu ?? (2 * mirostatTau);
-                {
-                    if (mirostat == MirostatType.Mirostat)
-                    {
-                        const int mirostat_m = 100;
-                        candidates.Temperature(NativeHandle, temperature);
-                        id = candidates.SampleTokenMirostat(NativeHandle, mirostatTau, mirostatEta, mirostat_m, ref mu);
-                    }
-                    else if (mirostat == MirostatType.Mirostat2)
-                    {
-                        candidates.Temperature(NativeHandle, temperature);
-                        id = candidates.SampleTokenMirostat2(NativeHandle, mirostatTau, mirostatEta, ref mu);
-                    }
-                    else
-                    {
-                        candidates.TopK(NativeHandle, topK);
-                        candidates.TailFree(NativeHandle, tfsZ);
-                        candidates.LocallyTypical(NativeHandle, typicalP);
-                        candidates.TopP(NativeHandle, topP);
-                        candidates.MinP(NativeHandle, minP);
-                        candidates.Temperature(NativeHandle, temperature);
-                        id = candidates.SampleToken(NativeHandle);
-                    }
-                }
-                mirostat_mu = mu;
-            }
-
-            grammar?.AcceptToken(NativeHandle, id);
-
-            return id;
-        }
-
-        /// <summary>
-        /// Apply the penalty for the tokens. Please don't use it unless you fully know what it does.
-        /// </summary>
-        /// <param name="logits_i"></param>
-        /// <param name="lastTokens"></param>
-        /// <param name="logitBias"></param>
-        /// <param name="repeatLastTokensCount"></param>
-        /// <param name="repeatPenalty"></param>
-        /// <param name="alphaFrequency"></param>
-        /// <param name="alphaPresence"></param>
-        /// <param name="penalizeNL"></param>
-        /// <returns></returns>
-        public LLamaTokenDataArray ApplyPenalty(int logits_i, IEnumerable<LLamaToken> lastTokens, Dictionary<LLamaToken, float>? logitBias = null, 
-                                                int repeatLastTokensCount = 64, float repeatPenalty = 1.1f, float alphaFrequency = .0f, float alphaPresence = .0f, 
-                                                bool penalizeNL = true)
-        {
-            var logits = NativeHandle.GetLogitsIth(logits_i);
-
-            // Apply params.logit_bias map
-            if (logitBias is not null)
-            {
-                foreach (var (key, value) in logitBias)
-                    logits[(int)key] += value;
-            }
-
-            // Save the newline logit value
-            var nl_token = NativeHandle.ModelHandle.Tokens.Newline;
-            var nl_logit = logits[(int?)nl_token ?? 0];
-
-            // Convert logits into token candidates
-            if (_samplingBuffer == null || _samplingBuffer.Length < logits.Length)
-                _samplingBuffer = new LLamaTokenData[logits.Length];
-            var candidates_p = LLamaTokenDataArray.Create(logits, _samplingBuffer);
-
-            // Extract most recently returned tokens
-            var last_n_repeat = Math.Min((int)ContextSize, repeatLastTokensCount);
-            var last_n_array = lastTokens.TakeLast(last_n_repeat).ToArray();
-
-            // Apply penalties to candidates
-            candidates_p.RepetitionPenalty(NativeHandle, last_n_array, repeatPenalty, alphaFrequency, alphaPresence);
-
-            // Restore newline token logit value if necessary
-            if (!penalizeNL && nl_token.HasValue)
-            {
-                var candidatesSpan = candidates_p.Data.Span;
-                for (var i = 0; i < candidates_p.Data.Length; i++)
-                {
-                    ref var item = ref candidatesSpan[i];
-                    if (item.id == nl_token)
-                        item.logit = nl_logit;
-                }
-                candidates_p.Sorted = false;
-            }
-
-            return candidates_p;
-        }
 
         /// <summary>
         /// Gets whether or not the Bos token should be added.

--- a/LLama/LLamaExecutorBase.cs
+++ b/LLama/LLamaExecutorBase.cs
@@ -81,11 +81,6 @@ namespace LLama
         /// <inheritdoc />
         public List<byte[]> Images { get; }
 
-        /// <summary>
-        /// Current "mu" value for mirostat sampling
-        /// </summary>
-        protected float? MirostatMu { get; set; }
-
         private readonly StreamingTokenDecoder _decoder;
 
         /// <summary>

--- a/LLama/LLamaInstructExecutor.cs
+++ b/LLama/LLamaInstructExecutor.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using LLama.Exceptions;
+using LLama.Sampling;
 using Microsoft.Extensions.Logging;
 
 namespace LLama
@@ -23,6 +24,8 @@ namespace LLama
         private readonly string _instructionPrefix;
         private LLamaToken[] _inp_pfx;
         private LLamaToken[] _inp_sfx;
+
+        private ISamplingPipeline? _pipeline;
 
         /// <summary>
         /// 
@@ -60,7 +63,6 @@ namespace LLama
                 SessionFilePath = _pathSession,
                 SessionTokens = _session_tokens.ToArray(),
                 LastTokensCapacity = _last_n_tokens.Capacity,
-                MirostatMu = MirostatMu
             };
             return state;
         }
@@ -227,28 +229,18 @@ namespace LLama
                     SaveSessionFile(_pathSession);
                 }
 
-                LLamaToken id;
-                if (inferenceParams.SamplingPipeline is not null)
-                {
-                    id = inferenceParams.SamplingPipeline.Sample(Context.NativeHandle, Context.NativeHandle.GetLogitsIth(batch.TokenCount - 1), _last_n_tokens.ToArray());
-                    inferenceParams.SamplingPipeline.Accept(Context.NativeHandle, id);
-                }
+                // use the explicitly supplied pipeline, if there is one. Otherwise construct a suitable one.
+                var pipeline = inferenceParams.SamplingPipeline;
+                if (pipeline != null)
+                    _pipeline = null;
                 else
-                {
-                    var tokenDataArray = Context.ApplyPenalty(batch.TokenCount - 1, _last_n_tokens, inferenceParams.LogitBias, repeat_last_n,
-                        inferenceParams.RepeatPenalty, inferenceParams.FrequencyPenalty, inferenceParams.PresencePenalty, inferenceParams.PenalizeNL);
+                    pipeline = inferenceParams.Create(ref _pipeline);
 
-                    var mu = MirostatMu;
-                    id = Context.Sample(
-                        tokenDataArray, ref mu, inferenceParams.Temperature, inferenceParams.Mirostat, inferenceParams.MirostatTau,
-                        inferenceParams.MirostatEta, inferenceParams.TopK, inferenceParams.TopP, inferenceParams.TfsZ, inferenceParams.TypicalP, inferenceParams.Grammar,
-                        inferenceParams.MinP
-                    );
-                    MirostatMu = mu;
-                }
+                // Sample with the pipeline
+                var id = pipeline.Sample(Context.NativeHandle, Context.NativeHandle.GetLogitsIth(batch.TokenCount - 1), _last_n_tokens.AsSpan(repeat_last_n));
+                pipeline.Accept(Context.NativeHandle, id);
 
                 _last_n_tokens.Enqueue(id);
-
                 _embeds.Add(id);
 
                 args.RemainedTokens--;

--- a/LLama/Sampling/DefaultSamplingPipeline.cs
+++ b/LLama/Sampling/DefaultSamplingPipeline.cs
@@ -13,7 +13,7 @@ public sealed class DefaultSamplingPipeline
     /// <summary>
     /// Bias values to add to certain logits
     /// </summary>
-    public Dictionary<int, float> LogitBias { get; } = new();
+    public Dictionary<LLamaToken, float> LogitBias { get; } = new();
 
     /// <summary>
     /// Repetition penalty, as described in https://arxiv.org/abs/1909.05858
@@ -98,7 +98,7 @@ public sealed class DefaultSamplingPipeline
     {
         // Apply logit bias
         foreach (var (key, value) in LogitBias)
-            logits[key] += value;
+            logits[(int)key] += value;
 
     }
 

--- a/LLama/Sampling/Mirostat2SamplingPipeline.cs
+++ b/LLama/Sampling/Mirostat2SamplingPipeline.cs
@@ -9,15 +9,15 @@ namespace LLama.Sampling;
 public class Mirostat2SamplingPipeline
     : BaseSamplingPipeline
 {
-    private const float DEFAULT_TAU = 5;
+    private const float DefaultTau = 5;
 
-    private float _mu = DEFAULT_TAU * 2;
+    private float _mu = DefaultTau * 2;
     /// <summary>
     /// Currently learned mu value
     /// </summary>
     public float Mu => _mu;
 
-    private float _tau = DEFAULT_TAU;
+    private float _tau = DefaultTau;
     /// <summary>
     /// target entropy
     /// </summary>


### PR DESCRIPTION
- Marked all properties for configuring sampling in `IInferenceParams` as obsolete, pushing to the newer `SamplingPipeline` system.
 - Removed old sampling code from `LLamaContext`, instead if no `SamplingPipeline` is supplied one is created (existing one is re-used, as much as possible).
 - Updated all examples to use new system.
 - Added `AsSpan` to `FixedSizeQueue` to avoid allocations of temporary arrays for every token!

The new sampling pipeline system was added a long time ago to address the issues with `IInferenceParams`. Configuring everything with one config object doesn't allow for re-ordering of sampling steps, doesn't allow custom samplers, and allows property combinations which are meaningless. For example using Mirostat sampling ignores almost every other property!

See the modified example files to see how the new system is used. In most cases it will simply involve passing a `DefaultSamplingPipeline` object.