### PR TITLE
Non-deterministic default seed (+minor sampling parameters names & comments update)

### DIFF
--- a/LLama.KernelMemory/LlamaSharpTextGenerator.cs
+++ b/LLama.KernelMemory/LlamaSharpTextGenerator.cs
@@ -92,8 +92,8 @@ namespace LLamaSharp.KernelMemory
                     SamplingPipeline = new DefaultSamplingPipeline()
                     {
                         Temperature = (float)options.Temperature,
-                        AlphaFrequency = (float)options.FrequencyPenalty,
-                        AlphaPresence = (float)options.PresencePenalty,
+                        FrequencyPenalty = (float)options.FrequencyPenalty,
+                        PresencePenalty = (float)options.PresencePenalty,
                         TopP = (float)options.NucleusSampling,
                     }
                 };
@@ -107,8 +107,8 @@ namespace LLamaSharp.KernelMemory
                 SamplingPipeline = new DefaultSamplingPipeline()
                 {
                     Temperature = (float)options.Temperature,
-                    AlphaFrequency = (float)options.FrequencyPenalty,
-                    AlphaPresence = (float)options.PresencePenalty,
+                    FrequencyPenalty = (float)options.FrequencyPenalty,
+                    PresencePenalty = (float)options.PresencePenalty,
                     TopP = (float)options.NucleusSampling,
                 }
             };

--- a/LLama.SemanticKernel/ExtensionMethods.cs
+++ b/LLama.SemanticKernel/ExtensionMethods.cs
@@ -53,8 +53,8 @@ public static class ExtensionMethods
             {
                 Temperature = (float)requestSettings.Temperature,
                 TopP = (float)requestSettings.TopP,
-                AlphaPresence = (float)requestSettings.PresencePenalty,
-                AlphaFrequency = (float)requestSettings.FrequencyPenalty,
+                PresencePenalty = (float)requestSettings.PresencePenalty,
+                FrequencyPenalty = (float)requestSettings.FrequencyPenalty,
             }
         };
     }

