### PR TITLE
Cleaned up non-important warnings from the error list

### DIFF
--- a/LLama.Examples/Examples/LlavaInteractiveModeExecute.cs
+++ b/LLama.Examples/Examples/LlavaInteractiveModeExecute.cs
@@ -93,7 +93,7 @@ namespace LLama.Examples.Examples
                     Console.WriteLine($"Here are the images, that are sent to the chat model in addition to your message.");
                     Console.WriteLine();
 
-                    foreach (var consoleImage in imageBytes?.Select(bytes => new CanvasImage(bytes)))
+                    foreach (var consoleImage in imageBytes?.Select(bytes => new CanvasImage(bytes)) ?? Array.Empty<CanvasImage>())
                     {
                         consoleImage.MaxWidth = 50;
                         AnsiConsole.Write(consoleImage);

--- a/LLama.Examples/Examples/SemanticKernelHomeAutomation.cs
+++ b/LLama.Examples/Examples/SemanticKernelHomeAutomation.cs
@@ -123,7 +123,7 @@ namespace LLama.Examples.Examples
                 ChatMessageContent chatResult = await chatCompletionService.GetChatMessageContentAsync(chatHistory, llamaSharpPromptExecutionSettings, _kernel, stoppingToken);
 
                 FunctionResult? fres = null;
-                if (chatResult.Content.Contains("[TURN ON THE LIGHT]"))
+                if (chatResult.Content!.Contains("[TURN ON THE LIGHT]"))
                 {
                     fres = await _kernel.InvokeAsync("OfficeLight", "TurnOn");
                 }

--- a/LLama.Examples/Examples/SemanticKernelHomeAutomation.cs
+++ b/LLama.Examples/Examples/SemanticKernelHomeAutomation.cs
@@ -68,7 +68,7 @@ namespace LLama.Examples.Examples
         }
     }
 
