### PR TITLE
Updated tests model to "LLama 3.2 1B Instruct"

### DIFF
--- a/LLama.Unittest/BasicTest.cs
+++ b/LLama.Unittest/BasicTest.cs
@@ -29,9 +29,9 @@ namespace LLama.Unittest
         [Fact]
         public void BasicModelProperties()
         {
-            Assert.Equal(32000, _model.VocabCount);
-            Assert.Equal(4096, _model.ContextSize);
-            Assert.Equal(4096, _model.EmbeddingSize);
+            Assert.Equal(128256, _model.VocabCount);
+            Assert.Equal(131072, _model.ContextSize);
+            Assert.Equal(2048, _model.EmbeddingSize);
         }
 
         [Fact]
@@ -41,35 +41,31 @@ namespace LLama.Unittest
             // tests are switched to use a new model!
             var expected = new Dictionary<string, string>
             {
-                { "general.name", "LLaMA v2" },
+                { "general.name", "Llama 3.2 1B Instruct" },
                 { "general.architecture", "llama" },
                 { "general.quantization_version", "2" },
-                { "general.file_type", "11" },
+                { "general.file_type", "2" },
 
-                { "llama.context_length", "4096" },
+                { "llama.context_length", "131072" },
                 { "llama.rope.dimension_count", "128" },
-                { "llama.embedding_length", "4096" },
-                { "llama.block_count", "32" },
-                { "llama.feed_forward_length", "11008" },
+                { "llama.embedding_length", "2048" },
+                { "llama.block_count", "16" },
+                { "llama.feed_forward_length", "8192" },
                 { "llama.attention.head_count", "32" },
                 { "llama.attention.head_count_kv", "32" },
-                { "llama.attention.layer_norm_rms_epsilon", "0.000001" },
+                { "llama.attention.layer_norm_rms_epsilon", "0.000010" },
 
                 { "tokenizer.ggml.eos_token_id", "2" },
-                { "tokenizer.ggml.model", "llama" },
-                { "tokenizer.ggml.bos_token_id", "1" },
-                { "tokenizer.ggml.unknown_token_id", "0" },
+                { "tokenizer.ggml.model", "gpt2" },
+                { "tokenizer.ggml.bos_token_id", "128000" },
             };
 
             // Print all keys
             foreach (var (key, value) in _model.Metadata)
                 _testOutputHelper.WriteLine($"{key} = {value}");
 
-            // Check the count is equal
-            Assert.Equal(expected.Count, _model.Metadata.Count);
-
             // Check every key
-            foreach (var (key, value) in _model.Metadata)
+            foreach (var (key, value) in expected)
                 Assert.Equal(expected[key], value);
         }
     }

--- a/LLama.Unittest/BasicTest.cs
+++ b/LLama.Unittest/BasicTest.cs
@@ -47,15 +47,15 @@ namespace LLama.Unittest
                 { "general.file_type", "2" },
 
                 { "llama.context_length", "131072" },
-                { "llama.rope.dimension_count", "128" },
+                { "llama.rope.dimension_count", "64" },
                 { "llama.embedding_length", "2048" },
                 { "llama.block_count", "16" },
                 { "llama.feed_forward_length", "8192" },
                 { "llama.attention.head_count", "32" },
-                { "llama.attention.head_count_kv", "32" },
+                { "llama.attention.head_count_kv", "8" },
                 { "llama.attention.layer_norm_rms_epsilon", "0.000010" },
 
-                { "tokenizer.ggml.eos_token_id", "2" },
+                { "tokenizer.ggml.eos_token_id", "128009" },
                 { "tokenizer.ggml.model", "gpt2" },
                 { "tokenizer.ggml.bos_token_id", "128000" },
             };
@@ -66,7 +66,7 @@ namespace LLama.Unittest
 
             // Check every key
             foreach (var (key, value) in expected)
-                Assert.Equal(expected[key], value);
+                Assert.Equal(_model.Metadata[key], value);
         }
     }
 }

