### PR TITLE
Optimization - A queue with fixed storage size backed by a circular buffer

### DIFF
--- a/LLama.Benchmark/Collections/FixedSizeQueueBenchmark.cs
+++ b/LLama.Benchmark/Collections/FixedSizeQueueBenchmark.cs
@@ -1,0 +1,46 @@
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Jobs;
+using LLama.Common;
+
+namespace LLama.Benchmark.Collections;
+
+[SimpleJob(RunStrategy.Throughput, RuntimeMoniker.Net80)]
+[MemoryDiagnoser]
+[BenchmarkCategory("Collections", "FixedSizeQueue")]
+public class FixedSizeQueueBenchmark
+{
+    [Params(32, 512, 4096)]
+    public int Capacity { get; set; }
+
+    private int[] _values = Array.Empty<int>();
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _values = Enumerable.Range(0, Capacity * 4).ToArray();
+    }
+
+    [Benchmark]
+    public int EnqueueWrap()
+    {
+        var queue = new FixedSizeQueue<int>(Capacity);
+        foreach (var value in _values)
+            queue.Enqueue(value);
+        return queue.Count;
+    }
+
+    [Benchmark]
+    public int IterateTailSum()
+    {
+        var queue = new FixedSizeQueue<int>(Capacity);
+        foreach (var value in _values)
+            queue.Enqueue(value);
+
+        var sum = 0;
+        foreach (var value in queue)
+            sum += value;
+        return sum;
+    }
+}

--- a/LLama/AntipromptProcessor.cs
+++ b/LLama/AntipromptProcessor.cs
@@ -11,7 +11,7 @@ namespace LLama
         private int _longestAntiprompt;
         private readonly List<string> _antiprompts = new();
 
-        private string? _string;
+        private string _buffer = string.Empty;
 
 
         /// <summary>
@@ -46,6 +46,8 @@ namespace LLama
             _longestAntiprompt = 0;
             foreach (var antiprompt in _antiprompts)
                 _longestAntiprompt = Math.Max(_longestAntiprompt, antiprompt.Length);
+
+            _buffer = string.Empty;
         }
 
         /// <summary>
@@ -55,18 +57,18 @@ namespace LLama
         /// <returns>true if the text buffer ends with any antiprompt</returns>
         public bool Add(string text)
         {
-            _string += text;
+            _buffer += text;
 
             // When the string gets very long (4x antiprompt length) trim it down (to 2x antiprompt length).
             // This trimming leaves a lot of extra characters because two sequences can be considered "equal" in unicode
             // even with different numbers of characters. Hopefully there are enough characters here to handle all those weird circumstances!
             var maxLength = Math.Max(32, _longestAntiprompt * 4);
             var trimLength = Math.Max(16, _longestAntiprompt * 2);
-            if (_string.Length > maxLength)
-                _string = _string.Substring(_string.Length - trimLength);
+            if (_buffer.Length > maxLength)
+                _buffer = _buffer.Substring(_buffer.Length - trimLength);
 
             foreach (var antiprompt in _antiprompts)
-                if (_string.EndsWith(antiprompt, StringComparison.CurrentCulture))
+                if (_buffer.EndsWith(antiprompt, StringComparison.CurrentCulture))
                     return true;
 
             return false;

--- a/LLama/Batched/BatchedExecutor.cs
+++ b/LLama/Batched/BatchedExecutor.cs
@@ -19,6 +19,7 @@ public sealed class BatchedExecutor
     private int _batchQueueHead;
     private int _batchedTokenCount;
     private bool _batchedTokenCountDirty = true;
+    private const int CleanupThreshold = 16;
     
     /// <summary>
     /// Set to 1 using interlocked exchange while inference is running
@@ -216,7 +217,7 @@ public sealed class BatchedExecutor
                 return;
             }
 
