### PR TITLE
Fix CUDA compile error

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -238,6 +238,11 @@ jobs:
           method: 'network'
           sub-packages: '["nvcc", "cudart", "cublas", "cublas_dev", "thrust", "visual_studio_integration"]'
 
+      - name: "Configure"
+        if: runner.os == 'Windows'
+        run: |
+          echo "CMAKE_CXX_FLAGS=/Zm1000" >> $GITHUB_ENV
+
       - uses: Jimver/cuda-toolkit@v0.2.15
         if: runner.os == 'Linux'
         id: cuda-toolkit-linux
@@ -249,6 +254,7 @@ jobs:
       - name: Build
         id: cmake_build
         run: |
+          echo "CMAKE_CXX_FLAGS is $CMAKE_CXX_FLAGS"
           mkdir build
           cd build
           cmake .. ${{ env.COMMON_DEFINE }} -DGGML_CUDA=ON


### PR DESCRIPTION
Added `zm1000` as a compiler flag to the Windows build, in an attempt to workaround a compiler error caused by insufficient heap space (due to very large C++ files)