--- a/LLama.Unittest/Constants.cs
+++ b/LLama.Unittest/Constants.cs
@@ -1,10 +1,10 @@
-﻿using System.Runtime.InteropServices;
+using System.Runtime.InteropServices;
 
 namespace LLama.Unittest
 {
     internal static class Constants
     {
-        public static readonly string GenerativeModelPath = "Models/llama-2-7b-chat.Q3_K_S.gguf";
+        public static readonly string GenerativeModelPath = "Models/Llama-3.2-1B-Instruct-Q4_0.gguf";
         public static readonly string EmbeddingModelPath = "Models/all-MiniLM-L12-v2.Q8_0.gguf";
 
         public static readonly string LLavaModelPath = "Models/llava-v1.6-mistral-7b.Q3_K_XS.gguf";

--- a/LLama.Unittest/KernelMemory/ITextTokenizerTests.cs
+++ b/LLama.Unittest/KernelMemory/ITextTokenizerTests.cs
@@ -39,7 +39,7 @@ namespace LLama.Unittest.KernelMemory
             var tokens = _generator!.GetTokens(text);
             var tokensCount = _generator.CountTokens(text);
 
-            var expected = " " + text; // the placement of the space corresponding to BOS will vary by model tokenizer
+            var expected = text;
             var actual = string.Join("", tokens);
 
             _testOutputHelper.WriteLine($"Tokens for '{text}':");
@@ -79,7 +79,7 @@ namespace LLama.Unittest.KernelMemory
             var tokens = _generator!.GetTokens(text);
             var tokensCount = _generator.CountTokens(text);
 
-            var expected = " " + text; // the placement of the space corresponding to BOS will vary by model tokenizer
+            var expected = text;
             var actual = string.Join("", tokens);
 
             _testOutputHelper.WriteLine($"Tokens for '{text}':");

--- a/LLama.Unittest/LLama.Unittest.csproj
+++ b/LLama.Unittest/LLama.Unittest.csproj
@@ -29,7 +29,7 @@
 
   <Target Name="DownloadContentFilesInner">
   
-    <DownloadFile SourceUrl="https://huggingface.co/TheBloke/Llama-2-7b-Chat-GGUF/resolve/main/llama-2-7b-chat.Q3_K_S.gguf" DestinationFolder="Models" DestinationFileName="llama-2-7b-chat.Q3_K_S.gguf" SkipUnchangedFiles="true">
+    <DownloadFile SourceUrl="https://huggingface.co/bartowski/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q4_0.gguf" DestinationFolder="Models" DestinationFileName="Llama-3.2-1B-Instruct-Q4_0.gguf" SkipUnchangedFiles="true">
 	</DownloadFile>
     
 	<DownloadFile SourceUrl="https://huggingface.co/cjpais/llava-1.6-mistral-7b-gguf/resolve/main/llava-v1.6-mistral-7b.Q3_K_XS.gguf" DestinationFolder="Models" DestinationFileName="llava-v1.6-mistral-7b.Q3_K_XS.gguf" SkipUnchangedFiles="true">
@@ -57,7 +57,7 @@
     <None Update="Models\all-MiniLM-L12-v2.Q8_0.gguf">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="Models\llama-2-7b-chat.Q3_K_S.gguf">
+    <None Update="Models\Llama-3.2-1B-Instruct-Q4_0.gguf">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Models\llava-v1.6-mistral-7b.Q3_K_XS.gguf">

--- a/LLama.Unittest/LLamaContextTests.cs
+++ b/LLama.Unittest/LLamaContextTests.cs
@@ -30,8 +30,8 @@ namespace LLama.Unittest
         public void CheckProperties()
         {
             Assert.Equal(128u, _context.ContextSize);
-            Assert.Equal(4096, _context.EmbeddingSize);
-            Assert.Equal(32000, _context.VocabCount);
+            Assert.Equal(2048, _context.EmbeddingSize);
+            Assert.Equal(128256, _context.VocabCount);
         }
 
         [Fact]
@@ -39,7 +39,7 @@ namespace LLama.Unittest
         {
             var tokens = _context.Tokenize("The quick brown fox", true);
 
-            Assert.Equal(new LLamaToken[] { 1, 450, 4996, 17354, 1701, 29916 }, tokens);
+            Assert.Equal(new LLamaToken[] { 128000, 791, 4062, 14198, 39935 }, tokens);
         }
 
         [Fact]
@@ -47,7 +47,7 @@ namespace LLama.Unittest
         {
             var tokens = _context.Tokenize("\n", false, false);
 
-            Assert.Equal(new LLamaToken[] { 29871, 13 }, tokens);
+            Assert.Equal(new LLamaToken[] { 198 }, tokens);
         }
 
         [Fact]
@@ -78,7 +78,7 @@ namespace LLama.Unittest
         {
             var tokens = _context.Tokenize("The quick brown fox", false);
 
-            Assert.Equal(new LLamaToken[] { 450, 4996, 17354, 1701, 29916 }, tokens);
+            Assert.Equal(new LLamaToken[] { 791, 4062, 14198, 39935 }, tokens);
         }
 
         [Fact]

--- a/LLama.Unittest/LLamaEmbedderTests.cs
+++ b/LLama.Unittest/LLamaEmbedderTests.cs
@@ -60,8 +60,8 @@ public sealed class LLamaEmbedderTests
         Assert.All(cat.Zip(embeddings[0].Vector.Span.EuclideanNormalization()), e => Assert.Equal(e.First, e.Second, 0.001));
         Assert.All(kitten.Zip(embeddings[1].Vector.Span.EuclideanNormalization()), e => Assert.Equal(e.First, e.Second, 0.001));
         Assert.All(spoon.Zip(embeddings[2].Vector.Span.EuclideanNormalization()), e => Assert.Equal(e.First, e.Second, 0.001));
-        Assert.True(embeddings.Usage?.InputTokenCount is 17 or 19 or 20);
-        Assert.True(embeddings.Usage?.TotalTokenCount is 17 or 19 or 20);
+        Assert.True(embeddings.Usage?.InputTokenCount is 16 or 19);
+        Assert.True(embeddings.Usage?.TotalTokenCount is 16 or 19);
 
         _testOutputHelper.WriteLine($"Cat    = [{string.Join(",", cat.AsMemory().Slice(0, 7).ToArray())}...]");
         _testOutputHelper.WriteLine($"Kitten = [{string.Join(",", kitten.AsMemory().Slice(0, 7).ToArray())}...]");
@@ -86,7 +86,7 @@ public sealed class LLamaEmbedderTests
     [Fact]
     public async Task EmbedCompareGenerateModel()
     {
-        await CompareEmbeddings(Constants.LLavaModelPath);
+        await CompareEmbeddings(Constants.GenerativeModelPath);
     }
 
     private async Task NonPooledEmbeddings(string modelPath)

--- a/LLama.Unittest/LLamaEmbedderTests.cs
+++ b/LLama.Unittest/LLamaEmbedderTests.cs
@@ -60,8 +60,8 @@ public sealed class LLamaEmbedderTests
         Assert.All(cat.Zip(embeddings[0].Vector.Span.EuclideanNormalization()), e => Assert.Equal(e.First, e.Second, 0.001));
         Assert.All(kitten.Zip(embeddings[1].Vector.Span.EuclideanNormalization()), e => Assert.Equal(e.First, e.Second, 0.001));
         Assert.All(spoon.Zip(embeddings[2].Vector.Span.EuclideanNormalization()), e => Assert.Equal(e.First, e.Second, 0.001));
-        Assert.True(embeddings.Usage?.InputTokenCount is 19 or 20);
-        Assert.True(embeddings.Usage?.TotalTokenCount is 19 or 20);
+        Assert.True(embeddings.Usage?.InputTokenCount is 17 or 19 or 20);
+        Assert.True(embeddings.Usage?.TotalTokenCount is 17 or 19 or 20);
 
         _testOutputHelper.WriteLine($"Cat    = [{string.Join(",", cat.AsMemory().Slice(0, 7).ToArray())}...]");
         _testOutputHelper.WriteLine($"Kitten = [{string.Join(",", kitten.AsMemory().Slice(0, 7).ToArray())}...]");
@@ -86,7 +86,7 @@ public sealed class LLamaEmbedderTests
     [Fact]
     public async Task EmbedCompareGenerateModel()
     {
-        await CompareEmbeddings(Constants.GenerativeModelPath);
+        await CompareEmbeddings(Constants.LLavaModelPath);
     }
 
     private async Task NonPooledEmbeddings(string modelPath)

--- a/LLama.Unittest/LLavaWeightsTests.cs
+++ b/LLama.Unittest/LLavaWeightsTests.cs
@@ -1,4 +1,4 @@
-﻿using LLama.Common;
+using LLama.Common;
 using LLama.Native;
 
 namespace LLama.Unittest
@@ -14,7 +14,7 @@ namespace LLama.Unittest
         
         public LLavaWeightTests()
         {
-            var @params = new ModelParams(Constants.GenerativeModelPath)
+            var @params = new ModelParams(Constants.LLavaModelPath)
             {
                 // Llava models requires big context
                 ContextSize = 4096,

--- a/LLama.Unittest/Native/SafeLlamaModelHandleTests.cs
+++ b/LLama.Unittest/Native/SafeLlamaModelHandleTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using LLama.Common;
 using LLama.Native;
 using LLama.Extensions;
@@ -29,7 +29,7 @@ public class SafeLlamaModelHandleTests
         var template = _model.NativeHandle.MetadataValueByKey(key);
         var name = Encoding.UTF8.GetStringFromSpan(template!.Value.Span);
 
-        const string expected = "LLaMA v2";
+        const string expected = "Llama 3.2 1B Instruct";
         Assert.Equal(expected, name);
 
         var metadataLookup = _model.Metadata[key];

--- a/LLama.Unittest/TemplateTests.cs
+++ b/LLama.Unittest/TemplateTests.cs
@@ -55,20 +55,14 @@ public sealed class TemplateTests
         Assert.Equal(8, templater.Count);
 
         var templateResult = Encoding.UTF8.GetString(dest);
-        const string expected = "<|im_start|>assistant\nhello<|im_end|>\n" +
-                                "<|im_start|>user\nworld<|im_end|>\n" +
-                                "<|im_start|>assistant\n" +
-                                "111<|im_end|>" +
-                                "\n<|im_start|>user\n" +
-                                "aaa<|im_end|>\n" +
-                                "<|im_start|>assistant\n" +
-                                "222<|im_end|>\n" +
-                                "<|im_start|>user\n" +
-                                "bbb<|im_end|>\n" +
-                                "<|im_start|>assistant\n" +
-                                "333<|im_end|>\n" +
-                                "<|im_start|>user\n" +
-                                "ccc<|im_end|>\n";
+        const string expected = "<|start_header_id|>assistant<|end_header_id|>\n\nhello<|eot_id|>"
+                                    + "<|start_header_id|>user<|end_header_id|>\n\nworld<|eot_id|>"
+                                    + "<|start_header_id|>assistant<|end_header_id|>\n\n111<|eot_id|>"
+                                    + "<|start_header_id|>user<|end_header_id|>\n\naaa<|eot_id|>"
+                                    + "<|start_header_id|>assistant<|end_header_id|>\n\n222<|eot_id|>"
+                                    + "<|start_header_id|>user<|end_header_id|>\n\nbbb<|eot_id|>"
+                                    + "<|start_header_id|>assistant<|end_header_id|>\n\n333<|eot_id|>"
+                                    + "<|start_header_id|>user<|end_header_id|>\n\nccc<|eot_id|>";
 
         Assert.Equal(expected, templateResult);
     }
@@ -136,21 +130,15 @@ public sealed class TemplateTests
         Assert.Equal(8, templater.Count);
 
         var templateResult = Encoding.UTF8.GetString(dest);
-        const string expected = "<|im_start|>assistant\nhello<|im_end|>\n" +
-                                "<|im_start|>user\nworld<|im_end|>\n" +
-                                "<|im_start|>assistant\n" +
-                                "111<|im_end|>" +
-                                "\n<|im_start|>user\n" +
-                                "aaa<|im_end|>\n" +
-                                "<|im_start|>assistant\n" +
-                                "222<|im_end|>\n" +
-                                "<|im_start|>user\n" +
-                                "bbb<|im_end|>\n" +
-                                "<|im_start|>assistant\n" +
-                                "333<|im_end|>\n" +
-                                "<|im_start|>user\n" +
-                                "ccc<|im_end|>\n" +
-                                "<|im_start|>assistant\n";
+        const string expected = "<|start_header_id|>assistant<|end_header_id|>\n\nhello<|eot_id|>"
+                                    + "<|start_header_id|>user<|end_header_id|>\n\nworld<|eot_id|>"
+                                    + "<|start_header_id|>assistant<|end_header_id|>\n\n111<|eot_id|>"
+                                    + "<|start_header_id|>user<|end_header_id|>\n\naaa<|eot_id|>"
+                                    + "<|start_header_id|>assistant<|end_header_id|>\n\n222<|eot_id|>"
+                                    + "<|start_header_id|>user<|end_header_id|>\n\nbbb<|eot_id|>"
+                                    + "<|start_header_id|>assistant<|end_header_id|>\n\n333<|eot_id|>"
+                                    + "<|start_header_id|>user<|end_header_id|>\n\nccc<|eot_id|>"
+                                    + "<|start_header_id|>assistant<|end_header_id|>\n\n";
 
         Assert.Equal(expected, templateResult);
     }
@@ -252,14 +240,14 @@ public sealed class TemplateTests
         var dest = templater.Apply();
         var templateResult = Encoding.UTF8.GetString(dest);
 
-        const string expectedTemplate = $"<|im_start|>user\n{userData}<|im_end|>\n";
+        const string expectedTemplate = $"<|start_header_id|>user<|end_header_id|>\n\n{userData}<|eot_id|>";
         Assert.Equal(expectedTemplate, templateResult);
     }
 
     [Fact]
     public void EndOTurnToken_ReturnsExpected()
     {
-        Assert.Null(_model.Tokens.EndOfTurnToken);
+        Assert.Equal("<|eot_id|>", _model.Tokens.EndOfTurnToken);
     }
 
     [Fact]
@@ -272,7 +260,7 @@ public sealed class TemplateTests
         var eosStr = ConvertTokenToString(_model.Tokens.EOS!.Value);
         _output.WriteLine(eosStr ?? "null");
 
-        Assert.Equal("</s>", _model.Tokens.EndOfSpeechToken);
+        Assert.Equal("<|eot_id|>", _model.Tokens.EndOfSpeechToken);
     }
 
     private string? ConvertTokenToString(LLamaToken token)

