### PR TITLE
Fix `llama_get_logits_ith` Null Handling

### DIFF
--- a/LLama/Exceptions/RuntimeError.cs
+++ b/LLama/Exceptions/RuntimeError.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using LLama.Native;
 
 namespace LLama.Exceptions;
@@ -55,5 +55,24 @@ public class LLamaDecodeError
         : base($"llama_decode failed: '{returnCode}'")
     {
         ReturnCode = returnCode;
+    }
+}
+
+/// <summary>
+/// `llama_get_logits_ith` returned null, indicating that the index was invalid
+/// </summary>
+public class NoLogitsException
+    : RuntimeError
+{
+    /// <summary>
+    /// The incorrect index passed to the `llama_get_logits_ith` call
+    /// </summary>
+    public int Index { get; }
+
+    /// <inheritdoc />
+    public NoLogitsException(int index)
+        : base($"llama_get_logits_ith({index}) returned null")
+    {
+        Index = index;
     }
 }

--- a/LLama/Exceptions/RuntimeError.cs
+++ b/LLama/Exceptions/RuntimeError.cs
@@ -61,7 +61,7 @@ public class LLamaDecodeError
 /// <summary>
 /// `llama_get_logits_ith` returned null, indicating that the index was invalid
 /// </summary>
-public class NoLogitsException
+public class GetLogitsInvalidIndexException
     : RuntimeError
 {
     /// <summary>
@@ -70,7 +70,7 @@ public class NoLogitsException
     public int Index { get; }
 
     /// <inheritdoc />
-    public NoLogitsException(int index)
+    public GetLogitsInvalidIndexException(int index)
         : base($"llama_get_logits_ith({index}) returned null")
     {
         Index = index;

--- a/LLama/Native/SafeLLamaContextHandle.cs
+++ b/LLama/Native/SafeLLamaContextHandle.cs
@@ -473,7 +473,7 @@ namespace LLama.Native
             {
                 var logits = llama_get_logits_ith(this, i);
                 if (logits == null)
-                    throw new NoLogitsException(i);
+                    throw new GetLogitsInvalidIndexException(i);
 
                 return new Span<float>(logits, model.VocabCount);
             }

--- a/LLama/Native/SafeLLamaContextHandle.cs
+++ b/LLama/Native/SafeLLamaContextHandle.cs
@@ -472,6 +472,9 @@ namespace LLama.Native
             unsafe
             {
                 var logits = llama_get_logits_ith(this, i);
+                if (logits == null)
+                    throw new NoLogitsException(i);
+
                 return new Span<float>(logits, model.VocabCount);
             }
         }


### PR DESCRIPTION
Throwing an exception when `llama_get_logits_ith` returns `null`. It's never valid to construct a `Span` from `null`, and doing so was causing issues (e.g. crashing the debugger when trying to inspect the span to diagnose the problem).