### PR TITLE
Fix compile.yml regressions + switch windows arm64 build to clang

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -222,7 +222,7 @@ jobs:
       matrix:
         include:
           - build: 'arm64'
-            defines: '-DCMAKE_GENERATOR_PLATFORM=ARM64 -DGGML_NATIVE=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF'
+            defines: '-T ClangCL -DCMAKE_GENERATOR_PLATFORM=ARM64 -DGGML_NATIVE=OFF'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes compile.yml regressions caused by the PR #1226 merge. This also switches the windows arm64 build step to use clang because it was never going to work (no msvc support for arm64).

I did a test run of the update binaries action over at my llamasharp fork (using llama.cpp commit `ff4affb4c1aa7eb4f28a0d9de1b205bd719802f2`) and it completed without issues.