### PR TITLE
Custom Sampler Stages

### DIFF
--- a/LLama.Examples/ExampleRunner.cs
+++ b/LLama.Examples/ExampleRunner.cs
@@ -35,6 +35,7 @@ public class ExampleRunner
         { "Batched Executor: LLava", BatchedExecutorLLava.Run },
         { "Batched Executor: BoolQ Benchmark", BatchedExecutorBoolQ.Run },
         { "Batched Executor: Beam Search", BatchedExecutorBeamSearch.Run },
+        { "Custom Sampling Pipeline", CustomSampler.Run },
         { "Speech Chat: Integration with Whisper.net", SpeechChat.Run },
         { "Exit", () => { Environment.Exit(0); return Task.CompletedTask; } }
     };

--- a/LLama.Examples/Examples/CustomSampler.cs
+++ b/LLama.Examples/Examples/CustomSampler.cs
@@ -86,7 +86,7 @@ namespace LLama.Examples.Examples
             // Make the most likely token impossible to pick
             tokenData.Data[0].Logit = float.NegativeInfinity;
             
-            // It's critically important to set this if the logits are no logner sorted after the custom 
+            // It's **critically** important to set this if the logits are no longer sorted after the custom 
             // sampler has run. If you're not sure, it's always safer to set it to false.
             //
             // In this case, because the first logit has just been set to negative infinity

--- a/LLama.Examples/Examples/CustomSampler.cs
+++ b/LLama.Examples/Examples/CustomSampler.cs
@@ -1,0 +1,114 @@
+using LLama.Common;
+using LLama.Examples.Extensions;
+using LLama.Native;
+using LLama.Sampling;
+
+namespace LLama.Examples.Examples
+{
+    public class CustomSampler
+    {
+        public static async Task Run()
+        {
+            var modelPath = UserSettings.GetModelPath();
+
+            var parameters = new ModelParams(modelPath);
+            using var model = await LLamaWeights.LoadFromFileAsync(parameters);
+
+            var ex = new StatelessExecutor(model, parameters);
+
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.WriteLine("In this example a custom sampling pipeline with a custom sampler stage is being used. This demonstrates how to customise the samplers used, and " +
+                "how to create a completely custom sampler stage which modifies the logits or selects a token." +
+                "" +
+                "In this case the custom sampler stage removes the most likely token. This will probably produce bad results, it's just a demo!"
+            );
+            Console.ForegroundColor = ConsoleColor.White;
+
+            var inferenceParams = new InferenceParams
+            {
+                SamplingPipeline = new CustomSamplingPipeline(),
+                MaxTokens = 50
+            };
+
+            while (true)
+            {
+                Console.Write("\nQuestion: ");
+                Console.ForegroundColor = ConsoleColor.Green;
+                var prompt = Console.ReadLine();
+                Console.ForegroundColor = ConsoleColor.White;
+                Console.Write("Answer: ");
+                prompt = $"Question: {prompt?.Trim()} Answer: ";
+                await foreach (var text in ex.InferAsync(prompt, inferenceParams).Spinner())
+                {
+                    Console.Write(text);
+                }
+            }
+        }
+    }
+
+    public class CustomSamplingPipeline
+        : BaseSamplingPipeline
+    {
+        protected override SafeLLamaSamplerChainHandle CreateChain(SafeLLamaContextHandle context)
+        {
+            var chain = SafeLLamaSamplerChainHandle.Create(LLamaSamplerChainParams.Default());
+
+            // Take only the 10 most likely tokens
+            chain.AddTopK(10);
+
+            // Remove the most likely token
+            chain.AddCustom(new RemoveMostLikelyToken());
+
+            // Select from the distribution
+            chain.AddSoftmax();
+            chain.AddDistributionSampler(42);
+
+            return chain;
+        }
+    }
+
+    public class RemoveMostLikelyToken
+        : ICustomSampler
+    {
+        public string Name => "Remove Most Likely Token";
+
+        public void Apply(ref LLamaTokenDataArrayNative tokenData)
+        {
+            // Doesn't make sense to run this stage if there is only one candidate left
+            if (tokenData.Size <= 1)
+                return;
+
+            // Ensure token data is sorted, so most likely token is first.
+            // Note that this is a descending sort, the  **largest** value is first.
+            if (!tokenData.Sorted)
+                tokenData.Data.Sort((a, b) => b.Logit.CompareTo(a.Logit));
+
+            // Make the most likely token impossible to pick
+            tokenData.Data[0].Logit = float.NegativeInfinity;
+            
+            // It's critically important to set this if the logits are no logner sorted after the custom 
+            // sampler has run. If you're not sure, it's always safer to set it to false.
+            //
+            // In this case, because the first logit has just been set to negative infinity
+            // the token data is definitely not sorted!
+            tokenData.Sorted = false;
+        }
+
+        public void Accept(LLamaToken token)
+        {
+        }
+
+        public void Reset()
+        {
+        }
+
+        public ICustomSampler Clone()
+        {
+            return new RemoveMostLikelyToken();
+        }
+
+        public void Free()
+        {
+        }
+    }
+}

