### PR TITLE
Disable GGML_F16C GGML_BMI2 for noavx buid (Fixes #1407)

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         include:
           - build: 'noavx'
-            defines: '-DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF'
+            defines: '-DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF'
             os: ubuntu-22.04
             arch: x64
           - build: 'avx2'
@@ -95,7 +95,7 @@ jobs:
       matrix:
         include:
           - build: 'noavx'
-            defines: '-DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF'
+            defines: '-DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF'
           - build: 'avx2'
             defines: ''
           - build: 'avx'
@@ -160,7 +160,7 @@ jobs:
       matrix:
         include:
           - build: 'noavx'
-            defines: '-DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF'
+            defines: '-DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF'
           - build: 'avx2'
             defines: ''
           - build: 'avx'
@@ -535,7 +535,7 @@ jobs:
             defines: '-DCMAKE_OSX_ARCHITECTURES=x86_64 -DGGML_METAL=OFF -DGGML_AVX=ON -DGGML_AVX2=ON'
             targets: '--target ggml ggml-base ggml-cpu ggml-blas llama mtmd'
           - build: 'x64-rosetta2'
-            defines: '-DCMAKE_OSX_ARCHITECTURES=x86_64 -DGGML_METAL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF'
+            defines: '-DCMAKE_OSX_ARCHITECTURES=x86_64 -DGGML_METAL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF'
             targets: '--target ggml ggml-base ggml-cpu ggml-blas llama mtmd'
     env:
       MACOS_RPATH_DEFINE: "-DCMAKE_INSTALL_RPATH='@loader_path' -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"


### PR DESCRIPTION
This PR disables the GGML_F16C and GGML_BMI2 options for the noavx builds in CI.

Without these options, the "noavx" binaries were still compiled with `-mf16c -mbmi2`,
so they crashed with SIGILL on old CPUs that have no F16C/BMI2 support such as Celeron J4125.

Fixes #1407

Tested locally with the following commands:

```
mkdir build && cd build
cmake .. -DGGML_NATIVE=OFF -DLLAMA_BUILD_TESTS=OFF -DLLAMA_OPENSSL=OFF \
  -DBUILD_SHARED_LIBS=ON -DLLAMA_BUILD_UI=OFF -DLLAMA_BUILD_APP=OFF \
  -DLLAMA_BUILD_EXAMPLES=OFF -DLLAMA_BUILD_SERVER=OFF \
  -DCMAKE_INSTALL_RPATH='$ORIGIN' -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
  -DCMAKE_PLATFORM_NO_VERSIONED_SONAME=ON \
  -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF
cmake --build . --config Release -j $(nproc) --target ggml ggml-base ggml-cpu llama mtmd
```

This changes the flags used to compile `ggml-cpu` from `-mbmi2 -mf16c -msse4.2` to `-msse4.2`.

I confirmed this by directly overwriting the `*.so` files above to `/path/to/app/runtimes/linux-x64/native/noavx`, and it successfully runs on a Synology DS920+ Docker environment.

I haven't tested the other environments, but I added the same options to each of them for consistency.