-            if (_batchQueueHead > 16 && _batchQueueHead > _batchQueue.Count / 2)
+            if (_batchQueueHead > CleanupThreshold && _batchQueueHead > _batchQueue.Count / 2)
             {
                 _batchQueue.RemoveRange(0, _batchQueueHead);
                 _batchQueueHead = 0;

--- a/LLama/Batched/BatchedExecutor.cs
+++ b/LLama/Batched/BatchedExecutor.cs
@@ -19,6 +19,7 @@ public sealed class BatchedExecutor
     private int _batchQueueHead;
     private int _batchedTokenCount;
     private bool _batchedTokenCountDirty = true;
+    // Skip compacting the queue until this many processed batches accumulate at the front.
     private const int CleanupThreshold = 16;
     
     /// <summary>
@@ -205,6 +206,7 @@ public sealed class BatchedExecutor
             _batchedTokenCountDirty = true;
         }
 
+        // Remove batches that have already been consumed so the head index does not grow without bound.
         void CleanupQueue()
         {
             if (_batchQueueHead == 0)

--- a/LLama/Batched/BatchedExecutor.cs
+++ b/LLama/Batched/BatchedExecutor.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using LLama.Abstractions;
@@ -16,7 +15,10 @@ public sealed class BatchedExecutor
     : IDisposable
 {
     private int _nextSequenceId;
-    private readonly List<IBatch> _batchQueue = [ ];
+    private readonly List<IBatch> _batchQueue = [];
+    private int _batchQueueHead;
+    private int _batchedTokenCount;
+    private bool _batchedTokenCountDirty = true;
     
     /// <summary>
     /// Set to 1 using interlocked exchange while inference is running
@@ -42,12 +44,27 @@ public sealed class BatchedExecutor
     /// <summary>
     /// Get the number of tokens in the batch, waiting for <see cref="Infer"/> to be called
     /// </summary>
-    public int BatchedTokenCount => _batchQueue.Sum(a => a.ItemCount);
+    public int BatchedTokenCount
+    {
+        get
+        {
+            if (_batchedTokenCountDirty)
+            {
+                var total = 0;
+                for (var i = _batchQueueHead; i < _batchQueue.Count; i++)
+                    total += _batchQueue[i].ItemCount;
+                _batchedTokenCount = total;
+                _batchedTokenCountDirty = false;
+            }
+
+            return _batchedTokenCount;
+        }
+    }
 
     /// <summary>
     /// Number of batches in the queue, waiting for <see cref="Infer"/> to be called
     /// </summary>
-    public int BatchQueueCount => _batchQueue.Count;
+    public int BatchQueueCount => _batchQueue.Count - _batchQueueHead;
 
     /// <summary>
     /// Check if this executor has been disposed.
@@ -147,12 +164,13 @@ public sealed class BatchedExecutor
             // again after the issue has been fixed (e.g. some KV cache space has been freed) to retry this operation.
             if (status != DecodeResult.Ok)
             {
-                _batchQueue.Insert(0, next);
+                RequeueFront(next);
                 return status;
             }
             
             // Everything was ok, advance the epoch
             Epoch++;
+            CleanupQueue();
             
             return status;
         }
@@ -166,12 +184,43 @@ public sealed class BatchedExecutor
         
         IBatch? GetNextBatch()
         {
-            if (_batchQueue.Count == 0)
+            if (_batchQueueHead >= _batchQueue.Count)
+            {
+                _batchQueue.Clear();
+                _batchQueueHead = 0;
                 return null;
-            
-            var nextBatch = _batchQueue[0];
-            _batchQueue.RemoveAt(0);
+            }
+
+            var nextBatch = _batchQueue[_batchQueueHead];
+            _batchQueueHead++;
+            _batchedTokenCountDirty = true;
             return nextBatch;
+        }
+
+        void RequeueFront(IBatch batch)
+        {
+            Debug.Assert(_batchQueueHead > 0, "Cannot requeue batch when queue head is at zero.");
+            _batchQueue[--_batchQueueHead] = batch;
+            _batchedTokenCountDirty = true;
+        }
+
+        void CleanupQueue()
+        {
+            if (_batchQueueHead == 0)
+                return;
+
+            if (_batchQueueHead >= _batchQueue.Count)
+            {
+                _batchQueue.Clear();
+                _batchQueueHead = 0;
+                return;
+            }
+
+            if (_batchQueueHead > 16 && _batchQueueHead > _batchQueue.Count / 2)
+            {
+                _batchQueue.RemoveRange(0, _batchQueueHead);
+                _batchQueueHead = 0;
+            }
         }
     }
 
