### PR TITLE
Allow arbitrary ChatSession message interleaving

### DIFF
--- a/LLama.Unittest/ChatSessionTests.cs
+++ b/LLama.Unittest/ChatSessionTests.cs
@@ -1,0 +1,57 @@
+using System.Runtime.CompilerServices;
+using LLama.Abstractions;
+using LLama.Common;
+using Xunit;
+
+namespace LLama.Unittest;
+
+public sealed class ChatSessionTests
+{
+    [Fact]
+    public void AddMessage_AllowsArbitraryUserAndAssistantInterleaving()
+    {
+        var executor = (ILLamaExecutor)RuntimeHelpers.GetUninitializedObject(typeof(TestExecutor));
+        var session = new ChatSession(executor);
+
+        session.AddUserMessage("multiply 2 by 3")
+            .AddUserMessage("then divide by -1")
+            .AddAssistantMessage("6")
+            .AddAssistantMessage("-6");
+
+        Assert.Collection(
+            session.History.Messages,
+            message => Assert.Equal((AuthorRole.User, "multiply 2 by 3"), (message.AuthorRole, message.Content)),
+            message => Assert.Equal((AuthorRole.User, "then divide by -1"), (message.AuthorRole, message.Content)),
+            message => Assert.Equal((AuthorRole.Assistant, "6"), (message.AuthorRole, message.Content)),
+            message => Assert.Equal((AuthorRole.Assistant, "-6"), (message.AuthorRole, message.Content)));
+    }
+
+    private sealed class TestExecutor : StatefulExecutorBase
+    {
+        private TestExecutor() : base(null!) { }
+
+        protected override Task<bool> GetLoopCondition(InferStateArgs args, CancellationToken cancellationToken = default)
+            => Task.FromResult(false);
+
+        protected override Task PreprocessInputs(string? text, InferStateArgs args, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        protected override Task<(bool, IReadOnlyList<string>)> PostProcess(IInferenceParams inferenceParams, InferStateArgs args, CancellationToken cancellationToken = default)
+            => Task.FromResult<(bool, IReadOnlyList<string>)>((true, []));
+
+        protected override Task InferInternal(IInferenceParams inferenceParams, InferStateArgs args, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public override Task SaveState(string filename, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public override ExecutorBaseState GetStateData()
+            => new();
+
+        public override Task LoadState(ExecutorBaseState data, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public override Task LoadState(string filename, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+}

--- a/LLama/ChatSession.cs
+++ b/LLama/ChatSession.cs
@@ -247,29 +247,6 @@ public class ChatSession
             throw new ArgumentException("Cannot add a system message after another message", nameof(message));
         }
 
-        // If current message is a user message, only allow the history to be empty,
-        // or the previous message to be a system message or assistant message.
-        if (message.AuthorRole == AuthorRole.User)
-        {
-            ChatHistory.Message? lastMessage = History.Messages.LastOrDefault();
-            if (lastMessage is not null && lastMessage.AuthorRole == AuthorRole.User)
-            {
-                throw new ArgumentException("Cannot add a user message after another user message", nameof(message));
-            }
-        }
-
-        // If the current message is an assistant message,
-        // the previous message must be a user message.
-        if (message.AuthorRole == AuthorRole.Assistant)
-        {
-            ChatHistory.Message? lastMessage = History.Messages.LastOrDefault();
-            if (lastMessage is null
-                || lastMessage.AuthorRole != AuthorRole.User)
-            {
-                throw new ArgumentException("Assistant message must be preceded with a user message", nameof(message));
-            }
-        }
-
         History.AddMessage(message.AuthorRole, message.Content);
         return this;
     }


### PR DESCRIPTION
 allow consecutive user and assistant messages in ChatSession history & preserve the existing rule that system messages must be first, add a regression test covering the interleaving reported in #857  Validation dotnet build LLama/LLamaSharp.csproj --configuration Release --no-restore -p:SkipDownloadReleaseBinaries=true\n- targeted ChatSessionTests harness: 1 passed, Closes #857