### PR TITLE
The log levels defined on llama.cpp and LlamaSharp side were not aligned anymore (issue #995)

### DIFF
--- a/LLama.Unittest/LLamaContextWithCustomLoggerTests.cs
+++ b/LLama.Unittest/LLamaContextWithCustomLoggerTests.cs
@@ -1,0 +1,63 @@
+using LLama.Common;
+using LLama.Native;
+using Microsoft.Extensions.Logging;
+
+namespace LLama.Unittest
+{
+    public sealed class LLamaContextWithCustomLoggerTests
+        : IDisposable
+    {
+        private sealed class CustomLogger : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => default;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception, string> formatter)
+            {
+            }
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+        }
+
+        private readonly LLamaWeights _weights;
+        private readonly LLamaContext _context;
+
+        public LLamaContextWithCustomLoggerTests()
+        {
+            var @params = new ModelParams(Constants.GenerativeModelPath)
+            {
+                ContextSize = 128,
+                GpuLayerCount = Constants.CIGpuLayerCount,
+            };
+
+            // This unit test used to fail when loading the weights with such a naive logger set.
+            //
+            // See https://github.com/SciSharp/LLamaSharp/issues/995
+            //
+            // So the unit test here doesn't check that the logger is actually used
+            // but at least that setting one doesn't crash the weights load.
+            NativeLogConfig.llama_log_set(new CustomLogger());
+
+            _weights = LLamaWeights.LoadFromFile(@params);
+            _context = _weights.CreateContext(@params);
+        }
+
+        public void Dispose()
+        {
+            _weights.Dispose();
+            _context.Dispose();
+        }
+
+        [Fact]
+        public void CheckProperties()
+        {
+            Assert.Equal(128u, _context.ContextSize);
+            Assert.Equal(2048, _context.EmbeddingSize);
+            Assert.Equal(128256, _context.VocabCount);
+        }
+    }
+}

--- a/LLama/Native/LLamaLogLevel.cs
+++ b/LLama/Native/LLamaLogLevel.cs
@@ -4,14 +4,26 @@ using Microsoft.Extensions.Logging;
 namespace LLama.Native
 {
     /// <summary>
-    /// Severity level of a log message
+    /// Severity level of a log message. This enum should always be aligned with
+    /// the one defined on llama.cpp side at
+    /// https://github.com/ggerganov/llama.cpp/blob/0eb4e12beebabae46d37b78742f4c5d4dbe52dc1/ggml/include/ggml.h#L559
     /// </summary>
     public enum LLamaLogLevel
     {
         /// <summary>
-        /// Logs that highlight when the current flow of execution is stopped due to a failure.
+        /// Logs are never written.
         /// </summary>
-        Error = 2,
+        None = 0,
+
+        /// <summary>
+        /// Logs that are used for interactive investigation during development.
+        /// </summary>
+        Debug = 1,
+
+        /// <summary>
+        /// Logs that track the general flow of the application.
+        /// </summary>
+        Info = 2,
 
         /// <summary>
         /// Logs that highlight an abnormal or unexpected event in the application flow, but do not otherwise cause the application execution to stop.
@@ -19,14 +31,14 @@ namespace LLama.Native
         Warning = 3,
 
         /// <summary>
-        /// Logs that track the general flow of the application.
+        /// Logs that highlight when the current flow of execution is stopped due to a failure.
         /// </summary>
-        Info = 4,
-
+        Error = 4,
+        
         /// <summary>
-        /// Logs that are used for interactive investigation during development.
+        /// Continue log level is equivalent to None in the way it is used in llama.cpp.
         /// </summary>
-        Debug = 5,
+        Continue = 5,
     }
 
     internal static class LLamaLogLevelExtensions
@@ -35,10 +47,12 @@ namespace LLama.Native
         {
             return (llama) switch
             {
-                LLamaLogLevel.Error => LogLevel.Error,
-                LLamaLogLevel.Warning => LogLevel.Warning,
-                LLamaLogLevel.Info => LogLevel.Information,
+                LLamaLogLevel.None => LogLevel.None,
                 LLamaLogLevel.Debug => LogLevel.Debug,
+                LLamaLogLevel.Info => LogLevel.Information,
+                LLamaLogLevel.Warning => LogLevel.Warning,
+                LLamaLogLevel.Error => LogLevel.Error,
+                LLamaLogLevel.Continue => LogLevel.None,
                 _ => throw new ArgumentOutOfRangeException(nameof(llama), llama, null)
             };
         }

--- a/LLama/Native/LLamaLogLevel.cs
+++ b/LLama/Native/LLamaLogLevel.cs
@@ -34,7 +34,7 @@ namespace LLama.Native
         /// Logs that highlight when the current flow of execution is stopped due to a failure.
         /// </summary>
         Error = 4,
-        
+
         /// <summary>
         /// Continue log level is equivalent to None in the way it is used in llama.cpp.
         /// </summary>
@@ -43,18 +43,24 @@ namespace LLama.Native
 
     internal static class LLamaLogLevelExtensions
     {
+        /// <summary>
+        /// Keeps track of the previous log level to be able to handle the log level <see cref="LLamaLogLevel.Continue"/>.
+        /// </summary>
+        [ThreadStatic] private static LogLevel _previous;
+
         public static LogLevel ToLogLevel(this LLamaLogLevel llama)
         {
-            return (llama) switch
+            _previous = llama switch
             {
                 LLamaLogLevel.None => LogLevel.None,
                 LLamaLogLevel.Debug => LogLevel.Debug,
                 LLamaLogLevel.Info => LogLevel.Information,
                 LLamaLogLevel.Warning => LogLevel.Warning,
                 LLamaLogLevel.Error => LogLevel.Error,
-                LLamaLogLevel.Continue => LogLevel.None,
+                LLamaLogLevel.Continue => _previous,
                 _ => throw new ArgumentOutOfRangeException(nameof(llama), llama, null)
             };
+            return _previous;
         }
     }
 }


### PR DESCRIPTION
Following this issue https://github.com/SciSharp/LLamaSharp/issues/995

After [this PR](https://github.com/ggerganov/llama.cpp/pull/9418) on the llama.cpp repo the loglevel defined on both llama.cpp and LlamaSharp sides were not aligned anymore. This misalignment made the model weight loading fail when a custom logger is used.

### Help
I am just wondering if it is correct to consider the `CONT` log level as equivalent to `NONE`.