--- a/LLama/Extensions/LLamaExecutorExtensions.cs
+++ b/LLama/Extensions/LLamaExecutorExtensions.cs
@@ -142,9 +142,9 @@ public static class LLamaExecutorExtensions
                 MaxTokens = options?.MaxOutputTokens ?? 256, // arbitrary upper limit
                 SamplingPipeline = new DefaultSamplingPipeline()
                 {
-                    AlphaFrequency = options?.AdditionalProperties?.TryGetValue(nameof(DefaultSamplingPipeline.AlphaFrequency), out float af) is true ? af : s_defaultPipeline.AlphaFrequency,
-                    AlphaPresence = options?.AdditionalProperties?.TryGetValue(nameof(DefaultSamplingPipeline.AlphaPresence), out float ap) is true ? ap : s_defaultPipeline.AlphaPresence,
-                    PenalizeEOS = options?.AdditionalProperties?.TryGetValue(nameof(DefaultSamplingPipeline.PenalizeEOS), out bool eos) is true ? eos : s_defaultPipeline.PenalizeEOS,
+                    FrequencyPenalty = options?.AdditionalProperties?.TryGetValue(nameof(DefaultSamplingPipeline.FrequencyPenalty), out float af) is true ? af : s_defaultPipeline.FrequencyPenalty,
+                    PresencePenalty = options?.AdditionalProperties?.TryGetValue(nameof(DefaultSamplingPipeline.PresencePenalty), out float ap) is true ? ap : s_defaultPipeline.PresencePenalty,
+                    PreventEOS = options?.AdditionalProperties?.TryGetValue(nameof(DefaultSamplingPipeline.PreventEOS), out bool eos) is true ? eos : s_defaultPipeline.PreventEOS,
                     PenalizeNewline = options?.AdditionalProperties?.TryGetValue(nameof(DefaultSamplingPipeline.PenalizeNewline), out bool pnl) is true ? pnl : s_defaultPipeline.PenalizeNewline,
                     RepeatPenalty = options?.AdditionalProperties?.TryGetValue(nameof(DefaultSamplingPipeline.RepeatPenalty), out float rp) is true ? rp : s_defaultPipeline.RepeatPenalty,
                     RepeatPenaltyCount = options?.AdditionalProperties?.TryGetValue(nameof(DefaultSamplingPipeline.RepeatPenaltyCount), out int rpc) is true ? rpc : s_defaultPipeline.RepeatPenaltyCount,

--- a/LLama/Sampling/DefaultSamplingPipeline.cs
+++ b/LLama/Sampling/DefaultSamplingPipeline.cs
@@ -25,15 +25,15 @@ public sealed class DefaultSamplingPipeline
     /// Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text
     /// so far, decreasing the model's likelihood to repeat the same line verbatim.
     /// </summary>
-    public float AlphaFrequency
+    public float FrequencyPenalty
     {
         get => _alphaFreq;
         init
         {
             if (value < -2)
-                throw new ArgumentOutOfRangeException(nameof(value), "AlphaFrequency must be greater than -2");
+                throw new ArgumentOutOfRangeException(nameof(value), $"{nameof(FrequencyPenalty)} must be greater than -2");
             if (value > 2)
-                throw new ArgumentOutOfRangeException(nameof(value), "AlphaFrequency must be less than 2");
+                throw new ArgumentOutOfRangeException(nameof(value), $"{nameof(FrequencyPenalty)} must be less than 2");
             _alphaFreq = value;
         }
     }
@@ -44,15 +44,15 @@ public sealed class DefaultSamplingPipeline
     /// Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the
     /// text so far, increasing the model's likelihood to talk about new topics.
     /// </summary>
-    public float AlphaPresence
+    public float PresencePenalty
     {
         get => _alphaPresence;
         init
         {
             if (value < -2)
-                throw new ArgumentOutOfRangeException(nameof(value), "AlphaFrequency must be greater than -2");
+                throw new ArgumentOutOfRangeException(nameof(value), $"{nameof(PresencePenalty)} must be greater than -2");
             if (value > 2)
-                throw new ArgumentOutOfRangeException(nameof(value), "AlphaFrequency must be less than 2");
+                throw new ArgumentOutOfRangeException(nameof(value), $"{nameof(PresencePenalty)} must be less than 2");
             _alphaPresence = value;
         }
     }
@@ -69,9 +69,9 @@ public sealed class DefaultSamplingPipeline
     public bool PenalizeNewline { get; init; } = false;
 
     /// <summary>
-    /// Whether the EOS token should be protected from being modified by penalty
+    /// Whether the EOS token should be suppressed. Setting this to 'true' prevents EOS from being sampled
     /// </summary>
-    public bool PenalizeEOS { get; init; } = false;
+    public bool PreventEOS { get; init; } = false;
 
     /// <summary>
     /// Temperature to apply (higher temperature is more "creative")
@@ -147,8 +147,8 @@ public sealed class DefaultSamplingPipeline
             context.VocabCount,
             context.ModelHandle.Tokens.EOS, context.ModelHandle.Tokens.Newline ?? 0,
             RepeatPenaltyCount, RepeatPenalty,
-            AlphaFrequency, AlphaPresence,
-            PenalizeNewline, PenalizeEOS
+            FrequencyPenalty, PresencePenalty,
+            PenalizeNewline, PreventEOS
         );
 
         chain.AddTopK(TopK);

--- a/LLama/Sampling/DefaultSamplingPipeline.cs
+++ b/LLama/Sampling/DefaultSamplingPipeline.cs
@@ -111,7 +111,7 @@ public sealed class DefaultSamplingPipeline
     /// <summary>
     /// Seed to use for random sampling
     /// </summary>
-    public uint Seed { get; set; } = 42;
+    public uint Seed { get; set; } = (uint) new Random().Next(0, int.MaxValue);
 
     /// <inheritdoc />
     protected override SafeLLamaSamplerChainHandle CreateChain(SafeLLamaContextHandle context)

--- a/LLama/Sampling/DefaultSamplingPipeline.cs
+++ b/LLama/Sampling/DefaultSamplingPipeline.cs
@@ -20,7 +20,6 @@ public sealed class DefaultSamplingPipeline
     /// </summary>
     public float RepeatPenalty { get; init; } = 1;
 
-
     /// <summary>
     /// Frequency penalty as described by OpenAI: https://platform.openai.com/docs/api-reference/chat/create<br />
     /// Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text
@@ -156,7 +155,16 @@ public sealed class DefaultSamplingPipeline
     /// <summary>
     /// Seed to use for random sampling
     /// </summary>
-    public uint Seed { get; set; } = (uint) new Random().Next(0, int.MaxValue);
+    public uint Seed { get; set; } = GetRandomSeed();
+
+
+    private static Random RandomSeedGenerator = new();
+    private static uint GetRandomSeed()
+    {
+        lock (RandomSeedGenerator)
+            return (uint) RandomSeedGenerator.Next(0, int.MaxValue) + (uint) RandomSeedGenerator.Next(0, int.MaxValue);
+    }
+
 
     /// <inheritdoc />
     protected override SafeLLamaSamplerChainHandle CreateChain(SafeLLamaContextHandle context)

--- a/LLama/Sampling/DefaultSamplingPipeline.cs
+++ b/LLama/Sampling/DefaultSamplingPipeline.cs
@@ -20,6 +20,45 @@ public sealed class DefaultSamplingPipeline
     /// </summary>
     public float RepeatPenalty { get; init; } = 1;
 
