### PR TITLE
Split platform-specific binaries for NuGet backends

### DIFF
--- a/LLama/runtimes/build/LLamaSharp.Backend.Cuda11.Linux.nuspec
+++ b/LLama/runtimes/build/LLamaSharp.Backend.Cuda11.Linux.nuspec
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package >
+    <metadata>
+        <id>LLamaSharp.Backend.Cuda11.Linux</id>
+        <version>$version$</version>
+        <title>LLamaSharp.Backend.Cuda11.Linux</title>
+        <authors>llama.cpp Authors</authors>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <license type="expression">MIT</license>
+        <projectUrl>https://github.com/SciSharp/LLamaSharp</projectUrl>
+        <description>LLamaSharp.Backend.Cuda11.Linux contains the Linux binaries for LLamaSharp with Cuda11 support.</description>
+        <releaseNotes></releaseNotes>
+        <copyright>Copyright 2023 The llama.cpp Authors. All rights reserved.</copyright>
+        <tags>LLamaSharp LLama LLM GPT AI ChatBot SciSharp</tags>
+    </metadata>
+
+    <files>
+        <file src="LLamaSharpBackend.props" target="build/netstandard2.0/LLamaSharp.Backend.Cuda11.props" />
+        <file src="runtimes/deps/cu11.7.1/libllava_shared.so" target="runtimes/linux-x64/native/cuda11/libllava_shared.so" />
+        <file src="runtimes/deps/cu11.7.1/libggml.so" target="runtimes/linux-x64/native/cuda11/libggml.so" />
+        <file src="runtimes/deps/cu11.7.1/libllama.so" target="runtimes/linux-x64/native/cuda11/libllama.so" />
+        
+        <file src="icon512.png" target="icon512.png" />
+    </files>
+</package>

--- a/LLama/runtimes/build/LLamaSharp.Backend.Cuda11.Windows.nuspec
+++ b/LLama/runtimes/build/LLamaSharp.Backend.Cuda11.Windows.nuspec
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package >
+    <metadata>
+        <id>LLamaSharp.Backend.Cuda11.Windows</id>
+        <version>$version$</version>
+        <title>LLamaSharp.Backend.Cuda11.Windows</title>
+        <authors>llama.cpp Authors</authors>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <license type="expression">MIT</license>
+        <projectUrl>https://github.com/SciSharp/LLamaSharp</projectUrl>
+        <description>LLamaSharp.Backend.Cuda11.Windows contains the Windows binaries for LLamaSharp with Cuda11 support.</description>
+        <releaseNotes></releaseNotes>
+        <copyright>Copyright 2023 The llama.cpp Authors. All rights reserved.</copyright>
+        <tags>LLamaSharp LLama LLM GPT AI ChatBot SciSharp</tags>
+    </metadata>
+
+    <files>
+        <file src="LLamaSharpBackend.props" target="build/netstandard2.0/LLamaSharp.Backend.Cuda11.props" />
+        <file src="runtimes/deps/cu11.7.1/llava_shared.dll" target="runtimes\win-x64\native\cuda11\llava_shared.dll" />
+        <file src="runtimes/deps/cu11.7.1/ggml.dll" target="runtimes\win-x64\native\cuda11\ggml.dll" />
+        <file src="runtimes/deps/cu11.7.1/llama.dll" target="runtimes\win-x64\native\cuda11\llama.dll" />
+        
+        <file src="icon512.png" target="icon512.png" />
+    </files>
+</package>

