### PR TITLE
fix: InteractiveExecutor not generating tokens due to early loop exit

### DIFF
--- a/LLama/LLamaInteractExecutor.cs
+++ b/LLama/LLamaInteractExecutor.cs
@@ -236,7 +236,7 @@ namespace LLama
                 args.WaitForInput = true;
             }
 
-            return Task.FromResult((true, (IReadOnlyList<string>)[]));
+            return Task.FromResult((false, (IReadOnlyList<string>)[]));
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Fix: InteractiveExecutor not generating tokens

### Description
This PR fixes a bug where [InteractiveExecutor](cci:1://file:///c:/Users/User/source/repos/avikeid2007/LLamaSharp/LLama/LLamaInteractExecutor.cs:30:8-38:9) loads the model successfully but does not generate any response tokens when using `ChatSession.ChatAsync()` or `Executor.InferAsync()`.

### Issue
The [PostProcess](cci:1://file:///c:/Users/User/source/repos/avikeid2007/LLamaSharp/LLama/LLamaInteractExecutor.cs:205:8-239:9) method was returning `true` for `breakGeneration` in the default fallthrough case, causing the inference loop to exit immediately before any tokens could be sampled.

### Changes
- Changed the default return value in [PostProcess](cci:1://file:///c:/Users/User/source/repos/avikeid2007/LLamaSharp/LLama/LLamaInteractExecutor.cs:205:8-239:9) from `true` to `false`

```csharp
// Before
return Task.FromResult((true, (IReadOnlyList<string>)[]));

// After
return Task.FromResult((false, (IReadOnlyList<string>)[]));