### PR TITLE
Adds an exception for missing templates.

### DIFF
--- a/LLama/Exceptions/RuntimeError.cs
+++ b/LLama/Exceptions/RuntimeError.cs
@@ -59,6 +59,25 @@ public class LLamaDecodeError
 }
 
 /// <summary>
+/// `llama_decode` return a non-zero status code
+/// </summary>
+public class MissingTemplateException
+    : RuntimeError
+{
+    /// <inheritdoc />
+    public MissingTemplateException()
+        : base("llama_chat_apply_template failed: template not found")
+    {
+    }
+    
+    /// <inheritdoc />
+    public MissingTemplateException(string message)
+        : base($"llama_chat_apply_template failed: template not found for '{message}'")
+    {
+    } 
+}
+
+/// <summary>
 /// `llama_get_logits_ith` returned null, indicating that the index was invalid
 /// </summary>
 public class GetLogitsInvalidIndexException

--- a/LLama/LLamaTemplate.cs
+++ b/LLama/LLamaTemplate.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
+using LLama.Exceptions;
 using LLama.Native;
 
 namespace LLama;
@@ -250,6 +251,19 @@ public sealed class LLamaTemplate
                 {
                     // Run templater and discover true length
                     var outputLength = ApplyInternal(_nativeChatMessages.AsSpan(0, Count), output);
+                    
+                    // if we have a return code of -1, the template was not found.
+                    if (outputLength == -1)
+                    {
+                        if (_customTemplate != null)
+                        {
+                            throw new MissingTemplateException(Encoding.GetString(_customTemplate));
+                        }
+                        else
+                        {
+                            throw new MissingTemplateException();    
+                        }
+                    }    
 
                     // If length was too big for output buffer run it again
                     if (outputLength > output.Length)


### PR DESCRIPTION
Adds better exception handling for when there are missing templates with a model when calling `llama_chat_apply_template`

Funny enough, it looks like https://github.com/ggerganov/llama.cpp/pull/10572 added support for my missing template, but still nice to have a better exception down the road.

Closes #1032 