+
+    /// <summary>
+    /// Frequency penalty as described by OpenAI: https://platform.openai.com/docs/api-reference/chat/create<br />
+    /// Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text
+    /// so far, decreasing the model's likelihood to repeat the same line verbatim.
+    /// </summary>
+    [Obsolete($"Use {nameof(FrequencyPenalty)} instead.")]
+    public float AlphaFrequency
+    {
+        get => _frequencyPenalty;
+        init
+        {
+            if (value < -2)
+                throw new ArgumentOutOfRangeException(nameof(value), $"{nameof(AlphaFrequency)} must be greater than -2");
+            if (value > 2)
+                throw new ArgumentOutOfRangeException(nameof(value), $"{nameof(AlphaFrequency)} must be less than 2");
+            _frequencyPenalty = value;
+        }
+    }
+
+    /// <summary>
+    /// Presence penalty as described by OpenAI: https://platform.openai.com/docs/api-reference/chat/create<br />
+    /// Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the
+    /// text so far, increasing the model's likelihood to talk about new topics.
+    /// </summary>
+    [Obsolete($"Use {nameof(PresencePenalty)} instead.")]
+    public float AlphaPresence
+    {
+        get => _presencePenalty;
+        init
+        {
+            if (value < -2)
+                throw new ArgumentOutOfRangeException(nameof(value), $"{nameof(AlphaPresence)} must be greater than -2");
+            if (value > 2)
+                throw new ArgumentOutOfRangeException(nameof(value), $"{nameof(AlphaPresence)} must be less than 2");
+            _presencePenalty = value;
+        }
+    }
+
     /// <summary>
     /// Frequency penalty as described by OpenAI: https://platform.openai.com/docs/api-reference/chat/create<br />
     /// Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text
@@ -27,17 +66,17 @@ public sealed class DefaultSamplingPipeline
     /// </summary>
     public float FrequencyPenalty
     {
-        get => _alphaFreq;
+        get => _frequencyPenalty;
         init
         {
             if (value < -2)
                 throw new ArgumentOutOfRangeException(nameof(value), $"{nameof(FrequencyPenalty)} must be greater than -2");
             if (value > 2)
                 throw new ArgumentOutOfRangeException(nameof(value), $"{nameof(FrequencyPenalty)} must be less than 2");
-            _alphaFreq = value;
+            _frequencyPenalty = value;
         }
     }
-    private readonly float _alphaFreq;
+    private readonly float _frequencyPenalty;
 
     /// <summary>
     /// Presence penalty as described by OpenAI: https://platform.openai.com/docs/api-reference/chat/create<br />
@@ -46,17 +85,17 @@ public sealed class DefaultSamplingPipeline
     /// </summary>
     public float PresencePenalty
     {
-        get => _alphaPresence;
+        get => _presencePenalty;
         init
         {
             if (value < -2)
                 throw new ArgumentOutOfRangeException(nameof(value), $"{nameof(PresencePenalty)} must be greater than -2");
             if (value > 2)
                 throw new ArgumentOutOfRangeException(nameof(value), $"{nameof(PresencePenalty)} must be less than 2");
-            _alphaPresence = value;
+            _presencePenalty = value;
         }
     }
-    private readonly float _alphaPresence;
+    private readonly float _presencePenalty;
 
     /// <summary>
     /// How many tokens should be considered for penalizing repetition
@@ -67,6 +106,12 @@ public sealed class DefaultSamplingPipeline
     /// Whether the newline token should be protected from being modified by penalty
     /// </summary>
     public bool PenalizeNewline { get; init; } = false;
+
+    /// <summary>
+    /// Whether the EOS token should be protected from being modified by penalty
+    /// </summary>
+    [Obsolete($"This doesn't do what the name implies. If you're sure you want to use it, use {nameof(PreventEOS)}.")]
+    public bool PenalizeEOS { get; init; } = false;
 
     /// <summary>
     /// Whether the EOS token should be suppressed. Setting this to 'true' prevents EOS from being sampled


### PR DESCRIPTION
Distribution seed for sampling used to always be fixed (42) by default, causing deterministic sampling.
This PR switches it to be randomly initialized with each new sampling pipeline instance.

Also changed some of the sampling pipeline's members' names and comments to better reflect their purpose.
- `AlphaFrequency` --> `FrequencyPenalty`
- `AlphaPresence` --> `PresencePenalty`
- `PenalizeEOS` --> `PreventEOS`
###### `PenalizeEOS` actually completely takes away the possibility for `EOS_TOKEN` to be sampled, causing infinite generation.