@@ -202,7 +251,7 @@ public sealed class BatchedExecutor
             throw new ArgumentOutOfRangeException(nameof(minCapacity), $"Request batch capacity must be less than or equal to BatchSize ({Context.BatchSize})");
 
         // Find a batch with space for at least minCapacity tokens
-        for (var i = 0; i < _batchQueue.Count; i++)
+        for (var i = _batchQueueHead; i < _batchQueue.Count; i++)
         {
             var item = _batchQueue[i];
             if (item is not TokenBatch { Batch: var batch })
@@ -213,13 +262,17 @@ public sealed class BatchedExecutor
                 continue;
 
             if (batch.TokenCount < Context.BatchSize)
-                return (batch, Epoch + (uint)(i + 1) * 2);
+            {
+                _batchedTokenCountDirty = true;
+                return (batch, Epoch + (uint)(i - _batchQueueHead + 1) * 2);
+            }
         }
         
         // Add a new batch to the end of the queue
         var end = new LLamaBatch();
         _batchQueue.Add(new TokenBatch(end));
-        return (end, Epoch + (uint)_batchQueue.Count * 2);
+        _batchedTokenCountDirty = true;
+        return (end, Epoch + (uint)(_batchQueue.Count - _batchQueueHead) * 2);
     }
     
     /// <summary>
@@ -234,7 +287,7 @@ public sealed class BatchedExecutor
             throw new ArgumentOutOfRangeException(nameof(minCapacity), $"Request batch capacity must be less than or equal to BatchSize ({Context.BatchSize})");
         
         // Find a batch with space for at least minCapacity embeddings
-        for (var i = 0; i < _batchQueue.Count; i++)
+        for (var i = _batchQueueHead; i < _batchQueue.Count; i++)
         {
             var item = _batchQueue[i];
             if (item is not EmbeddingBatch { Batch: var batch })
@@ -245,13 +298,17 @@ public sealed class BatchedExecutor
                 continue;
             
             if (batch.EmbeddingsCount < Context.BatchSize)
-                return (batch, Epoch + (uint)(i + 1) * 2);
+            {
+                _batchedTokenCountDirty = true;
+                return (batch, Epoch + (uint)(i - _batchQueueHead + 1) * 2);
+            }
         }
         
         // Add a new batch to the end of the queue
         var end = new LLamaBatchEmbeddings(Context.EmbeddingSize);
         _batchQueue.Add(new EmbeddingBatch(end));
-        return (end, Epoch + (uint)_batchQueue.Count * 2);
+        _batchedTokenCountDirty = true;
+        return (end, Epoch + (uint)(_batchQueue.Count - _batchQueueHead) * 2);
     }
 
     #region batches

--- a/LLama/Common/FixedSizeQueue.cs
+++ b/LLama/Common/FixedSizeQueue.cs
@@ -16,7 +16,9 @@ namespace LLama.Common
         private int _count;
         private T[]? _window;
 
+        // Minimum capacity for the temporary buffer used to expose a contiguous view.
         private const int MinimumWindowSize = 4;
+        // Resize multiplier for the temporary buffer to reduce copy churn as it grows.
         private const int WindowGrowthFactor = 2;
 
         /// <inheritdoc />
@@ -123,6 +125,9 @@ namespace LLama.Common
             return GetEnumerator();
         }
 
