### PR TITLE
Fix musl detection using RID instead of distro name

### DIFF
--- a/LLama/Native/Load/NativeLibraryUtils.cs
+++ b/LLama/Native/Load/NativeLibraryUtils.cs
@@ -236,9 +236,9 @@ namespace LLama.Native
                     libPrefix = "lib";
                     return;
                 }
-                if(RuntimeInformation.RuntimeIdentifier.ToLower().StartsWith("alpine"))
+                if(RuntimeInformation.RuntimeIdentifier.ToLower().Contains("musl"))
                 {
-                    // alpine linux distro
+                    // musl-based linux distro (e.g. Alpine)
                     os = "linux-musl-x64";
                     fileExtension = ".so";
                     libPrefix = "lib";


### PR DESCRIPTION
Changes `alpine` to `musl` in the NativeLibraryUtils.

The runtime identifier on musl based distros (for example, alpine) is linux-musl-x64, not alpine-*, so the previous StartsWith("alpine") check failed, causing the loader to switch to linux-x64. Musl tests are passing after this change (tested on my fork).