### PR TITLE
Fix Typo in Documentation: "stucture" to "structure" in NativeLibraryConfig

### DIFF
--- a/docs/xmldocs/llama.native.nativelibraryconfig.md
+++ b/docs/xmldocs/llama.native.nativelibraryconfig.md
@@ -195,7 +195,7 @@ Thrown if `LibraryHasLoaded` is true.
 
 ### **WithSearchDirectories(IEnumerable&lt;String&gt;)**
 
-Add self-defined search directories. Note that the file stucture of the added 
+Add self-defined search directories. Note that the file structure of the added 
  directories must be the same as the default directory. Besides, the directory 
  won't be used recursively.
 
@@ -213,7 +213,7 @@ public NativeLibraryConfig WithSearchDirectories(IEnumerable<string> directories
 
 ### **WithSearchDirectory(String)**
 
-Add self-defined search directories. Note that the file stucture of the added 
+Add self-defined search directories. Note that the file structure of the added 
  directories must be the same as the default directory. Besides, the directory 
  won't be used recursively.
 


### PR DESCRIPTION


Description:  
This pull request corrects a typographical error in the documentation for NativeLibraryConfig. The word "stucture" has been replaced with the correct spelling "structure" in the descriptions for the WithSearchDirectories and WithSearchDirectory methods. No functional code changes were made; this update is documentation-only to improve clarity and professionalism.