### PR TITLE
Updates json gbnf to match llama.cpp example

### DIFF
--- a/LLama.Examples/Assets/json.gbnf
+++ b/LLama.Examples/Assets/json.gbnf
@@ -1,5 +1,3 @@
-# https://github.com/ggerganov/llama.cpp/blob/8183159cf3def112f6d1fe94815fce70e1bffa12/grammars/json.gbnf
-
 root   ::= object
 value  ::= object | array | string | number | ("true" | "false" | "null") ws
 
@@ -17,11 +15,11 @@ array  ::=
 
 string ::=
   "\"" (
-    [^"\\] |
-    "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]) # escapes
+    [^"\\\x7F\x00-\x1F] |
+    "\\" (["\\bfnrt] | "u" [0-9a-fA-F]{4}) # escapes
   )* "\"" ws
 
-number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? ws
+number ::= ("-"? ([0-9] | [1-9] [0-9]{0,15})) ("." [0-9]+)? ([eE] [-+]? [0-9] [1-9]{0,15})? ws
 
 # Optional space: by convention, applied in this grammar after literal chars when allowed
-ws ::= ([ \t\n] ws)?
+ws ::= | " " | "\n" [ \t]{0,20}


### PR DESCRIPTION
Example had a tendency to start just outputting whitespace until it ran out of tokens without a few of the constraints they added around whitespace generation. This gets it in line with example at https://github.com/ggerganov/llama.cpp/blob/master/grammars/json.gbnf