### PR TITLE
Fix: Increase Vulkan detection timeout to 12 seconds

### DIFF
--- a/LLama/Native/Load/SystemInfo.cs
+++ b/LLama/Native/Load/SystemInfo.cs
@@ -84,13 +84,11 @@ namespace LLama.Native
                         CreateNoWindow = true
                     }
                 };
-                var (exitCode, output, error, ok) = process.SafeRun(TimeSpan.FromSeconds(1));
+                var (exitCode, output, error, ok) = process.SafeRun(TimeSpan.FromSeconds(12));
 
-                if (!ok)
-                    return null;
-
-                // Return the output
-                return output;
+                // If ok return the output else return null 
+                return ok ? output :
+                    null;
             }
             catch
             {


### PR DESCRIPTION
The previous timeout of 1 second for detecting the Vulkan GPU using `vulkaninfo --summary` was insufficient on some systems, leading to the command timing out and the inference falling back to the CPU. This commit increases the timeout to 12 seconds to accommodate systems where `vulkaninfo` takes longer to complete.

This change addresses an issue where the Vulkan backend would frequently fall back to CPU inference due to the `vulkaninfo` command timing out before it could return the necessary information to detect the GPU. The increased timeout ensures that the command has sufficient time to complete on a wider range of systems, enabling the Vulkan backend to correctly detect and utilize the GPU for inference.