### PR TITLE
Fixes Extended grammar optimization mode would crash if TopK sampling is set to zero.

### DIFF
--- a/LLama/Sampling/DefaultSamplingPipeline.cs
+++ b/LLama/Sampling/DefaultSamplingPipeline.cs
@@ -246,7 +246,8 @@ public class DefaultSamplingPipeline
                 }
                     
                 // Extended optimization : Apply the grammar to the TopK tokens and check if the selected token is valid
-                if (GrammarOptimization == GrammarOptimizationMode.Extended)
+                // Only run if TopK > 0
+                if (GrammarOptimization == GrammarOptimizationMode.Extended && TopK > 0)
                 {
                     // Calculate a safe TopK value
                     var safeTopK = Math.Min(TopK, nativeAll.Data.Length);


### PR DESCRIPTION
Fixes the crash I identified in #1281 between grammar optimization and TopK sampling. In summary, now the `GrammarOptimizationMode.Extended` code runs only if TopK is set to something above zero. 