+        /// <summary>
+        /// Returns up to <paramref name="count"/> of the most recent items as a contiguous span.
+        /// </summary>
         internal ReadOnlySpan<T> AsSpan(int count)
         {
             count = Math.Min(count, _count);

--- a/LLama/Common/FixedSizeQueue.cs
+++ b/LLama/Common/FixedSizeQueue.cs
@@ -6,21 +6,33 @@ using System.Linq;
 namespace LLama.Common
 {
     /// <summary>
-    /// A queue with fixed storage size.
-    /// Currently it's only a naive implementation and needs to be further optimized in the future.
+    /// A queue with fixed storage size backed by a circular buffer.
     /// </summary>
     public class FixedSizeQueue<T>
         : IReadOnlyList<T>
     {
-        private readonly List<T> _storage;
+        private readonly T[] _buffer;
+        private int _start;
+        private int _count;
+        private T[]? _window;
 
         /// <inheritdoc />
-        public T this[int index] => _storage[index];
+        public T this[int index]
+        {
+            get
+            {
+                if ((uint)index >= (uint)_count)
+                    throw new ArgumentOutOfRangeException(nameof(index));
+
+                var actualIndex = (_start + index) % Capacity;
+                return _buffer[actualIndex];
+            }
+        }
 
         /// <summary>
         /// Number of items in this queue
         /// </summary>
-        public int Count => _storage.Count;
+        public int Count => _count;
 
         /// <summary>
         /// Maximum number of items allowed in this queue
@@ -28,53 +40,61 @@ namespace LLama.Common
         public int Capacity { get; }
 
         /// <summary>
-        /// Create a new queue
+        /// Create a new queue.
         /// </summary>
-        /// <param name="size">the maximum number of items to store in this queue</param>
+        /// <param name="size">The maximum number of items to store in this queue.</param>
         public FixedSizeQueue(int size)
         {
+            if (size <= 0)
+                throw new ArgumentOutOfRangeException(nameof(size), size, "Capacity must be positive.");
+
             Capacity = size;
-            _storage = new();
+            _buffer = new T[size];
+            _start = 0;
+            _count = 0;
         }
 
         /// <summary>
-        /// Fill the quene with the data. Please ensure that data.Count &lt;= size
+        /// Fill the queue with existing data. Please ensure that data.Count &lt;= size
         /// </summary>
         /// <param name="size"></param>
         /// <param name="data"></param>
         public FixedSizeQueue(int size, IEnumerable<T> data)
+            : this(size)
         {
 #if NET6_0_OR_GREATER
-            // Try to check the size without enumerating the entire IEnumerable. This may not be able to get the count,
-            // in which case we'll have to check later
             if (data.TryGetNonEnumeratedCount(out var dataCount) && dataCount > size)
-                throw new ArgumentException($"The max size set for the quene is {size}, but got {dataCount} initial values.");
+                throw new ArgumentException($"The max size set for the queue is {size}, but got {dataCount} initial values.");
 #endif
 
-            // Size of "data" is unknown, copy it all into a list
-            Capacity = size;
-            _storage = new List<T>(data);
-
-            // Now check if that list is a valid size.
-            if (_storage.Count > Capacity)
-                throw new ArgumentException($"The max size set for the quene is {size}, but got {_storage.Count} initial values.");
+            foreach (var item in data)
+                Enqueue(item);
         }
 
         /// <summary>
-        /// Enquene an element.
+        /// Enqueue an element. When the queue is full the oldest element is overwritten.
         /// </summary>
-        /// <returns></returns>
         public void Enqueue(T item)
         {
-            _storage.Add(item);
-            if (_storage.Count > Capacity)
-                _storage.RemoveAt(0);
+            if (_count < Capacity)
+            {
+                var tail = (_start + _count) % Capacity;
+                _buffer[tail] = item;
+                _count++;
+            }
+            else
+            {
+                _buffer[_start] = item;
+                _start++;
+                if (_start == Capacity)
+                    _start = 0;
+            }
         }
 
         /// <inheritdoc />
         public IEnumerator<T> GetEnumerator()
         {
-            return _storage.GetEnumerator();
+            return Enumerate().GetEnumerator();
         }
 
         /// <inheritdoc />
@@ -85,15 +105,35 @@ namespace LLama.Common
 
         internal ReadOnlySpan<T> AsSpan(int count)
         {
-            // Ensure the request isn't for more tokens than actually exist
-            count = Math.Min(count, Count);
+            count = Math.Min(count, _count);
+            if (count == 0)
+                return ReadOnlySpan<T>.Empty;
 
-            // Take `count` items from the end
-#if NET8_0_OR_GREATER
-            return CollectionsMarshal.AsSpan(_storage)[^count..];
-#else
-            return _storage.ToArray().AsSpan(_storage.Count - count, count);
-#endif
+            var start = (_start + _count - count + Capacity) % Capacity;
+
+            if (start + count <= Capacity)
+            {
+                return new ReadOnlySpan<T>(_buffer, start, count);
+            }
+
+            _window ??= new T[Math.Min(Capacity, Math.Max(4, count))];
+            if (_window.Length < count)
+            {
+                Array.Resize(ref _window, Math.Min(Capacity, Math.Max(_window.Length * 2, count)));
+            }
+
+            var firstSegmentLength = Capacity - start;
+            Array.Copy(_buffer, start, _window, 0, firstSegmentLength);
+            Array.Copy(_buffer, 0, _window, firstSegmentLength, count - firstSegmentLength);
+            return _window.AsSpan(0, count);
+        }
+
+        private IEnumerable<T> Enumerate()
+        {
+            for (var i = 0; i < _count; i++)
+            {
+                yield return this[i];
+            }
         }
     }
 }

--- a/LLama/Common/FixedSizeQueue.cs
+++ b/LLama/Common/FixedSizeQueue.cs
@@ -46,7 +46,7 @@ namespace LLama.Common
         public FixedSizeQueue(int size)
         {
             if (size <= 0)
-                throw new ArgumentOutOfRangeException(nameof(size), size, "Capacity must be positive.");
+                throw new ArgumentOutOfRangeException(nameof(size), size, "Capacity must be greater than zero.");
 
             Capacity = size;
             _buffer = new T[size];

--- a/LLama/Common/FixedSizeQueue.cs
+++ b/LLama/Common/FixedSizeQueue.cs
@@ -60,7 +60,7 @@ namespace LLama.Common
         }
 
         /// <summary>
-        /// Fill the queue with existing data. Please ensure that data.Count <= size
+        /// Fill the queue with existing data. Please ensure that data.Count &lt;= size
         /// </summary>
         /// <param name="size"></param>
         /// <param name="data"></param>

--- a/LLama/Common/FixedSizeQueue.cs
+++ b/LLama/Common/FixedSizeQueue.cs
@@ -67,8 +67,25 @@ namespace LLama.Common
                 throw new ArgumentException($"The max size set for the queue is {size}, but got {dataCount} initial values.");
 #endif
 
+            if (data is ICollection<T> collection)
+            {
+                if (collection.Count > size)
+                    throw new ArgumentException($"The max size set for the queue is {size}, but got {collection.Count} initial values.");
+
+                foreach (var item in collection)
+                    Enqueue(item);
+                return;
+            }
+
+            var index = 0;
             foreach (var item in data)
+            {
+                if (index >= size)
+                    throw new ArgumentException($"The max size set for the queue is {size}, but got {index + 1} initial values.");
+
                 Enqueue(item);
+                index++;
+            }
         }
 
         /// <summary>

