### PR TITLE
Specify file open permissions needed as read only. 

### DIFF
--- a/LLama/Native/SafeLlamaModelHandle.cs
+++ b/LLama/Native/SafeLlamaModelHandle.cs
@@ -129,7 +129,7 @@ namespace LLama.Native
             // - File exists (automatically throws FileNotFoundException)
             // - File is readable (explicit check)
             // This provides better error messages that llama.cpp, which would throw an access violation exception in both cases.
-            using (var fs = new FileStream(modelPath, FileMode.Open))
+            using (var fs = new FileStream(modelPath, FileMode.Open, FileAccess.Read))
                 if (!fs.CanRead)
                     throw new InvalidOperationException($"Model file '{modelPath}' is not readable");
 


### PR DESCRIPTION
Default open behavior looks to be read/write.  Resulting in failed file open of model in environments with strict read-only file system settings)