### PR TITLE
ggml-base and ggml-cpu in Linux/Windows CPU build action

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -59,6 +59,16 @@ jobs:
           path: ./build/ggml/src/libggml.so
           name: ggml-bin-linux-${{ matrix.build }}-x64.so
           if-no-files-found: error
+      - uses: actions/upload-artifact@v4
+        with:
+          path: ./build/ggml/src/libggml-base.so
+          name: ggml-base-bin-linux-${{ matrix.build }}-x64.so
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v4
+        with:
+          path: ./build/ggml/src/ggml-cpu/libggml-cpu.so
+          name: ggml-cpu-bin-linux-${{ matrix.build }}-x64.so
+          if-no-files-found: error
       - name: Upload Llava
         uses: actions/upload-artifact@v4
         with:
@@ -108,6 +118,18 @@ jobs:
         with:
           path: .\build\bin\Release\ggml.dll
           name: ggml-bin-win-${{ matrix.build }}-x64.dll
+          if-no-files-found: error
+      - name: Upload artifacts (ggml-base)
+        uses: actions/upload-artifact@v4
+        with:
+          path: .\build\bin\Release\ggml-base.dll
+          name: ggml-base-bin-win-${{ matrix.build }}-x64.dll
+          if-no-files-found: error
+      - name: Upload artifacts (ggml-cpu)
+        uses: actions/upload-artifact@v4
+        with:
+          path: .\build\bin\Release\ggml-cpu.dll
+          name: ggml-cpu-bin-win-${{ matrix.build }}-x64.dll
           if-no-files-found: error
 
       - name: Upload artifacts (llava)
@@ -433,37 +455,53 @@ jobs:
 
           # Linux
           cp artifacts/ggml-bin-linux-noavx-x64.so/libggml.so           deps/libggml.so
+          cp artifacts/ggml-base-bin-linux-noavx-x64.so/libggml-base.so deps/libggml-base.so
+          cp artifacts/ggml-cpu-bin-linux-noavx-x64.so/libggml-cpu.so   deps/libggml-cpu.so
           cp artifacts/llama-bin-linux-noavx-x64.so/libllama.so         deps/libllama.so
           cp artifacts/llava-bin-linux-noavx-x64.so/libllava_shared.so  deps/libllava_shared.so
 
           cp artifacts/ggml-bin-linux-avx-x64.so/libggml.so             deps/avx/libggml.so
+          cp artifacts/ggml-base-bin-linux-avx-x64.so/libggml-base.so   deps/avx/libggml-base.so
+          cp artifacts/ggml-cpu-bin-linux-avx-x64.so/libggml-cpu.so     deps/avx/libggml-cpu.so
           cp artifacts/llama-bin-linux-avx-x64.so/libllama.so           deps/avx/libllama.so
           cp artifacts/llava-bin-linux-avx-x64.so/libllava_shared.so    deps/avx/libllava_shared.so
 
           cp artifacts/ggml-bin-linux-avx2-x64.so/libggml.so            deps/avx2/libggml.so
+          cp artifacts/ggml-base-bin-linux-avx2-x64.so/libggml-base.so  deps/avx2/libggml-base.so
+          cp artifacts/ggml-cpu-bin-linux-avx2-x64.so/libggml-cpu.so    deps/avx2/libggml-cpu.so
           cp artifacts/llama-bin-linux-avx2-x64.so/libllama.so          deps/avx2/libllama.so
           cp artifacts/llava-bin-linux-avx2-x64.so/libllava_shared.so   deps/avx2/libllava_shared.so
 
