### PR TITLE
Fixed `LLamaTokenDataArrayNative.Create`'s size initialization

### DIFF
--- a/LLama/Native/LLamaTokenDataArray.cs
+++ b/LLama/Native/LLamaTokenDataArray.cs
@@ -219,7 +219,7 @@ namespace LLama.Native
                 native = new LLamaTokenDataArrayNative
                 {
                     _data = (LLamaTokenData*)handle.Pointer,
-                    Size = (ulong)array.Data.Length,
+                    _size = (ulong)array.Data.Length,
                     Sorted = array.Sorted
                 };
             }


### PR DESCRIPTION
This PR fixes an initialization issue of `LLamaTokenDataNativeArray`'s `_size` property, which is initialized at 0
![image](https://github.com/user-attachments/assets/286c8b5b-1413-4006-9538-86ade611c95b)
but when `.Create()` is called, it attempts to set _size to some value that HAS to be larger than 0,
![image](https://github.com/user-attachments/assets/0bbd21d5-381d-47bb-925d-321bb35974c0)
..which triggers this exception:
![image](https://github.com/user-attachments/assets/cf965efb-ddb6-4272-96b6-31d09878fa69)