### PR TITLE
Conversation `-1` instead of `_end`

### DIFF
--- a/LLama/Batched/Conversation.cs
+++ b/LLama/Batched/Conversation.cs
@@ -410,7 +410,7 @@ public sealed class Conversation
         }
 
         /// <summary>
-        /// Removes all tokens starting from the given position
+        /// Removes <see cref="count"/> tokens starting from <see cref="start"/>
         /// </summary>
         /// <param name="start">Start position (inclusive)</param>
         /// <param name="count">Number of tokens</param>
@@ -419,7 +419,8 @@ public sealed class Conversation
             if (count <= 0)
                 return;
 
-            _conversation.Executor.Context.NativeHandle.KvCacheRemove(_conversation.ConversationId, start, -1);
+            var end = start.Value + count;
+            _conversation.Executor.Context.NativeHandle.KvCacheRemove(_conversation.ConversationId, start, end);
         }
         #endregion
 

--- a/LLama/Batched/Conversation.cs
+++ b/LLama/Batched/Conversation.cs
@@ -84,7 +84,7 @@ public sealed class Conversation
         _disposed = true;
 
         // Remove this conversation from the KV cache
-        Executor.Context.NativeHandle.KvCacheRemove(ConversationId, 0, _end);
+        Executor.Context.NativeHandle.KvCacheRemove(ConversationId, -1, -1);
 
         // Prevent finalizer from running
         GC.SuppressFinalize(this);
@@ -419,8 +419,7 @@ public sealed class Conversation
             if (count <= 0)
                 return;
 
-            var end = start.Value + count;
-            _conversation.Executor.Context.NativeHandle.KvCacheRemove(_conversation.ConversationId, start, end);
+            _conversation.Executor.Context.NativeHandle.KvCacheRemove(_conversation.ConversationId, start, -1);
         }
         #endregion
 


### PR DESCRIPTION
Using `-1` for start/end positions in `Conversation`. This eliminates the possibility of KV cache leaks due to bugs with `_end` getting out of sync.