-          cp artifacts/ggml-bin-linux-avx512-x64.so/libggml.so          deps/avx512/libggml.so
-          cp artifacts/llama-bin-linux-avx512-x64.so/libllama.so        deps/avx512/libllama.so
-          cp artifacts/llava-bin-linux-avx512-x64.so/libllava_shared.so deps/avx512/libllava_shared.so
+          cp artifacts/ggml-bin-linux-avx512-x64.so/libggml.so           deps/avx512/libggml.so
+          cp artifacts/ggml-base-bin-linux-avx512-x64.so/libggml-base.so deps/avx512/libggml-base.so
+          cp artifacts/ggml-cpu-bin-linux-avx512-x64.so/libggml-cpu.so   deps/avx512/libggml-cpu.so
+          cp artifacts/llama-bin-linux-avx512-x64.so/libllama.so         deps/avx512/libllama.so
+          cp artifacts/llava-bin-linux-avx512-x64.so/libllava_shared.so  deps/avx512/libllava_shared.so
 
           # Windows
-          cp artifacts/ggml-bin-win-noavx-x64.dll/ggml.dll            deps/ggml.dll
-          cp artifacts/llama-bin-win-noavx-x64.dll/llama.dll          deps/llama.dll
-          cp artifacts/llava-bin-win-noavx-x64.dll/llava_shared.dll   deps/llava_shared.dll
+          cp artifacts/ggml-bin-win-noavx-x64.dll/ggml.dll             deps/ggml.dll
+          cp artifacts/ggml-base-bin-win-noavx-x64.so/libggml-base.dll deps/libggml-base.dll
+          cp artifacts/ggml-cpu-bin-win-noavx-x64.so/libggml-cpu.dll   deps/libggml-cpu.dll
+          cp artifacts/llama-bin-win-noavx-x64.dll/llama.dll           deps/llama.dll
+          cp artifacts/llava-bin-win-noavx-x64.dll/llava_shared.dll    deps/llava_shared.dll
 
           cp artifacts/ggml-bin-win-avx-x64.dll/ggml.dll              deps/avx/ggml.dll
+          cp artifacts/ggml-base-bin-win-avx-x64.so/libggml-base.dll  deps/avx/libggml-base.dll
+          cp artifacts/ggml-cpu-bin-win-avx-x64.so/libggml-cpu.dll    deps/avx/libggml-cpu.dll
           cp artifacts/llama-bin-win-avx-x64.dll/llama.dll            deps/avx/llama.dll
           cp artifacts/llava-bin-win-avx-x64.dll/llava_shared.dll     deps/avx/llava_shared.dll
 
           cp artifacts/ggml-bin-win-avx2-x64.dll/ggml.dll             deps/avx2/ggml.dll
+          cp artifacts/ggml-base-bin-win-avx2-x64.so/libggml-base.dll deps/avx2/libggml-base.dll
+          cp artifacts/ggml-cpu-bin-win-avx2-x64.so/libggml-cpu.dll   deps/avx2/libggml-cpu.dll
           cp artifacts/llama-bin-win-avx2-x64.dll/llama.dll           deps/avx2/llama.dll
           cp artifacts/llava-bin-win-avx2-x64.dll/llava_shared.dll    deps/avx2/llava_shared.dll
 
-          cp artifacts/ggml-bin-win-avx512-x64.dll/ggml.dll           deps/avx512/ggml.dll
-          cp artifacts/llama-bin-win-avx512-x64.dll/llama.dll         deps/avx512/llama.dll
-          cp artifacts/llava-bin-win-avx512-x64.dll/llava_shared.dll  deps/avx512/llava_shared.dll
+          cp artifacts/ggml-bin-win-avx512-x64.dll/ggml.dll             deps/avx512/ggml.dll
+          cp artifacts/ggml-base-bin-win-avx512-x64.so/libggml-base.dll deps/avx512/libggml-base.dll
+          cp artifacts/ggml-cpu-bin-win-avx512-x64.so/libggml-cpu.dll   deps/avx512/libggml-cpu.dll
+          cp artifacts/llama-bin-win-avx512-x64.dll/llama.dll           deps/avx512/llama.dll
+          cp artifacts/llava-bin-win-avx512-x64.dll/llava_shared.dll    deps/avx512/llava_shared.dll
 
           # MacOS
           cp artifacts/ggml-bin-osx-arm64.dylib/libggml.dylib           deps/osx-arm64/libggml.dylib


### PR DESCRIPTION
Including the new ggml-base and ggml-cpu files in linux and windows CPU build action output.