--- a/LLama/runtimes/build/LLamaSharp.Backend.Cuda11.nuspec
+++ b/LLama/runtimes/build/LLamaSharp.Backend.Cuda11.nuspec
@@ -1,31 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package >
-  <metadata>
-    <id>LLamaSharp.Backend.Cuda11</id>
-    <version>$version$</version>
-    <title>LLamaSharp.Backend.Cuda11, the backend for LLamaSharp</title>
-    <authors>llama.cpp Authors</authors>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <license type="expression">MIT</license>
-    <icon>icon512.png</icon>
-    <projectUrl>https://github.com/SciSharp/LLamaSharp</projectUrl>
-    <description>LLamaSharp.Backend.Cuda11 is a backend for LLamaSharp to use with Cuda11.</description>
-    <releaseNotes></releaseNotes>
-    <copyright>Copyright 2023 The llama.cpp Authors. All rights reserved.</copyright>
-    <tags>LLamaSharp LLama LLM GPT AI ChatBot SciSharp</tags>
-  </metadata>
+    <metadata>
+        <id>LLamaSharp.Backend.Cuda11</id>
+        <version>$version$</version>
+        <title>LLamaSharp.Backend.Cuda11, the backend for LLamaSharp</title>
+        <authors>llama.cpp Authors</authors>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <license type="expression">MIT</license>
+        <icon>icon512.png</icon>
+        <projectUrl>https://github.com/SciSharp/LLamaSharp</projectUrl>
+        <description>LLamaSharp.Backend.Cuda11 is a backend for LLamaSharp to use with Cuda11.</description>
+        <releaseNotes></releaseNotes>
+        <copyright>Copyright 2023 The llama.cpp Authors. All rights reserved.</copyright>
+        <tags>LLamaSharp LLama LLM GPT AI ChatBot SciSharp</tags>
 
-  <files>
-    <file src="LLamaSharpBackend.props" target="build/netstandard2.0/LLamaSharp.Backend.Cuda11.props" />
+        <!-- Dependencies on platform-specific packages -->
+        <dependencies>
+            <dependency id="LLamaSharp.Backend.Cuda11.Windows" version="$version$" exclude="Linux" />
+            <dependency id="LLamaSharp.Backend.Cuda11.Linux" version="$version$" exclude="Win" />
+        </dependencies>
+    </metadata>
 
-    <file src="runtimes/deps/cu11.7.1/libllava_shared.so" target="runtimes\linux-x64\native\cuda11\libllava_shared.so" />
-    <file src="runtimes/deps/cu11.7.1/llava_shared.dll" target="runtimes\win-x64\native\cuda11\llava_shared.dll" />
-
-    <file src="runtimes/deps/cu11.7.1/ggml.dll" target="runtimes\win-x64\native\cuda11\ggml.dll" />
-    <file src="runtimes/deps/cu11.7.1/llama.dll" target="runtimes\win-x64\native\cuda11\llama.dll" />
-    <file src="runtimes/deps/cu11.7.1/libggml.so" target="runtimes\linux-x64\native\cuda11\libggml.so" />
-    <file src="runtimes/deps/cu11.7.1/libllama.so" target="runtimes\linux-x64\native\cuda11\libllama.so" />
-    
-    <file src="icon512.png" target="icon512.png" />
-  </files>
+    <files>
+        <file src="icon512.png" target="icon512.png" />
+    </files>
 </package>

--- a/LLama/runtimes/build/LLamaSharp.Backend.Cuda11.nuspec
+++ b/LLama/runtimes/build/LLamaSharp.Backend.Cuda11.nuspec
@@ -16,8 +16,8 @@
 
         <!-- Dependencies on platform-specific packages -->
         <dependencies>
-            <dependency id="LLamaSharp.Backend.Cuda11.Windows" version="$version$" exclude="Linux" />
-            <dependency id="LLamaSharp.Backend.Cuda11.Linux" version="$version$" exclude="Win" />
+            <dependency id="LLamaSharp.Backend.Cuda11.Windows" version="$version$" />
+            <dependency id="LLamaSharp.Backend.Cuda11.Linux" version="$version$" />
         </dependencies>
     </metadata>
 

--- a/LLama/runtimes/build/LLamaSharp.Backend.Cuda12.Linux.nuspec
+++ b/LLama/runtimes/build/LLamaSharp.Backend.Cuda12.Linux.nuspec
@@ -1,28 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package >
     <metadata>
-        <id>LLamaSharp.Backend.Cuda12</id>
+        <id>LLamaSharp.Backend.Cuda12.Linux</id>
         <version>$version$</version>
-        <title>LLamaSharp.Backend.Cuda12, the backend for LLamaSharp</title>
+        <title>LLamaSharp.Backend.Cuda12.Linux</title>
         <authors>llama.cpp Authors</authors>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <license type="expression">MIT</license>
