### PR TITLE
Fix Kernel Memory

### DIFF
--- a/LLama.KernelMemory/BuilderExtensions.cs
+++ b/LLama.KernelMemory/BuilderExtensions.cs
@@ -73,7 +73,6 @@ namespace LLamaSharp.KernelMemory
             {
                 ContextSize = config.ContextSize ?? 2048,
                 GpuLayerCount = config.GpuLayerCount ?? 20,
-                Embeddings = true,
                 MainGpu = config.MainGpu,
                 SplitMode = config.SplitMode
             };

--- a/LLama.KernelMemory/LLamaSharp.KernelMemory.csproj
+++ b/LLama.KernelMemory/LLamaSharp.KernelMemory.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.KernelMemory.Abstractions" Version="0.95.241216.1" />
+    <PackageReference Include="Microsoft.KernelMemory.Abstractions" Version="0.96.250120.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LLama.KernelMemory/LlamaSharpTextGenerator.cs
+++ b/LLama.KernelMemory/LlamaSharpTextGenerator.cs
@@ -1,6 +1,7 @@
 using LLama;
 using LLama.Common;
 using LLama.Sampling;
+using Microsoft.KernelMemory;
 using Microsoft.KernelMemory.AI;
 
 namespace LLamaSharp.KernelMemory
@@ -73,9 +74,11 @@ namespace LLamaSharp.KernelMemory
         }
 
         /// <inheritdoc/>
-        public IAsyncEnumerable<string> GenerateTextAsync(string prompt, TextGenerationOptions options, CancellationToken cancellationToken = default)
+        public IAsyncEnumerable<GeneratedTextContent> GenerateTextAsync(string prompt, TextGenerationOptions options, CancellationToken cancellationToken = default)
         {
-            return _executor.InferAsync(prompt, OptionsToParams(options, _defaultInferenceParams), cancellationToken: cancellationToken);
+            return _executor
+                  .InferAsync(prompt, OptionsToParams(options, _defaultInferenceParams), cancellationToken: cancellationToken)
+                  .Select(a => new GeneratedTextContent(a));
         }
 
         private static InferenceParams OptionsToParams(TextGenerationOptions options, InferenceParams? defaultParams)


### PR DESCRIPTION
Fixed Kernel memory by not setting `embeddings=true` for text generation.

Fixes:
 - #891 
 - #1079