### PR TITLE
Fix Typos in Documentation and Comments

### DIFF
--- a/LLama.Web/wwwroot/lib/jquery-validation/dist/additional-methods.js
+++ b/LLama.Web/wwwroot/lib/jquery-validation/dist/additional-methods.js
@@ -257,7 +257,7 @@ $.validator.addMethod( "cifES", function( value, element ) {
 }, "Please specify a valid CIF number." );
 
 /*
- * Brazillian CPF number (Cadastrado de Pessoas Físicas) is the equivalent of a Brazilian tax registration number.
+ * Brazilian CPF number (Cadastrado de Pessoas Físicas) is the equivalent of a Brazilian tax registration number.
  * CPF numbers have 11 digits in total: 9 numbers followed by 2 check numbers that are being used for validation.
  */
 $.validator.addMethod( "cpfBR", function( value ) {

--- a/docs/xmldocs/llama.extensions.icontextparamsextensions.md
+++ b/docs/xmldocs/llama.extensions.icontextparamsextensions.md
@@ -2,7 +2,7 @@
 
 Namespace: LLama.Extensions
 
-Extention methods to the IContextParams interface
+Extension methods to the IContextParams interface
 
 ```csharp
 public static class IContextParamsExtensions


### PR DESCRIPTION


Description:  
This pull request corrects minor typos in the codebase:
- Updates the spelling of "Brazilian" in a comment within additional-methods.js.
- Fixes the word "Extention" to "Extension" in the documentation for IContextParamsExtensions.

These changes improve clarity and maintain consistency in the documentation and code comments. No functional code changes are included.