### PR TITLE
set RPATH to "@loader_path" / "$ORIGIN" to ensure executables and dynamic libraries search for dependencies in their origin directory

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -460,11 +460,13 @@ jobs:
       matrix:
         include:
           - build: 'arm64'
-            defines: '-DCMAKE_OSX_ARCHITECTURES=arm64 -DGGML_METAL_EMBED_LIBRARY=ON -DCMAKE_INSTALL_RPATH=''@loader_path'' -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON '
+            defines: '-DCMAKE_OSX_ARCHITECTURES=arm64 -DGGML_METAL_EMBED_LIBRARY=ON'
           - build: 'x64'
-            defines: '-DCMAKE_OSX_ARCHITECTURES=x86_64 -DGGML_METAL=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DCMAKE_INSTALL_RPATH=''@loader_path'' -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON '
+            defines: '-DCMAKE_OSX_ARCHITECTURES=x86_64 -DGGML_METAL=OFF -DGGML_AVX=ON -DGGML_AVX2=ON'
           - build: 'x64-rosetta2'
-            defines: '-DCMAKE_OSX_ARCHITECTURES=x86_64 -DGGML_METAL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DCMAKE_INSTALL_RPATH=''@loader_path'' -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON '
+            defines: '-DCMAKE_OSX_ARCHITECTURES=x86_64 -DGGML_METAL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF'
+    env:
+      MACOS_RPATH_DEFINE: "-DCMAKE_INSTALL_RPATH='@loader_path' -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"
     runs-on: macos-latest   
     steps:
       - uses: actions/checkout@v4
@@ -481,7 +483,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. ${{ env.COMMON_DEFINE }} ${{ matrix.defines }}
+          cmake .. ${{ env.COMMON_DEFINE }} ${{ env.MACOS_RPATH_DEFINE }} ${{ matrix.defines }}
           cmake --build . --config Release -j ${env:NUMBER_OF_PROCESSORS}
           ls -R
       - name: Upload ggml


### PR DESCRIPTION
Linked with the issue:
https://github.com/SciSharp/LLamaSharp/issues/1277#issue-3501172244

I seems that should be done something similar on LINUX (not done in this PR)

[Reference llama.cpp PR](https://github.com/ggml-org/llama.cpp/pull/14309#issue-3164332869)