--- a/LLama.Examples/Examples/CustomSampler.cs
+++ b/LLama.Examples/Examples/CustomSampler.cs
@@ -107,7 +107,7 @@ namespace LLama.Examples.Examples
             return new RemoveMostLikelyToken();
         }
 
-        public void Free()
+        public void Dispose()
         {
         }
     }

--- a/LLama/Native/LLamaTokenDataArray.cs
+++ b/LLama/Native/LLamaTokenDataArray.cs
@@ -149,7 +149,7 @@ namespace LLama.Native
         /// <summary>
         /// Number of LLamaTokenData in the array
         /// </summary>
-        public ulong size;
+        private ulong _size;
 
         /// <summary>
         /// The index in the array (i.e. not the token id)
@@ -167,13 +167,13 @@ namespace LLama.Native
             {
                 unsafe
                 {
-                    return new Span<LLamaTokenData>(_data, checked((int)size));
+                    return new Span<LLamaTokenData>(_data, checked((int)Size));
                 }
             }
         }
         
         /// <summary>
-        /// Indicates if the items in the array are sorted
+        /// Indicates if the items in the array are sorted, so the most likely token is first
         /// </summary>
         public bool Sorted
         {
@@ -191,6 +191,20 @@ namespace LLama.Native
         }
 
         /// <summary>
+        /// Number of LLamaTokenData in the array. Set this to shrink the array
+        /// </summary>
+        public ulong Size
+        {
+            get => _size;
+            set
+            {
+                if (value > _size)
+                    throw new ArgumentOutOfRangeException(nameof(value), "Cannot set Size property to a larger value");
+                _size = value;
+            }
+        }
+
+        /// <summary>
         /// Create a new LLamaTokenDataArrayNative around the data in the LLamaTokenDataArray 
         /// </summary>
         /// <param name="array">Data source</param>
@@ -205,7 +219,7 @@ namespace LLama.Native
                 native = new LLamaTokenDataArrayNative
                 {
                     _data = (LLamaTokenData*)handle.Pointer,
-                    size = (ulong)array.Data.Length,
+                    Size = (ulong)array.Data.Length,
                     Sorted = array.Sorted
                 };
             }

--- a/LLama/Native/SafeLLamaSamplerHandle.cs
+++ b/LLama/Native/SafeLLamaSamplerHandle.cs
@@ -701,7 +701,7 @@ internal class CustomSamplerHandle
 
         sampler._gcHandle.Free();
 
-        sampler._sampler.Free();
+        sampler._sampler.Dispose();
     }
 }
 
@@ -709,6 +709,7 @@ internal class CustomSamplerHandle
 /// A custom sampler stage for modifying logits or selecting a token
 /// </summary>
 public interface ICustomSampler
