### PR TITLE
Downgrade compile.yml from macos-latest to macos-14

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -467,7 +467,7 @@ jobs:
             defines: '-DCMAKE_OSX_ARCHITECTURES=x86_64 -DGGML_METAL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF'
     env:
       MACOS_RPATH_DEFINE: "-DCMAKE_INSTALL_RPATH='@loader_path' -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"
-    runs-on: macos-latest   
+    runs-on: macos-14   
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Currently, macos tests are failing because the binaries are built with `macos-15` while the unit tests run on `macos-14`. This PR downgrades `compile.yml` to build the binaries using `macos-14`.

I've rebuilt the binaries on my end, and unit tests passed on both `macos-14` and `macos-15` after these changes.