-    class Worker(
+    internal class Worker(
         IHostApplicationLifetime hostApplicationLifetime,
         [FromKeyedServices("HomeAutomationKernel")] Kernel kernel) : BackgroundService
     {
@@ -92,7 +92,7 @@ namespace LLama.Examples.Examples
                  TopP = 0.1f
             };
 
-            string? input = null;
+            string? input;
 
             while ((input = Console.ReadLine()) != null)
             {
@@ -125,17 +125,17 @@ namespace LLama.Examples.Examples
                 FunctionResult? fres = null;
                 if (chatResult.Content!.Contains("[TURN ON THE LIGHT]"))
                 {
-                    fres = await _kernel.InvokeAsync("OfficeLight", "TurnOn");
+                    fres = await _kernel.InvokeAsync("OfficeLight", "TurnOn", cancellationToken: stoppingToken);
                 }
                 else if (chatResult.Content.Contains("[TURN OFF THE LIGHT]"))
                 {
-                    fres = await _kernel.InvokeAsync("OfficeLight", "TurnOff");
+                    fres = await _kernel.InvokeAsync("OfficeLight", "TurnOff", cancellationToken: stoppingToken);
                 }
 
                 Console.ForegroundColor = ConsoleColor.Green;
                 if (fres != null || chatResult.Content.Contains("[WHICH LIGHT IS ON]"))
                 {
-                    fres = await _kernel.InvokeAsync("OfficeLight", "IsTurnedOn");
+                    fres = await _kernel.InvokeAsync("OfficeLight", "IsTurnedOn", cancellationToken: stoppingToken);
                     Console.Write($">>> Result:\n {(fres.GetValue<bool>()==true?"The light is ON.": "The light is OFF.")}\n\n> ");
                 }
                 else
@@ -154,7 +154,7 @@ namespace LLama.Examples.Examples
     /// Class that represents a controllable light.
     /// </summary>
     [Description("Represents a light")]
-    class MyLightPlugin(bool turnedOn = false)
+    internal class MyLightPlugin(bool turnedOn = false)
     {
         private bool _turnedOn = turnedOn;
 

--- a/LLama.Examples/Examples/SemanticKernelMemory.cs
+++ b/LLama.Examples/Examples/SemanticKernelMemory.cs
@@ -15,7 +15,6 @@ namespace LLama.Examples.Examples
             Console.WriteLine("This example is from: \n" +
                 "https://github.com/microsoft/semantic-kernel/blob/main/dotnet/samples/KernelSyntaxExamples/Example14_SemanticMemory.cs");
 
-            var seed = 1337u;
             // Load weights into memory
             var parameters = new ModelParams(modelPath)
             {

--- a/LLama.Examples/LLama.Examples.csproj
+++ b/LLama.Examples/LLama.Examples.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.SemanticKernel" Version="1.29.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.6.2-alpha" />
     <PackageReference Include="NAudio" Version="2.2.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="Spectre.Console.ImageSharp" Version="0.49.1" />
     <PackageReference Include="Whisper.net" Version="1.7.4" />

--- a/LLama.Unittest/SemanticKernel/LLamaSharpChatCompletionTests.cs
+++ b/LLama.Unittest/SemanticKernel/LLamaSharpChatCompletionTests.cs
@@ -12,13 +12,13 @@ namespace LLama.Unittest.SemanticKernel
 
         public LLamaSharpChatCompletionTests()
         {
-            this.mockStatelessExecutor = new Mock<ILLamaExecutor>();
+            mockStatelessExecutor = new Mock<ILLamaExecutor>();
         }
 
         private LLamaSharpChatCompletion CreateLLamaSharpChatCompletion()
         {
             return new LLamaSharpChatCompletion(
-                this.mockStatelessExecutor.Object,
+                mockStatelessExecutor.Object,
                 null,
                 null,
                 null);
@@ -28,7 +28,7 @@ namespace LLama.Unittest.SemanticKernel
         public async Task GetChatMessageContentsAsync_StateUnderTest_ExpectedBehavior()
         {
             // Arrange
-            var unitUnderTest = this.CreateLLamaSharpChatCompletion();
+            var unitUnderTest = CreateLLamaSharpChatCompletion();
             ChatHistory chatHistory = new ChatHistory();
             PromptExecutionSettings? executionSettings = null;
             Kernel? kernel = null;
@@ -51,7 +51,7 @@ namespace LLama.Unittest.SemanticKernel
         public async Task GetStreamingChatMessageContentsAsync_StateUnderTest_ExpectedBehavior()
         {
             // Arrange
-            var unitUnderTest = this.CreateLLamaSharpChatCompletion();
+            var unitUnderTest = CreateLLamaSharpChatCompletion();
             ChatHistory chatHistory = new ChatHistory();
             PromptExecutionSettings? executionSettings = null;
             Kernel? kernel = null;

--- a/LLama.Web/Pages/Error.cshtml.cs
+++ b/LLama.Web/Pages/Error.cshtml.cs
@@ -8,7 +8,7 @@ namespace LLama.Web.Pages
     [IgnoreAntiforgeryToken]
     public class ErrorModel : PageModel
     {
-        public string? RequestId { get; set; }
+        public string RequestId { get; set; }
 
         public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
 

--- a/LLama/ChatSession.cs
+++ b/LLama/ChatSession.cs
@@ -779,7 +779,7 @@ public record SessionState
 
         return new SessionState(
             contextState,
-            executorState,
+            executorState!,
             history,
             inputTransforms.ToList(),
             outputTransform,

--- a/LLama/Common/ChatHistory.cs
+++ b/LLama/Common/ChatHistory.cs
@@ -64,8 +64,8 @@ namespace LLama.Common
             /// <param name="content">Message content</param>
             public Message(AuthorRole authorRole, string content)
             {
-                this.AuthorRole = authorRole;
-                this.Content = content;
+                AuthorRole = authorRole;
+                Content = content;
             }
         }
 
@@ -87,7 +87,7 @@ namespace LLama.Common
         /// <param name="messageHistory"></param>
         public ChatHistory(Message[] messageHistory)
         {
-            this.Messages = messageHistory.ToList();
+            Messages = messageHistory.ToList();
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace LLama.Common
         /// <param name="content">Message content</param>
         public void AddMessage(AuthorRole authorRole, string content)
         {
-            this.Messages.Add(new Message(authorRole, content));
+            Messages.Add(new Message(authorRole, content));
         }
 
         /// <summary>

--- a/LLama/Common/PolymorphicJSONConverter.cs
+++ b/LLama/Common/PolymorphicJSONConverter.cs
@@ -45,7 +45,7 @@ namespace LLama.Common
         public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
         {
             writer.WriteStartObject();
-            writer.WriteString("Name", value.GetType().Name);
+            writer.WriteString("Name", value!.GetType().Name);
             writer.WritePropertyName("Data");
             JsonSerializer.Serialize(writer, value, value.GetType(), options);
             writer.WriteEndObject();

--- a/LLama/LLamaExecutorBase.cs
+++ b/LLama/LLamaExecutorBase.cs
@@ -395,7 +395,7 @@ namespace LLama
             public bool NeedToSaveSession { get; set; }
         }
 
-#pragma warning disable // Missing XML and irrelevant nullable warnings
+#pragma warning disable CS1591, CS8618 // Missing XML and irrelevant nullable warnings
         [JsonConverter(typeof(PolymorphicJSONConverter<ExecutorBaseState>))]
         public class ExecutorBaseState
         {

--- a/LLama/LLamaExecutorBase.cs
+++ b/LLama/LLamaExecutorBase.cs
@@ -395,6 +395,7 @@ namespace LLama
             public bool NeedToSaveSession { get; set; }
         }
 
+#pragma warning disable // Missing XML and nullable warnings that
         [JsonConverter(typeof(PolymorphicJSONConverter<ExecutorBaseState>))]
         public class ExecutorBaseState
         {
@@ -431,5 +432,6 @@ namespace LLama
             [JsonPropertyName("mirostat_mu")]
             public float? MirostatMu { get; set; }
         }
+#pragma warning restore
     }
 }

--- a/LLama/LLamaExecutorBase.cs
+++ b/LLama/LLamaExecutorBase.cs
@@ -395,7 +395,7 @@ namespace LLama
             public bool NeedToSaveSession { get; set; }
         }
 
-#pragma warning disable // Missing XML and nullable warnings that
+#pragma warning disable // Missing XML and irrelevant nullable warnings
         [JsonConverter(typeof(PolymorphicJSONConverter<ExecutorBaseState>))]
         public class ExecutorBaseState
         {

--- a/LLama/LLamaInstructExecutor.cs
+++ b/LLama/LLamaInstructExecutor.cs
@@ -25,8 +25,6 @@ namespace LLama
         private LLamaToken[] _inp_pfx;
         private LLamaToken[] _inp_sfx;
 
-        private ISamplingPipeline? _pipeline;
-
         /// <summary>
         /// 
         /// </summary>
@@ -72,17 +70,17 @@ namespace LLama
             if(data is InstructExecutorState state)
             {
                 _n_session_consumed = state.ConsumedSessionCount;
-                _embed_inps = state.EmbedInps.ToList();
+                _embed_inps = state.EmbedInps!.ToList();
                 _is_prompt_run = state.IsPromptRun;
                 _consumedTokensCount = state.ConsumedTokensCount;
-                _embeds = state.Embeds.ToList();
-                _last_n_tokens = new FixedSizeQueue<LLamaToken>(state.LastTokensCapacity, state.LastTokens);
-                _inp_pfx = state.InputPrefixTokens;
-                _inp_sfx = state.InputSuffixTokens;
+                _embeds = state.Embeds!.ToList();
+                _last_n_tokens = new FixedSizeQueue<LLamaToken>(state.LastTokensCapacity, state.LastTokens!);
+                _inp_pfx = state.InputPrefixTokens!;
+                _inp_sfx = state.InputSuffixTokens!;
                 _n_matching_session_tokens = state.MatchingSessionTokensCount;
                 _pastTokensCount = state.PastTokensCount;
                 _pathSession = state.SessionFilePath;
-                _session_tokens = state.SessionTokens.ToList();
+                _session_tokens = state.SessionTokens!.ToList();
             }
             else
             {
@@ -107,7 +105,7 @@ namespace LLama
             using (var fs = new FileStream(filename, FileMode.Open, FileAccess.Read))
             {
                 var state = await JsonSerializer.DeserializeAsync<InstructExecutorState>(fs);
-                await LoadState(state);
+                await LoadState(state!);
             }
         }
 
@@ -224,7 +222,7 @@ namespace LLama
                 if (!string.IsNullOrEmpty(_pathSession) && args.NeedToSaveSession)
                 {
                     args.NeedToSaveSession = false;
-                    SaveSessionFile(_pathSession);
+                    SaveSessionFile(_pathSession!);
                 }
 
                 // Sample with the pipeline
@@ -266,12 +264,12 @@ namespace LLama
             /// Instruction prefix tokens.
             /// </summary>
             [JsonPropertyName("inp_pfx")]
-            public LLamaToken[] InputPrefixTokens { get; set; }
+            public LLamaToken[]? InputPrefixTokens { get; set; }
             /// <summary>
             /// Instruction suffix tokens.
             /// </summary>
             [JsonPropertyName("inp_sfx")]
-            public LLamaToken[] InputSuffixTokens { get; set; }
+            public LLamaToken[]? InputSuffixTokens { get; set; }
         }
     }
 }

--- a/LLama/LLamaInteractExecutor.cs
+++ b/LLama/LLamaInteractExecutor.cs
@@ -123,7 +123,7 @@ namespace LLama
             {
                 // When running the first input (prompt) in interactive mode, we should specially process it.
                 if (text == null) throw new ArgumentException("Prompt cannot be null to trigger continuation if a prompt has not been provided previously.");
-                if (!this.IsMultiModal)
+                if (!IsMultiModal)
                 {
                     _embed_inps = Context.Tokenize(text, true, true).ToList();
                 }
@@ -142,7 +142,7 @@ namespace LLama
                         text += "\n";
                     }
 
-                    if (!this.IsMultiModal)
+                    if (!IsMultiModal)
                     {
                         var line_inp = Context.Tokenize(text, false, true);
                         _embed_inps.AddRange(line_inp);
@@ -160,9 +160,7 @@ namespace LLama
 
         /// <inheritdoc />
         private Task PreprocessLlava(string text, InferStateArgs args, bool addBos = true )
-        {
-            int usedTokens = 0;
-            
+        {   
             // If the prompt contains the tag <image> extract this.
             _imageInPrompt = text.Contains("<image>");
             if (_imageInPrompt && IsMultiModal)
@@ -182,7 +180,6 @@ namespace LLama
                 var segment2 = Context.Tokenize(postImagePrompt, false, true);
                 _embed_inps.AddRange(segment1);
                 _embed_inps.AddRange(segment2);
-                usedTokens += (segment1.Length + segment2.Length);
             }
             else
             {

--- a/LLama/LLamaTransforms.cs
+++ b/LLama/LLamaTransforms.cs
@@ -30,11 +30,13 @@ namespace LLama
             private readonly string _unknownName;
             private readonly bool _isInstructMode;
 
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
             public string UserName => _userName;
             public string AssistantName => _assistantName;
             public string SystemName => _systemName;
             public string UnknownName => _unknownName;
             public bool IsInstructMode => _isInstructMode;
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
             /// <summary>
             /// 

--- a/LLama/Native/LLamaAttentionType.cs
+++ b/LLama/Native/LLamaAttentionType.cs
@@ -6,9 +6,18 @@ namespace LLama.Native;
 /// <remarks>llama_attention_type</remarks>
 public enum LLamaAttentionType
 {
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+    /// <summary>
+    /// Unspecified attention type. The library will attempt to find the best fit
+    /// </summary>
     Unspecified = -1,
+
+    /// <summary>
+    /// The causal mask will be applied, causing tokens to only see previous tokens in the same sequence, and not future ones
+    /// </summary>
     Causal = 0,
+
+    /// <summary>
+    /// The causal mask will not be applied, and tokens of the same sequence will be able to see each other
+    /// </summary>
     NonCausal = 1,
-#pragma warning restore CS1591  // Missing XML comment for publicly visible type or member
 }

--- a/LLama/Native/LLamaAttentionType.cs
+++ b/LLama/Native/LLamaAttentionType.cs
@@ -6,7 +6,9 @@ namespace LLama.Native;
 /// <remarks>llama_attention_type</remarks>
 public enum LLamaAttentionType
 {
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     Unspecified = -1,
     Causal = 0,
     NonCausal = 1,
+#pragma warning restore CS1591  // Missing XML comment for publicly visible type or member
 }

--- a/LLama/Native/LLamaPoolingType.cs
+++ b/LLama/Native/LLamaPoolingType.cs
@@ -28,6 +28,9 @@ public enum LLamaPoolingType
     /// </summary>
     CLS = 2,
 
+    /// <summary>
+    /// Return the embeddings of the last token
+    /// </summary>
     Last = 3,
 
     /// <summary>

--- a/LLama/Native/LLamaRopeType.cs
+++ b/LLama/Native/LLamaRopeType.cs
@@ -1,4 +1,5 @@
 namespace LLama.Native;
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
 /// <summary>
 /// 

--- a/LLama/Native/LLamaTokenAttr.cs
+++ b/LLama/Native/LLamaTokenAttr.cs
@@ -1,6 +1,7 @@
 using System;
 
 namespace LLama.Native;
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
 /// <summary>
 /// Token attributes

--- a/LLama/Native/LLavaImageEmbed.cs
+++ b/LLama/Native/LLavaImageEmbed.cs
@@ -7,6 +7,13 @@ namespace LLama.Native;
 [StructLayout(LayoutKind.Sequential)]
 public unsafe struct LLavaImageEmbed
 {
+    /// <summary>
+    /// The embeddings of the embedded image. Should be a float[]
+    /// </summary>
     public float* embed;
+
+    /// <summary>
+    /// 
+    /// </summary>
     public int n_image_pos;
 }

--- a/LLama/Native/LLavaImageEmbed.cs
+++ b/LLama/Native/LLavaImageEmbed.cs
@@ -8,7 +8,7 @@ namespace LLama.Native;
 public unsafe struct LLavaImageEmbed
 {
     /// <summary>
-    /// The embeddings of the embedded image. Should be a float[]
+    /// The embeddings of the embedded image.
     /// </summary>
     public float* embed;
 

--- a/LLama/Native/LLavaImageEmbed.cs
+++ b/LLama/Native/LLavaImageEmbed.cs
@@ -13,7 +13,7 @@ public unsafe struct LLavaImageEmbed
     public float* embed;
 
     /// <summary>
-    /// 
+    /// The position of the image's tokens.
     /// </summary>
     public int n_image_pos;
 }

--- a/LLama/Native/Load/NativeLibraryConfig.cs
+++ b/LLama/Native/Load/NativeLibraryConfig.cs
@@ -245,6 +245,7 @@ namespace LLama.Native
         /// <param name="AllowFallback"></param>
         /// <param name="SkipCheck"></param>
         /// <param name="SearchDirectories"></param>
+        /// <param name="UseVulkan"></param>
         public record Description(string? Path, NativeLibraryName Library, bool UseCuda, bool UseVulkan, AvxLevel AvxLevel, bool AllowFallback, bool SkipCheck, 
             string[] SearchDirectories)
         {
@@ -276,6 +277,9 @@ namespace LLama.Native
     }
 #endif
 
+    /// <summary>
+    /// Global configuration handle for the Native (cpp) library.
+    /// </summary>
     public sealed partial class NativeLibraryConfig
     {
         /// <summary>

--- a/LLama/Native/Load/NativeLibraryConfig.cs
+++ b/LLama/Native/Load/NativeLibraryConfig.cs
@@ -376,7 +376,7 @@ namespace LLama.Native
         /// <returns>Whether the running is successful.</returns>
         public bool DryRun(out INativeLibrary? loadedLibrary)
         {
-            LogCallback?.Invoke(LLamaLogLevel.Debug, $"Beginning dry run for {this.NativeLibraryName.GetLibraryName()}...");
+            LogCallback?.Invoke(LLamaLogLevel.Debug, $"Beginning dry run for {NativeLibraryName.GetLibraryName()}...");
             return NativeLibraryUtils.TryLoadLibrary(this, out loadedLibrary) != IntPtr.Zero;
         }
     }

--- a/LLama/Native/Load/NativeLibraryMetadata.cs
+++ b/LLama/Native/Load/NativeLibraryMetadata.cs
@@ -10,6 +10,7 @@ namespace LLama.Native
     /// <param name="AvxLevel">Which AvxLevel it's compiled with.</param>
     public record class NativeLibraryMetadata(NativeLibraryName NativeLibraryName, bool UseCuda, bool UseVulkan, AvxLevel AvxLevel)
     {
+        /// <inheritdoc/>
         public override string ToString()
         {
             return $"(NativeLibraryName: {NativeLibraryName}, UseCuda: {UseCuda}, UseVulkan: {UseVulkan}, AvxLevel: {AvxLevel})";

--- a/LLama/Native/NativeApi.LLava.cs
+++ b/LLama/Native/NativeApi.LLava.cs
@@ -53,6 +53,8 @@ public static partial class NativeApi
     /// </summary>
     /// <param name="ctx_llama">Llama Context</param>
     /// <param name="embed">Embedding handle</param>
+    /// <param name="n_batch"></param>
+    /// <param name="n_past"></param>
     /// <returns>True on success</returns>
     [DllImport(llavaLibraryName, EntryPoint = "llava_eval_image_embed", CallingConvention = CallingConvention.Cdecl)]
     [return: MarshalAs(UnmanagedType.U1)]

--- a/LLama/Native/NativeApi.cs
+++ b/LLama/Native/NativeApi.cs
@@ -7,7 +7,7 @@ namespace LLama.Native
     /// <summary>
     /// Direct translation of the llama.cpp API
     /// </summary>
-	public static partial class NativeApi
+    public static partial class NativeApi
     {
         /// <summary>
         /// A method that does nothing. This is a native method, calling it will force the llama native dependencies to be loaded.
@@ -17,6 +17,13 @@ namespace LLama.Native
         {
             llama_max_devices();
         }
+
+#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
+        /// <summary>
+        /// Call once at the end of the program - currently only used for MPI
+        /// </summary>
+        public static extern void llama_backend_free();
+#pragma warning restore CS0626 // Method, operator, or accessor is marked external and has no attributes on it
 
         /// <summary>
         /// Get the maximum number of devices supported by llama.cpp

--- a/LLama/Native/NativeApi.cs
+++ b/LLama/Native/NativeApi.cs
@@ -19,11 +19,6 @@ namespace LLama.Native
         }
 
         /// <summary>
-        /// Call once at the end of the program - currently only used for MPI
-        /// </summary>
-        public static extern void llama_backend_free();
-
-        /// <summary>
         /// Get the maximum number of devices supported by llama.cpp
         /// </summary>
         /// <returns></returns>
@@ -104,9 +99,15 @@ namespace LLama.Native
         [return: MarshalAs(UnmanagedType.U1)]
         public static extern bool llama_state_save_file(SafeLLamaContextHandle ctx, string path_session, LLamaToken[] tokens, ulong n_token_count);
 
+        /// <summary>
+        /// Saves the specified sequence as a file on specified filepath. Can later be loaded via <see cref="llama_state_load_file(SafeLLamaContextHandle, string, LLamaToken[], ulong, out ulong)"/>
+        /// </summary>
         [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern unsafe nuint llama_state_seq_save_file(SafeLLamaContextHandle ctx, string filepath, LLamaSeqId seq_id, LLamaToken* tokens, nuint n_token_count);
 
+        /// <summary>
+        /// Loads a sequence saved as a file via <see cref="llama_state_save_file(SafeLLamaContextHandle, string, LLamaToken[], ulong)"/> into the specified sequence
+        /// </summary>
         [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern unsafe nuint llama_state_seq_load_file(SafeLLamaContextHandle ctx, string filepath, LLamaSeqId dest_seq_id, LLamaToken* tokens_out, nuint n_token_capacity, out nuint n_token_count_out);
 


### PR DESCRIPTION
LLamaSharp had [a lot of warnings that appear on each PR](https://github.com/SciSharp/LLamaSharp/pull/1110/files#file-llama-llamainteractexecutor-cs-L102), and bloat the error list.
Some of them are valid, but most of them are just nullables stuff, or missing documentations.
This PR takes care of the non-important warnings, bumping the visibility of current and future important ones.

For reference, here is how it looks on current master:
![image](https://github.com/user-attachments/assets/fd1d781c-f4e5-490a-81f0-3e797ba40683)

And here are the warnings that remain after this PR -- only obsolete warnings and warnings about await:
![image](https://github.com/user-attachments/assets/617021b1-0cf8-4de8-a54d-73c733af1cc9)

