### PR TITLE
Adding extra values to the decode_result enum

### DIFF
--- a/LLama/Native/DecodeResult.cs
+++ b/LLama/Native/DecodeResult.cs
@@ -19,4 +19,19 @@ public enum DecodeResult
     /// Could not find a KV slot for the batch (try reducing the size of the batch or increase the context)
     /// </summary>
     NoKvSlot = 1,
+
+    /// <summary>
+    /// Compute was aborted (e.g. due to callback request or timeout)
+    /// </summary>
+    ComputeAborted = 2,
+
+    /// <summary>
+    /// Failed to allocate memory or reserve output space
+    /// </summary>
+    AllocationFailed = -2,
+
+    /// <summary>
+    /// General failure during decode (e.g. internal error, slot failure)
+    /// </summary>
+    DecodeFailed = -3,
 }


### PR DESCRIPTION
I started getting -3 values when doing batch operations upon calling `Infer` on the batched executor. I was checking for NoKvSlot, but it turns out `-3` aligns to "failed to prepare ubatch" when calling `find_slot`. I believe these values first appeared with this [commit](https://github.com/ggml-org/llama.cpp/commit/e0dbec0bc6cd4b6230cda7a6ed1e9dac08d1600b) two weeks ago, but that's with, admittedly, limited research.

I'd like a better enum value, but unfortunately, they also are using -3 for `GGML_STATUS_FAILED` results when calling `graph_compute`, so the value has a double meaning. So, I'm definitely open to other names for the value than what I have here, but at a loss at what they could be.