### PR TITLE
Added 'strict' parameter for template retrieval

### DIFF
--- a/LLama/Exceptions/RuntimeError.cs
+++ b/LLama/Exceptions/RuntimeError.cs
@@ -78,6 +78,21 @@ public class MissingTemplateException
 }
 
 /// <summary>
+/// `llama_decode` return a non-zero status code
+/// </summary>
+public class TemplateNotFoundException
+    : RuntimeError
+{
+    /// <inheritdoc />
+    public TemplateNotFoundException(string name)
+        : base($"llama_model_chat_template failed: Tried to retrieve template '{name}' but it couldn't be found.\n" +
+                                            $"This might mean that the model was exported incorrectly, or that this is a base model that contains no templates.\n" +
+                                            $"This exception can be disabled by passing 'strict=false' as a parameter when retrieving the template.")
+    {
+    } 
+}
+
+/// <summary>
 /// `llama_get_logits_ith` returned null, indicating that the index was invalid
 /// </summary>
 public class GetLogitsInvalidIndexException

--- a/LLama/LLamaTemplate.cs
+++ b/LLama/LLamaTemplate.cs
@@ -105,19 +105,21 @@ public sealed class LLamaTemplate
     /// <summary>
     /// Construct a new template, using the default model template
     /// </summary>
-    /// <param name="model"></param>
-    /// <param name="name"></param>
-    public LLamaTemplate(SafeLlamaModelHandle model, string? name = null)
-        : this(model.GetTemplate(name))
+    /// <param name="model">The native handle of the loaded model.</param>
+    /// <param name="name">The name of the template, in case there are many or differently named. Set to 'null' for the default behaviour of finding an appropriate match.</param>
+    /// <param name="strict">Setting this to true will cause the call to throw if no valid templates are found.</param>
+    public LLamaTemplate(SafeLlamaModelHandle model, string? name = null, bool strict = true)
+        : this(model.GetTemplate(name, strict))
     {
     }
 
     /// <summary>
     /// Construct a new template, using the default model template
     /// </summary>
-    /// <param name="weights"></param>
-    public LLamaTemplate(LLamaWeights weights)
-        : this(weights.NativeHandle)
+    /// <param name="weights">The handle of the loaded model's weights.</param>
+    /// <param name="strict">Setting this to true will cause the call to throw if no valid templates are found.</param>
+    public LLamaTemplate(LLamaWeights weights, bool strict = true)
+        : this(weights.NativeHandle, strict: strict)
     {
     }
 

--- a/LLama/Native/SafeLlamaModelHandle.cs
+++ b/LLama/Native/SafeLlamaModelHandle.cs
@@ -603,15 +603,24 @@ namespace LLama.Native
         /// Get the default chat template. Returns nullptr if not available
         /// If name is NULL, returns the default chat template
         /// </summary>
-        /// <param name="name"></param>
+        /// <param name="name">The name of the template, in case there are many or differently named. Set to 'null' for the default behaviour of finding an appropriate match.</param>
+        /// <param name="strict">Setting this to true will cause the call to throw if no valid templates are found.</param>
         /// <returns></returns>
-        public string? GetTemplate(string? name = null)
+        public string? GetTemplate(string? name = null, bool strict = true)
         {
             unsafe
             {
                 var bytesPtr = llama_model_chat_template(this, name);
                 if (bytesPtr == null)
-                    return null;
+                {
+                    if (strict)
+                        throw new Exception($"Tried to retrieve template for '{name}' but no templates were found.\n" +
+                                            $"This might mean that the model was exported incorrectly, or that this is a base model that contains no template.\n" +
+                                            $"This exception can be disabled by passing 'strict=false' as a parameter when retrieving the template.");
+                    else
+                        return null;
+
+                }
 
                 // Find null terminator
                 var spanBytes = new Span<byte>(bytesPtr, int.MaxValue);

--- a/LLama/Native/SafeLlamaModelHandle.cs
+++ b/LLama/Native/SafeLlamaModelHandle.cs
@@ -614,9 +614,7 @@ namespace LLama.Native
                 if (bytesPtr == null)
                 {
                     if (strict)
-                        throw new Exception($"Tried to retrieve template for '{name}' but no templates were found.\n" +
-                                            $"This might mean that the model was exported incorrectly, or that this is a base model that contains no template.\n" +
-                                            $"This exception can be disabled by passing 'strict=false' as a parameter when retrieving the template.");
+                        throw new TemplateNotFoundException(name ?? "default template");
                     else
                         return null;
 


### PR DESCRIPTION
This PR adds an additional check to the `LLamaTemplate` constructor and `Model.GetTemplate()`, causing it to throw an exception if a valid template was expected to be returned (`strict = true`) but could not be found.

This aims to avoid accidental confusion for users that try to use LLamaSharp's auto-template-formatting functionalities with a model whose template is either not supported or not found (e.g. base model vs instruct model).

The default behaviour can be disabled by passing `strict = false` when calling to retrieve the template.