### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Join [QQ group](http://qm.qq.com/cgi-bin/qm/qr?_wv=1027&k=sN9VVMwbWjs5L0ATpizKKx
 
 ## Star history
 
-[![Star History Chart](https://api.star-history.com/svg?repos=SciSharp/LLamaSharp)](https://star-history.com/#SciSharp/LLamaSharp&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=SciSharp/LLamaSharp)](https://star-history.dera.page/#SciSharp/LLamaSharp&Date)
 
 ## Contributor wall of fame
 


### PR DESCRIPTION
The star history chart in the README is currently broken due to GitHub stargazer API restrictions. This change moves it to a working alternative provider that requires no API token, so the chart renders correctly again.