### PR TITLE
Expose `DecodeSpecialTokens` through `IInferenceParams` for `StatelessExecutor`

### DIFF
--- a/LLama.Web/Common/InferenceOptions.cs
+++ b/LLama.Web/Common/InferenceOptions.cs
@@ -21,5 +21,8 @@ namespace LLama.Web.Common
 
         /// <inheritdoc />
         public ISamplingPipeline SamplingPipeline { get; set; } = new DefaultSamplingPipeline();
+
+        /// <inheritdoc />
+        public bool DecodeSpecialTokens { get; set; }
     }
 }

--- a/LLama/Abstractions/IInferenceParams.cs
+++ b/LLama/Abstractions/IInferenceParams.cs
@@ -28,5 +28,13 @@ namespace LLama.Abstractions
 		/// Set a custom sampling pipeline to use.
 		/// </summary>
 		ISamplingPipeline SamplingPipeline { get; set; }
+
+		/// <summary>
+		/// If true, special characters will be converted to text. If false they will be invisible.
+		/// </summary>
+		/// <remark>
+		/// Controls the behavior of decoders like <see cref="StreamingTokenDecoder" />
+		/// </remark>
+		public bool DecodeSpecialTokens { get; set; }
 	}
 }

--- a/LLama/Common/InferenceParams.cs
+++ b/LLama/Common/InferenceParams.cs
@@ -30,6 +30,9 @@ namespace LLama.Common
 
         /// <inheritdoc />
         public ISamplingPipeline SamplingPipeline { get; set; } = new DefaultSamplingPipeline();
+
+        /// <inheritdoc />
+        public bool DecodeSpecialTokens { get; set; }
     }
 
     /// <summary>

--- a/LLama/LLamaStatelessExecutor.cs
+++ b/LLama/LLamaStatelessExecutor.cs
@@ -88,7 +88,10 @@ namespace LLama
                 throw new ArgumentOutOfRangeException(nameof(inferenceParams), $"TokensKeep ({inferenceParams.TokensKeep}) cannot be larger than ContextSize ({Context.ContextSize})");
 
             // Create decoders for the token stream
-            var decoder = new StreamingTokenDecoder(Context);
+            var decoder = new StreamingTokenDecoder(Context)
+            {
+                DecodeSpecialTokens = inferenceParams.DecodeSpecialTokens,
+            };
             var antiprocessor = new AntipromptProcessor(inferenceParams.AntiPrompts);
 
             if (ApplyTemplate)


### PR DESCRIPTION
Add `DecodeSpecialTokens` property to `IInferenceParams` - implement it where applicable. Use the new property in `StatelessExecutor`.

As far as I can tell, this meant changing
* `InferenceParams` (Llama) 
* `InferenceOptions` (LLama.Web)

The only executor that was using the `StreamingTokenDecoder` class is `StatelessExecutor` - I suspect that means that `Context.Decode` is not susceptible to this issue, although I've not tried that since I don't have a non-stateless use case (yet).

Fixes SciSharp/LLamaSharp#1201