### PR TITLE
Remove setting hardcoded value for n_seq_max in IContextParamsExtensions

### DIFF
--- a/LLama/Extensions/IContextParamsExtensions.cs
+++ b/LLama/Extensions/IContextParamsExtensions.cs
@@ -58,8 +58,7 @@ namespace LLama.Extensions
                 null => LLamaFlashAttentionType.LLAMA_FLASH_ATTENTION_TYPE_AUTO
             };
             result.kv_unified = true;
-            result.n_seq_max = (uint)Math.Min(Math.Max(10, result.n_ctx / 8), 64);
-
+            
             result.n_threads = Threads(@params.Threads);
             result.n_threads_batch = Threads(@params.BatchThreads);
 


### PR DESCRIPTION
It's already set from passed argument `result.n_seq_max = @params.SeqMax;`

Overwriting it with hardcoded value is removed
result.n_seq_max = Math.Min(Math.Max(10U, result.n_ctx / 8U), 64U /*0x40*/);

Ref: https://github.com/SciSharp/LLamaSharp/discussions/1353