### PR TITLE
Fix failing workflow caused by new python version

### DIFF
--- a/.github/workflows/release-minor.yml
+++ b/.github/workflows/release-minor.yml
@@ -59,7 +59,7 @@ jobs:
     # Deploy the documentation to GitHub Pages
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.x
+        python-version: '3.13'
     - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
     - uses: actions/cache@v4
       with:

--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -59,7 +59,7 @@ jobs:
     # Deploy the documentation to GitHub Pages
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.x
+        python-version: '3.13'
     - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
     - uses: actions/cache@v4
       with:


### PR DESCRIPTION
This pins the Python version to the version used in the last known succesful run (August 2025), which should fix the error (missing `pkg_resources`) we saw pop up today.