### PR TITLE
Create stale_issues.yml

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -1,0 +1,20 @@
+name: Close stale issues
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue has been automatically marked as stale due to inactivity. If no further activity occurs, it will be closed in 7 days.'
+          stale-pr-message: 'This pull request has been automatically marked as stale due to inactivity. If no further activity occurs, it will be closed in 7 days.'
+          days-before-stale: 60
+          days-before-close: 7
+          stale-issue-label: 'stale'
+          exempt-issue-labels: 'do not close'
+          operations-per-run: 30


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically manage stale issues and pull requests in the repository.

Automation of stale issue management:

* [`.github/workflows/stale_issues.yml`](diffhunk://#diff-4ec584088ec00526a0b7adc6f1e8aefb1f8640ac0c40f8470426390c66857e69R1-R20): Added a workflow named "Close stale issues" that uses the `actions/stale` GitHub Action to mark issues and pull requests as stale after 60 days of inactivity and close them 7 days later. Exemptions are provided for issues labeled with "do not close."