### PR TITLE
Update Vulkan from 1.3.261.1 to 1.4.335.0 and fix download url

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -224,7 +224,7 @@ jobs:
                   windows-latest
               ]
       env:
-          VULKAN_VERSION: 1.3.261.1
+          VULKAN_VERSION: 1.4.335.0
       runs-on: ${{ matrix.os }}
       steps:
           - name: Clone
@@ -246,7 +246,7 @@ jobs:
             id: get_vulkan
             if: ${{ matrix.os == 'windows-latest' }}
             run: |
-                curl.exe -o $env:RUNNER_TEMP/VulkanSDK-Installer.exe -L "https://sdk.lunarg.com/sdk/download/${env:VULKAN_VERSION}/windows/VulkanSDK-${env:VULKAN_VERSION}-Installer.exe"
+                curl.exe -o $env:RUNNER_TEMP/VulkanSDK-Installer.exe -L "https://sdk.lunarg.com/sdk/download/${env:VULKAN_VERSION}/windows/vulkansdk-windows-X64-${env:VULKAN_VERSION}.exe"
                 & "$env:RUNNER_TEMP\VulkanSDK-Installer.exe" --accept-licenses --default-answer --confirm-command install
                 Add-Content $env:GITHUB_ENV "VULKAN_SDK=C:\VulkanSDK\${env:VULKAN_VERSION}"
                 Add-Content $env:GITHUB_PATH "C:\VulkanSDK\${env:VULKAN_VERSION}\bin"


### PR DESCRIPTION
This PR updates the Vulkan version in `compile.yml` to the latest version, and fixes the broken download url.
I did try downloading the previous version (`1.3.261.1`) from the new download url format, but it didn't work, and I have not come across any issues with the latest version so far, so this seems like the best fix.