+    : IDisposable
 {
     /// <summary>
     /// The human readable name of this stage
@@ -716,8 +717,14 @@ public interface ICustomSampler
     string Name { get; }
 
     /// <summary>
-    /// Apply this stage to a set of logits. This can modify logits or select a token (or both). If logits are modified, the Sorted flag must be cleared.
+    /// Apply this stage to a set of logits.
+    /// This can modify logits or select a token (or both).
+    /// If logits are modified the Sorted flag <b>must</b> be set to false.
     /// </summary>
+    /// <remarks>
+    /// If the logits are no longer sorted after the custom sampler has run it is <b>critically</b> important to
+    /// set <i>Sorted=false</i>. If unsure, always set it to false, this is a safe default.
+    /// </remarks>
     /// <param name="tokenData"></param>
     void Apply(ref LLamaTokenDataArrayNative tokenData);
 
@@ -736,9 +743,4 @@ public interface ICustomSampler
     /// Create a clone of this sampler
     /// </summary>
     ICustomSampler Clone();
-
-    /// <summary>
-    /// Free all unmanaged resources held by this sampler
-    /// </summary>
-    void Free();
 }

--- a/LLama/Sampling/DefaultSamplingPipeline.cs
+++ b/LLama/Sampling/DefaultSamplingPipeline.cs
@@ -141,9 +141,38 @@ public sealed class DefaultSamplingPipeline
         chain.AddMinP(MinP, MinKeep);
         chain.AddTemperature(Temperature);
 
+        chain.AddCustom(new DemoSampler());
+
         chain.AddSoftmax();
         chain.AddDistributionSampler(Seed);
 
         return chain;
+    }
+}
+
+public class DemoSampler
+    : ICustomSampler
+{
+    public string Name => "Demo Custom Sampler";
+
+    public void Apply(ref LLamaTokenDataArrayNative tokenData)
+    {
+    }
+
+    public void Accept(LLamaToken token)
+    {
+    }
+
+    public void Reset()
+    {
+    }
+
+    public ICustomSampler Clone()
+    {
+        return new DemoSampler();
+    }
+
+    public void Free()
+    {
     }
 }

--- a/LLama/Sampling/DefaultSamplingPipeline.cs
+++ b/LLama/Sampling/DefaultSamplingPipeline.cs
@@ -141,38 +141,9 @@ public sealed class DefaultSamplingPipeline
         chain.AddMinP(MinP, MinKeep);
         chain.AddTemperature(Temperature);
 
-        chain.AddCustom(new DemoSampler());
-
         chain.AddSoftmax();
         chain.AddDistributionSampler(Seed);
 
         return chain;
-    }
-}
-
-public class DemoSampler
-    : ICustomSampler
-{
-    public string Name => "Demo Custom Sampler";
-
-    public void Apply(ref LLamaTokenDataArrayNative tokenData)
-    {
-    }
-
-    public void Accept(LLamaToken token)
-    {
-    }
-
-    public void Reset()
-    {
-    }
-
-    public ICustomSampler Clone()
-    {
-        return new DemoSampler();
-    }
-
-    public void Free()
-    {
     }
 }


### PR DESCRIPTION
Added support for custom sampler stages, written entirely in safe C#. These stages can be added to a sampler pipeline just like any other. See the example in `LLama.Examples\Examples\CustomSampler.cs` for an example of a custom pipeline using a custom stage.

The internals here are fairly complex, because we need to keep some manually managed memory (so we can have persistent pointers to it) and also make sure the GC doesn't collect things. The overall flow is as follows:
 - A custom sampler is written by the user implementing `ICustomSampler`
 - This is added to a pipeline with `AddCustom`
 - A `CustomSamplerHandle` is allocated, to own all of the various bits of memory
 - The `CustomSamplerHandle` holds a `GCHandle` which keeps **itself** alive. 
 - `CustomSamplerHandle` also allocates some memory to hold some native structures (`_samplerNativePtr` and `_samplerNativeInterfacePtr`) and passes pointers across to the native side.
 - When the native side calls `free` it will destroy the `GCHandle` keeping itself alive, free the native memory, and finally calls `ICustomSampler.Free`.