-        <icon>icon512.png</icon>
         <projectUrl>https://github.com/SciSharp/LLamaSharp</projectUrl>
-        <description>LLamaSharp.Backend.Cuda12 is a backend for LLamaSharp to use with Cuda12.</description>
+        <description>LLamaSharp.Backend.Cuda12.Linux contains the Linux binaries for LLamaSharp with Cuda12 support.</description>
         <releaseNotes></releaseNotes>
         <copyright>Copyright 2023 The llama.cpp Authors. All rights reserved.</copyright>
         <tags>LLamaSharp LLama LLM GPT AI ChatBot SciSharp</tags>
-
-        <!-- Dependencies on platform-specific packages -->
-        <dependencies>
-            <dependency id="LLamaSharp.Backend.Cuda12.Windows" version="$version$" exclude="Linux" />
-            <dependency id="LLamaSharp.Backend.Cuda12.Linux" version="$version$" exclude="Win" />
-        </dependencies>
     </metadata>
 
     <files>
         <file src="LLamaSharpBackend.props" target="build/netstandard2.0/LLamaSharp.Backend.Cuda12.props" />
+        
+        <file src="runtimes/deps/cu12.2.0/libllava_shared.so" target="runtimes/linux-x64/native/cuda12/libllava_shared.so" />
+        <file src="runtimes/deps/cu12.2.0/libggml.so" target="runtimes/linux-x64/native/cuda12/libggml.so" />
+        <file src="runtimes/deps/cu12.2.0/libllama.so" target="runtimes/linux-x64/native/cuda12/libllama.so" />
+        
         <file src="icon512.png" target="icon512.png" />
     </files>
 </package>

--- a/LLama/runtimes/build/LLamaSharp.Backend.Cuda12.Windows.nuspec
+++ b/LLama/runtimes/build/LLamaSharp.Backend.Cuda12.Windows.nuspec
@@ -1,28 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package >
     <metadata>
-        <id>LLamaSharp.Backend.Cuda12</id>
+        <id>LLamaSharp.Backend.Cuda12.Windows</id>
         <version>$version$</version>
-        <title>LLamaSharp.Backend.Cuda12, the backend for LLamaSharp</title>
+        <title>LLamaSharp.Backend.Cuda12.Windows</title>
         <authors>llama.cpp Authors</authors>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <license type="expression">MIT</license>
-        <icon>icon512.png</icon>
         <projectUrl>https://github.com/SciSharp/LLamaSharp</projectUrl>
-        <description>LLamaSharp.Backend.Cuda12 is a backend for LLamaSharp to use with Cuda12.</description>
+        <description>LLamaSharp.Backend.Cuda12.Windows contains the Windows binaries for LLamaSharp with Cuda12 support.</description>
         <releaseNotes></releaseNotes>
         <copyright>Copyright 2023 The llama.cpp Authors. All rights reserved.</copyright>
         <tags>LLamaSharp LLama LLM GPT AI ChatBot SciSharp</tags>
-
-        <!-- Dependencies on platform-specific packages -->
-        <dependencies>
-            <dependency id="LLamaSharp.Backend.Cuda12.Windows" version="$version$" exclude="Linux" />
-            <dependency id="LLamaSharp.Backend.Cuda12.Linux" version="$version$" exclude="Win" />
-        </dependencies>
     </metadata>
 
     <files>
         <file src="LLamaSharpBackend.props" target="build/netstandard2.0/LLamaSharp.Backend.Cuda12.props" />
+        
+        <file src="runtimes/deps/cu12.2.0/llava_shared.dll" target="runtimes\win-x64\native\cuda12\llava_shared.dll" />
+        <file src="runtimes/deps/cu12.2.0/ggml.dll" target="runtimes\win-x64\native\cuda12\ggml.dll" />
+        <file src="runtimes/deps/cu12.2.0/llama.dll" target="runtimes\win-x64\native\cuda12\llama.dll" />
+        
         <file src="icon512.png" target="icon512.png" />
     </files>
 </package>