--- a/LLama/Common/FixedSizeQueue.cs
+++ b/LLama/Common/FixedSizeQueue.cs
@@ -55,7 +55,7 @@ namespace LLama.Common
         }
 
         /// <summary>
-        /// Fill the queue with existing data. Please ensure that data.Count &lt;= size
+        /// Fill the queue with existing data. Please ensure that data.Count <= size
         /// </summary>
         /// <param name="size"></param>
         /// <param name="data"></param>

--- a/LLama/Common/FixedSizeQueue.cs
+++ b/LLama/Common/FixedSizeQueue.cs
@@ -16,6 +16,9 @@ namespace LLama.Common
         private int _count;
         private T[]? _window;
 
+        private const int MinimumWindowSize = 4;
+        private const int WindowGrowthFactor = 2;
+
         /// <inheritdoc />
         public T this[int index]
         {
@@ -133,10 +136,10 @@ namespace LLama.Common
                 return new ReadOnlySpan<T>(_buffer, start, count);
             }
 
-            _window ??= new T[Math.Min(Capacity, Math.Max(4, count))];
+            _window ??= new T[Math.Min(Capacity, Math.Max(MinimumWindowSize, count))];
             if (_window.Length < count)
             {
-                Array.Resize(ref _window, Math.Min(Capacity, Math.Max(_window.Length * 2, count)));
+                Array.Resize(ref _window, Math.Min(Capacity, Math.Max(_window.Length * WindowGrowthFactor, count)));
             }
 
             var firstSegmentLength = Capacity - start;

