### PR TITLE
Fixed LLama.Web error starting session

### DIFF
--- a/LLama.Web/Common/InferenceOptions.cs
+++ b/LLama.Web/Common/InferenceOptions.cs
@@ -20,6 +20,6 @@ namespace LLama.Web.Common
         public IReadOnlyList<string> AntiPrompts { get; set; } = Array.Empty<string>();
 
         /// <inheritdoc />
-        public required ISamplingPipeline SamplingPipeline { get; set; }
+        public ISamplingPipeline SamplingPipeline { get; set; } = new DefaultSamplingPipeline();
     }
 }

--- a/LLama.Web/appsettings.Development.json
+++ b/LLama.Web/appsettings.Development.json
@@ -3,7 +3,9 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.AspNetCore.SignalR": "Debug",
+      "Microsoft.AspNetCore.Http.Connections": "Debug"
     }
   }
 }

--- a/LLama.Web/appsettings.json
+++ b/LLama.Web/appsettings.json
@@ -10,13 +10,13 @@
     "ModelLoadType": 0,
     "Models": [
       {
-        "Name": "Example LLama2-7b-Chat",
+        "Name": "Example LLava-v1.6-mistral",
         "MaxInstances": 20,
-        "ModelPath": "..\\LLama.Unittest\\Models\\llama-2-7b-chat.Q4_0.gguf",
+        "ModelPath": "..\\LLama.Unittest\\Models\\llava-v1.6-mistral-7b.Q3_K_XS.gguf",
         "ContextSize": 2048,
         "BatchSize": 2048,
         "Threads": 4,
-        "GpuLayerCount": 6,
+        "GpuLayerCount": 32,
         "UseMemorymap": true,
         "UseMemoryLock": false,
         "MainGpu": 0,


### PR DESCRIPTION
This should fix #1080

InferenceOptions.SamplingPipeline now is not required. Is not sent from client. This was the main issue for #1080
Added options to debug SignalR calls at appsettings.Development.json. If you dont have this enabled, SignalR serialization errors are not logged (even with Warning level)
Changed default web model to llava-v1.6-mistral-7b.Q3_K_XS.gguf, previous one (llama-2-7b-chat.Q4_0.gguf) did no exist