--- a/LLama/runtimes/build/LLamaSharp.Backend.Cuda12.nuspec
+++ b/LLama/runtimes/build/LLamaSharp.Backend.Cuda12.nuspec
@@ -16,8 +16,8 @@
 
         <!-- Dependencies on platform-specific packages -->
         <dependencies>
-            <dependency id="LLamaSharp.Backend.Cuda12.Windows" version="$version$" exclude="Linux" />
-            <dependency id="LLamaSharp.Backend.Cuda12.Linux" version="$version$" exclude="Win" />
+            <dependency id="LLamaSharp.Backend.Cuda12.Windows" version="$version$" />
+            <dependency id="LLamaSharp.Backend.Cuda12.Linux" version="$version$" />
         </dependencies>
     </metadata>
 

--- a/LLama/runtimes/build/LLamaSharp.Backend.Vulkan.Linux.nuspec
+++ b/LLama/runtimes/build/LLamaSharp.Backend.Vulkan.Linux.nuspec
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package >
+    <metadata>
+        <id>LLamaSharp.Backend.Vulkan.Linux</id>
+        <version>$version$</version>
+        <title>LLamaSharp.Backend.Vulkan.Linux</title>
+        <authors>llama.cpp Authors</authors>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <license type="expression">MIT</license>
+        <projectUrl>https://github.com/SciSharp/LLamaSharp</projectUrl>
+        <description>LLamaSharp.Backend.Vulkan.Linux contains the Linux binaries for LLamaSharp with Vulkan support.</description>
+        <releaseNotes></releaseNotes>
+        <copyright>Copyright 2023 The llama.cpp Authors. All rights reserved.</copyright>
+        <tags>LLamaSharp LLama LLM GPT AI ChatBot SciSharp</tags>
+    </metadata>
+
+    <files>
+        <file src="LLamaSharpBackend.props" target="build/netstandard2.0/LLamaSharp.Backend.Vulkan.props" />
+        <file src="runtimes/deps/vulkan/libllava_shared.so" target="runtimes/linux-x64/native/vulkan/libllava_shared.so" />
+        <file src="runtimes/deps/vulkan/libggml.so" target="runtimes/linux-x64/native/vulkan/libggml.so" />
+        <file src="runtimes/deps/vulkan/libllama.so" target="runtimes/linux-x64/native/vulkan/libllama.so" />
+        
+        <file src="icon512.png" target="icon512.png" />
+    </files>
+</package>

--- a/LLama/runtimes/build/LLamaSharp.Backend.Vulkan.Windows.nuspec
+++ b/LLama/runtimes/build/LLamaSharp.Backend.Vulkan.Windows.nuspec
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package >
+    <metadata>
+        <id>LLamaSharp.Backend.Vulkan.Windows</id>
+        <version>$version$</version>
+        <title>LLamaSharp.Backend.Vulkan.Windows</title>
+        <authors>llama.cpp Authors</authors>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <license type="expression">MIT</license>
+        <projectUrl>https://github.com/SciSharp/LLamaSharp</projectUrl>
+        <description>LLamaSharp.Backend.Vulkan.Windows contains the Windows binaries for LLamaSharp with Vulkan support.</description>
+        <releaseNotes></releaseNotes>
+        <copyright>Copyright 2023 The llama.cpp Authors. All rights reserved.</copyright>
+        <tags>LLamaSharp LLama LLM GPT AI ChatBot SciSharp</tags>
+    </metadata>
+
+    <files>
+        <file src="LLamaSharpBackend.props" target="build/netstandard2.0/LLamaSharp.Backend.Vulkan.props" />
+        <file src="runtimes/deps/vulkan/llava_shared.dll" target="runtimes\win-x64\native\vulkan\llava_shared.dll" />
+        <file src="runtimes/deps/vulkan/ggml.dll" target="runtimes\win-x64\native\vulkan\ggml.dll" />
+        <file src="runtimes/deps/vulkan/llama.dll" target="runtimes\win-x64\native\vulkan\llama.dll" />
+        <file src="icon512.png" target="icon512.png" />
+    </files>
+</package>

