### PR TITLE
Various fixes regarding special tokens (embeddings & anti-prompt)

### DIFF
--- a/LLama.Examples/Examples/BatchedExecutorBoolQ.cs
+++ b/LLama.Examples/Examples/BatchedExecutorBoolQ.cs
@@ -178,7 +178,7 @@ public class BatchedExecutorBoolQ
 
             // Prompt
             _conversation = executor.Create();
-            _conversation.Prompt(_executor.Context.Tokenize(templatedQuestion));
+            _conversation.Prompt(_executor.Context.Tokenize(templatedQuestion, special: true));
 
             Question = question;
             Answer = answer;

--- a/LLama/LLamaEmbedder.cs
+++ b/LLama/LLamaEmbedder.cs
@@ -64,7 +64,7 @@ public sealed partial class LLamaEmbedder
     private async Task<(IReadOnlyList<float[]> Embeddings, int Tokens)> GetEmbeddingsWithTokenCount(string input, CancellationToken cancellationToken = default)
     {
         // Add all of the tokens to the batch
-        var tokens = Context.Tokenize(input);
+        var tokens = Context.Tokenize(input, special: true);
         var batch = new LLamaBatch();
         for (var i = 0; i < tokens.Length; i++)
             batch.Add(tokens[i], i, LLamaSeqId.Zero, true);

--- a/LLama/LLamaInteractExecutor.cs
+++ b/LLama/LLamaInteractExecutor.cs
@@ -315,7 +315,7 @@ namespace LLama
                     id = Context.NativeHandle.ModelHandle.Vocab.Newline!.Value;
                     if (args.Antiprompts is not null && args.Antiprompts.Count > 0)
                     {
-                        var first_antiprompt = Context.Tokenize(args.Antiprompts[0], false);
+                        var first_antiprompt = Context.Tokenize(args.Antiprompts[0], false, true);
                         _embed_inps.AddRange(first_antiprompt);
                     }
                 }


### PR DESCRIPTION
Fixed some issues with the following:
- Fixed special tokens parsing as plain text in LLamaEmbedder

- Fixed anti-prompt passing as plain text in InteractiveExecutor
- BatchedExecutorBoolQ example now tokenizes special tokens

I wonder if at this point it's worth making the default `Tokenize()` parameter be `special = true` instead,
.. because every single one of the library's calls seems to be needing this to be set as `true`:
![image](https://github.com/user-attachments/assets/b4331d47-eaca-400c-b704-4cb4bfb240f8)

Although if you think it's safest for users if accidental special are parsed as plain text I can understand that too.