--- a/LLama/Common/FixedSizeQueue.cs
+++ b/LLama/Common/FixedSizeQueue.cs
@@ -125,34 +125,6 @@ namespace LLama.Common
             return GetEnumerator();
         }
 
-        /// <summary>
-        /// Returns up to <paramref name="count"/> of the most recent items as a contiguous span.
-        /// </summary>
-        internal ReadOnlySpan<T> AsSpan(int count)
-        {
-            count = Math.Min(count, _count);
-            if (count == 0)
-                return ReadOnlySpan<T>.Empty;
-
-            var start = (_start + _count - count + Capacity) % Capacity;
-
-            if (start + count <= Capacity)
-            {
-                return new ReadOnlySpan<T>(_buffer, start, count);
-            }
-
-            _window ??= new T[Math.Min(Capacity, Math.Max(MinimumWindowSize, count))];
-            if (_window.Length < count)
-            {
-                Array.Resize(ref _window, Math.Min(Capacity, Math.Max(_window.Length * WindowGrowthFactor, count)));
-            }
-
-            var firstSegmentLength = Capacity - start;
-            Array.Copy(_buffer, start, _window, 0, firstSegmentLength);
-            Array.Copy(_buffer, 0, _window, firstSegmentLength, count - firstSegmentLength);
-            return _window.AsSpan(0, count);
-        }
-
         private IEnumerable<T> Enumerate()
         {
             for (var i = 0; i < _count; i++)

--- a/LLama/LLamaInstructExecutor.cs
+++ b/LLama/LLamaInstructExecutor.cs
@@ -158,7 +158,7 @@ namespace LLama
         {
             if (_embed_inps.Count <= _consumedTokensCount)
             {
-                if (_last_n_tokens.TokensEndsWithAnyString(args.Antiprompts, Context.NativeHandle.ModelHandle, Context.Encoding))
+                if (!string.IsNullOrEmpty(args.LastOutput) && AntipromptProcessor.Add(args.LastOutput))
                 {
                     args.WaitForInput = true;
                     return (true, Array.Empty<string>());

--- a/LLama/LLamaInteractExecutor.cs
+++ b/LLama/LLamaInteractExecutor.cs
@@ -207,7 +207,7 @@ namespace LLama
         {
             if (_embed_inps.Count <= _consumedTokensCount)
             {
-                if (_last_n_tokens.TokensEndsWithAnyString(args.Antiprompts, Context.NativeHandle.ModelHandle, Context.Encoding))
+                if (!string.IsNullOrEmpty(args.LastOutput) && AntipromptProcessor.Add(args.LastOutput))
                     args.WaitForInput = true;
 
                 if (_pastTokensCount > 0 && args.WaitForInput)

--- a/LLama/StreamingTokenDecoder.cs
+++ b/LLama/StreamingTokenDecoder.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using LLama.Native;
 
@@ -181,7 +183,12 @@ namespace LLama
             if (_characters.Count == 0)
                 return "";
 
-            var str = string.Join("", _characters);
+#if NET5_0_OR_GREATER
+            var span = CollectionsMarshal.AsSpan(_characters);
+            var str = new string(span);
+#else
+            var str = new string(_characters.ToArray());
+#endif
             _characters.Clear();
             return str;
         }


### PR DESCRIPTION
This should provide some optimizations to the FixedQueue. My test are:

**BEFORE THE CHANGES:**

<img width="425" height="226" alt="image" src="https://github.com/user-attachments/assets/50ac9e3d-2e0d-4729-818d-fc03894915db" />

**AFTER THE CHANGES:**

<img width="425" height="235" alt="image" src="https://github.com/user-attachments/assets/c19ebcf4-8f22-41d4-8901-3db2640c99ed" />