--- a/LLama/runtimes/build/LLamaSharp.Backend.Vulkan.nuspec
+++ b/LLama/runtimes/build/LLamaSharp.Backend.Vulkan.nuspec
@@ -16,8 +16,8 @@
 
         <!-- Dependencies on platform-specific packages -->
         <dependencies>
-            <dependency id="LLamaSharp.Backend.Vulkan.Windows" version="$version$" exclude="Linux" />
-            <dependency id="LLamaSharp.Backend.Vulkan.Linux" version="$version$" exclude="Win" />
+            <dependency id="LLamaSharp.Backend.Vulkan.Windows" version="$version$" />
+            <dependency id="LLamaSharp.Backend.Vulkan.Linux" version="$version$" />
         </dependencies>
     </metadata>
 

--- a/LLama/runtimes/build/LLamaSharp.Backend.Vulkan.nuspec
+++ b/LLama/runtimes/build/LLamaSharp.Backend.Vulkan.nuspec
@@ -13,19 +13,15 @@
         <releaseNotes></releaseNotes>
         <copyright>Copyright 2023 The llama.cpp Authors. All rights reserved.</copyright>
         <tags>LLamaSharp LLama LLM GPT AI ChatBot SciSharp</tags>
+
+        <!-- Dependencies on platform-specific packages -->
+        <dependencies>
+            <dependency id="LLamaSharp.Backend.Vulkan.Windows" version="$version$" exclude="Linux" />
+            <dependency id="LLamaSharp.Backend.Vulkan.Linux" version="$version$" exclude="Win" />
+        </dependencies>
     </metadata>
-    
+
     <files>
-        <file src="LLamaSharpBackend.props" target="build/netstandard2.0/LLamaSharp.Backend.Vulkan.props" />
-    
-        <file src="runtimes/deps/vulkan/libllava_shared.so" target="runtimes\linux-x64\native\vulkan\libllava_shared.so" />
-        <file src="runtimes/deps/vulkan/llava_shared.dll" target="runtimes\win-x64\native\vulkan\llava_shared.dll" />
-    
-        <file src="runtimes/deps/vulkan/ggml.dll" target="runtimes\win-x64\native\vulkan\ggml.dll" />
-        <file src="runtimes/deps/vulkan/llama.dll" target="runtimes\win-x64\native\vulkan\llama.dll" />
-        <file src="runtimes/deps/vulkan/libggml.so" target="runtimes\linux-x64\native\vulkan\libggml.so" />
-        <file src="runtimes/deps/vulkan/libllama.so" target="runtimes\linux-x64\native\vulkan\libllama.so" />
-        
         <file src="icon512.png" target="icon512.png" />
     </files>
 </package>


### PR DESCRIPTION
This PR refactors the NuGet package structure for the `LLamaSharp.Backend.Cuda11`, `LLamaSharp.Backend.Cuda12` and `LLamaSharp.Backend.Vulkan` packages by splitting the platform-specific binaries (Windows and Linux) into separate packages, and adds them as dependencies on the main packages. This way we can work around the 250MB limit for NuGet which broke the latest release.

| Package Name                          | File Size Before (MB) | File Size After (MB) |
|---------------------------------------|-----------------------|----------------------|
| `LLamaSharp.Backend.Cuda11`    | 286.36 MB         | 0.032 MB         |
| `LLamaSharp.Backend.Cuda11.Windows` | N/A                   | 142.56 MB         |
| `LLamaSharp.Backend.Cuda11.Linux`   | N/A                   | 143.82 MB         |
| `LLamaSharp.Backend.Cuda12`    | 284.33 MB         | 0.032 MB         |
| `LLamaSharp.Backend.Cuda12.Windows` | N/A                   | 141.62 MB         |
| `LLamaSharp.Backend.Cuda12.Linux`   | N/A                   | 142.74 MB         |
| `LLamaSharp.Backend.Vulkan`    | 3.49 MB         | 0.032 MB         |
| `LLamaSharp.Backend.Vulkan.Windows` | N/A                   | 1.54 MB         |
| `LLamaSharp.Backend.Vulkan.Linux`   | N/A                   | 1.98 MB         |