--- a/LLama.Unittest/Transformers/PromptTemplateTransformerTests.cs
+++ b/LLama.Unittest/Transformers/PromptTemplateTransformerTests.cs
@@ -1,4 +1,4 @@
-﻿using LLama.Common;
+using LLama.Common;
 using LLama.Transformers;
 
 namespace LLama.Unittest.Transformers;
@@ -28,9 +28,7 @@ public class PromptTemplateTransformerTests
             Messages = [new ChatHistory.Message(AuthorRole.User, userData)]
         });
 
-        const string expected = "<|im_start|>user\n" +
-                                $"{userData}<|im_end|>\n" +
-                                "<|im_start|>assistant\n";
+        const string expected = $"<|start_header_id|>user<|end_header_id|>\n\n{userData}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n";
         Assert.Equal(expected, template);
     }
 
@@ -62,21 +60,15 @@ public class PromptTemplateTransformerTests
 
         // Call once with empty array to discover length
         var templateResult = PromptTemplateTransformer.ToModelPrompt(templater);
-        const string expected = "<|im_start|>assistant\nhello<|im_end|>\n" +
-                                "<|im_start|>user\nworld<|im_end|>\n" +
-                                "<|im_start|>assistant\n" +
-                                "111<|im_end|>" +
-                                "\n<|im_start|>user\n" +
-                                "aaa<|im_end|>\n" +
-                                "<|im_start|>assistant\n" +
-                                "222<|im_end|>\n" +
-                                "<|im_start|>user\n" +
-                                "bbb<|im_end|>\n" +
-                                "<|im_start|>assistant\n" +
-                                "333<|im_end|>\n" +
-                                "<|im_start|>user\n" +
-                                "ccc<|im_end|>\n" +
-                                "<|im_start|>assistant\n";
+        const string expected = "<|start_header_id|>assistant<|end_header_id|>\n\nhello<|eot_id|>"
+                                    + "<|start_header_id|>user<|end_header_id|>\n\nworld<|eot_id|>"
+                                    + "<|start_header_id|>assistant<|end_header_id|>\n\n111<|eot_id|>"
+                                    + "<|start_header_id|>user<|end_header_id|>\n\naaa<|eot_id|>"
+                                    + "<|start_header_id|>assistant<|end_header_id|>\n\n222<|eot_id|>"
+                                    + "<|start_header_id|>user<|end_header_id|>\n\nbbb<|eot_id|>"
+                                    + "<|start_header_id|>assistant<|end_header_id|>\n\n333<|eot_id|>"
+                                    + "<|start_header_id|>user<|end_header_id|>\n\nccc<|eot_id|>"
+                                    + "<|start_header_id|>assistant<|end_header_id|>\n\n";
 
         Assert.Equal(expected, templateResult);
     }


### PR DESCRIPTION
This PR makes the default model used for CI tests be the smaller `LLaMA-3.2-1B-Instruct-Q4_0` instead of the significantly larger `llama-2-7b-chat.Q3_K_S`. This should speed up CI tests and save a couple GB in space.