### PR TITLE
Implement Sequence ID pooling in BatchedExecutor to prevent native SeqMax overflow and crashes

### DIFF
--- a/LLama/Batched/BatchedExecutor.cs
+++ b/LLama/Batched/BatchedExecutor.cs
@@ -14,7 +14,54 @@ namespace LLama.Batched;
 public sealed class BatchedExecutor
     : IDisposable
 {
-    private int _nextSequenceId;
+    /// <summary>
+    /// Tracks the sequence IDs currently in use by active conversations.
+    /// This pool ensures that IDs are reused and never exceed the native backend's SeqMax allocation.
+    /// </summary>
+    private readonly HashSet<int> _activeSequenceIds = new();
+
+    /// <summary>
+    /// Allocates the lowest available Sequence ID for a new conversation.
+    /// </summary>
+    /// <returns>A unique sequence ID bounded by the maximum number of concurrent active conversations.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if no sequence IDs can be allocated.</exception>
+    internal LLamaSeqId GetNextSequenceId()
+    {
+        // LOCK REQUIRED: Prevent race conditions if multiple conversations are created simultaneously
+        lock (_activeSequenceIds)
+        {
+            // Linearly search for the lowest available ID.
+            // Because IDs are recycled when conversations are disposed, this will naturally 
+            // stay bounded below the host's maximum concurrency limit (SeqMax).
+            for (int i = 0; i < int.MaxValue; i++)
+            {
+                if (!_activeSequenceIds.Contains(i))
+                {
+                    _activeSequenceIds.Add(i);
+                    return (LLamaSeqId)i;
+                }
+            }
+        }
+
+        // Fallback safety (practically unreachable unless int.MaxValue concurrent users are active)
+        throw new InvalidOperationException("Failed to allocate a Sequence ID.");
+    }
+
+    /// <summary>
+    /// Returns a Sequence ID to the pool so it can be reused by future conversations.
+    /// This should be called exactly once when a Conversation is being disposed.
+    /// </summary>
+    /// <param name="id">The sequence ID to release.</param>
+    internal void ReleaseSequenceId(LLamaSeqId id)
+    {
+        // LOCK REQUIRED: Prevent race conditions against GetNextSequenceId
+        lock (_activeSequenceIds)
+        {
+            // Remove the ID from the active set, making it available for the next GetNextSequenceId() call
+            _activeSequenceIds.Remove((int)id);
+        }
+    }
+
     private readonly List<IBatch> _batchQueue = [];
     private string? _mtmdMarker;
     private int _batchQueueHead;
@@ -243,11 +290,6 @@ public sealed class BatchedExecutor
         IsDisposed = true;
 
         Context.Dispose();
-    }
-
-    internal LLamaSeqId GetNextSequenceId()
-    {
-        return checked((LLamaSeqId)_nextSequenceId++);
     }
     
     /// <summary>

--- a/LLama/Batched/Conversation.cs
+++ b/LLama/Batched/Conversation.cs
@@ -135,6 +135,9 @@ public sealed class Conversation
         // Remove this conversation from the KV cache
         Executor.Context.NativeHandle.MemorySequenceRemove(ConversationId, -1, -1);
 
+        // Release the ID back to the pool to be reused!
+        Executor.ReleaseSequenceId(ConversationId);
+
         // Prevent finalizer from running
         GC.SuppressFinalize(this);
     }


### PR DESCRIPTION
### Description

**The Problem**
Under sustained traffic or continuous batching scenarios, the `BatchedExecutor` eventually causes the native `llama.cpp` backend to deadlock, reject tokens, or throw a segmentation fault.

**The Root Cause**
Currently, `BatchedExecutor` assigns sequence IDs using a strictly incrementing counter (`_nextSequenceId++`). When a `Conversation` is disposed, its tokens are properly removed from the KV cache via `MemorySequenceRemove`, but its Sequence ID is permanently abandoned.

In `llama.cpp`, the `SeqMax` (`n_seq_max`) parameter dictates the static allocation of arrays within the native KV cache. It expects sequence IDs to act as strictly bounded array indices (from `0` to `SeqMax - 1`). Once the C# `_nextSequenceId` counter exceeds `SeqMax`, passing that ID to the native backend results in an out-of-bounds memory access.

**The Solution**
This PR replaces the strictly incrementing counter with a Sequence ID pool.

1. **`BatchedExecutor`**: Updated to track active IDs (e.g., using a thread-safe `HashSet` or similar structure) and assign the lowest available sequence ID. Added a `ReleaseSequenceId` method.
2. **`Conversation`**: Updated the `Dispose()` method to call `Executor.ReleaseSequenceId(ConversationId)` after clearing the KV cache.

**Benefits**

* **Native Memory Safety:** Guarantees that sequence IDs will never exceed the configured `SeqMax` limit as long as concurrent conversations stay within bounds.
* **Indefinite Uptime:** Allows the `BatchedExecutor` to run continuously under high-traffic workloads without requiring the host application to dangerously destroy and recreate the massive native context to reset the ID counter.

