### PR TITLE
Read the release version from LLamaSharp.csproj

### DIFF
--- a/.github/prepare_release.sh
+++ b/.github/prepare_release.sh
@@ -1,23 +1,28 @@
 #!/bin/bash -e
 
-is_minor="$1"    # type is "minor" or "patch"
-is_patch="$2"    # type is "minor" or "patch"
+# The version to publish is read from LLama/LLamaSharp.csproj and used verbatim.
+# Bump <Version> there in the release PR: whatever it says is exactly what ships.
+version=$(dotnet msbuild ./LLama/LLamaSharp.csproj -getProperty:Version)
+version="${version//[$'\t\r\n ']/}"
 
-echo "is_minor: $is_minor"
-echo "is_patch: $is_patch"
-
-if [ "$is_minor" = true ] && [ "$is_patch" = true ]; then
-  echo "Only one of minor version and patch version should be specified."
+if ! [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Could not read a valid version from LLama/LLamaSharp.csproj (got '$version')."
   exit 1
-elif [ "$is_minor" = true ] && [ "$is_patch" = false ]; then
-  type="minor"
-  echo "decided to update minor version"
-elif [ "$is_minor" = false ] && [ "$is_patch" = true ]; then
-  type="patch"
-  echo "decided to update patch version"
+fi
+
+echo "Releasing version: $version";
+
+# Refuse to rebuild a version that is already on nuget.org, so a re-run of the
+# workflow fails loudly instead of silently doing nothing.
+published=$(curl -sf https://api.nuget.org/v3-flatcontainer/llamasharp/index.json || true)
+if [ -n "$published" ]; then
+  if echo "$published" | grep -Fq "\"$version\""; then
+    echo "LLamaSharp $version is already published on nuget.org."
+    echo "Bump <Version> in LLama/LLamaSharp.csproj before releasing again."
+    exit 1
+  fi
 else
-  echo "At least one of minor version and patch version should be specified."
-  exit 1
+  echo "Warning: could not reach nuget.org to check for an existing $version, continuing anyway.";
 fi
 
 mkdir ./temp;
@@ -25,58 +30,19 @@ mkdir ./temp/runtimes;
 cp ./LLama/runtimes ./temp -R;
 cp ./LLama/runtimes/build/*.* ./temp/;
 
-# get the current version
-cd temp;
-dotnet add package LLamaSharp;
-version=$(dotnet list temp.csproj package | grep LLamaSharp);
-# TODO: This didn´t work on osx...we need a solution
-read -ra arr <<< "$version"
-version="${arr[-1]}"
-echo "The latest version: $version";
-
-
-# update the version
-if [[ $type == "minor" ]]; then
-    regex="[0-9]+\.([0-9]+)\.[0-9]+$"
-    if [[ $version =~ $regex ]]; then
-        b="${BASH_REMATCH[1]}"
-        b=$((b + 1))
-        updated_version="${version%%.*}.$b.0"
-        echo "Updated version: $updated_version"
-    else
-        echo "Invalid version format"
-        exit 1
-    fi
-elif [[ $type == "patch" ]]; then
-    regex="([0-9]+)$"
-    if [[ $version =~ $regex ]]; then
-        c="${BASH_REMATCH[1]}"
-        c=$((c + 1))
-        updated_version="${version%.*}.$c"
-        echo "Updated version: $updated_version"
-    else
-        echo "Invalid version format"
-        exit 1
-    fi
-else
-    echo "Invalid type" 
-    exit 1
-fi
-
-cd ..
 # pack the main package
-dotnet pack ./LLama/LLamaSharp.csproj -c Release -o ./temp/ /p:PackageVersion=$updated_version /p:Version=$updated_version /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg;
+dotnet pack ./LLama/LLamaSharp.csproj -c Release -o ./temp/ /p:PackageVersion=$version /p:Version=$version /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg;
 
 # pack the backends
 cd temp
 for nuspec in *.nuspec
 do
   echo "Packing $nuspec"
-  nuget pack $nuspec -version $updated_version
+  nuget pack $nuspec -version $version
 done
 
 # write the version to the file
-echo $updated_version > version.txt
+echo $version > version.txt
 
 cd ..
 exit 0

--- a/.github/prepare_release.sh
+++ b/.github/prepare_release.sh
@@ -13,16 +13,24 @@ fi
 echo "Releasing version: $version";
 
 # Refuse to rebuild a version that is already on nuget.org, so a re-run of the
-# workflow fails loudly instead of silently doing nothing.
-published=$(curl -sf https://api.nuget.org/v3-flatcontainer/llamasharp/index.json || true)
-if [ -n "$published" ]; then
-  if echo "$published" | grep -Fq "\"$version\""; then
-    echo "LLamaSharp $version is already published on nuget.org."
-    echo "Bump <Version> in LLama/LLamaSharp.csproj before releasing again."
-    exit 1
-  fi
-else
-  echo "Warning: could not reach nuget.org to check for an existing $version, continuing anyway.";
+# workflow fails loudly instead of silently doing nothing. This job ends in a push
+# to nuget.org, so if the API cannot be reached there is no point carrying on.
+nuget_index="https://api.nuget.org/v3-flatcontainer/llamasharp/index.json"
+if ! published=$(curl -sf --connect-timeout 10 --max-time 60 --retry 3 --retry-delay 5 "$nuget_index"); then
+  echo "Could not query nuget.org for the published versions of LLamaSharp."
+  echo "Refusing to release without that check, since the release publishes to nuget.org anyway."
+  exit 1
+fi
+
+if ! echo "$published" | grep -Fq '"versions"'; then
+  echo "Unexpected response from $nuget_index, expected a JSON document listing versions."
+  exit 1
+fi
+
+if echo "$published" | grep -Fq "\"$version\""; then
+  echo "LLamaSharp $version is already published on nuget.org."
+  echo "Bump <Version> in LLama/LLamaSharp.csproj before releasing again."
+  exit 1
 fi
 
 mkdir ./temp;

--- a/.github/workflows/release-minor-trigger.yml
+++ b/.github/workflows/release-minor-trigger.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release-minor-trigger:
-    if: contains(github.event.pull_request.labels.*.name, 'minor-release') && !contains(github.event.pull_request.labels.*.name, 'patch-release')
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'minor-release') && !contains(github.event.pull_request.labels.*.name, 'patch-release')
     runs-on: ubuntu-22.04
     
     steps:

--- a/.github/workflows/release-minor.yml
+++ b/.github/workflows/release-minor.yml
@@ -43,7 +43,7 @@ jobs:
         git fetch origin;
         
         chmod +x ./.github/prepare_release.sh
-        ./.github/prepare_release.sh true false
+        ./.github/prepare_release.sh
 
     - name: Upload packages artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/release-patch-trigger.yml
+++ b/.github/workflows/release-patch-trigger.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release-patch-trigger:
-    if: contains(github.event.pull_request.labels.*.name, 'patch-release') && !contains(github.event.pull_request.labels.*.name, 'minor-release')
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'patch-release') && !contains(github.event.pull_request.labels.*.name, 'minor-release')
     runs-on: ubuntu-22.04
     
     steps:

--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -43,7 +43,7 @@ jobs:
         git fetch origin;
         
         chmod +x ./.github/prepare_release.sh
-        ./.github/prepare_release.sh false true
+        ./.github/prepare_release.sh
 
     - name: Upload packages artifacts
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
This PR changes the release workflow to read the release version from `LLamaSharp.csproj`. Previously, it would get the latest LLamaSharp package from nuget, read the version and bump it, however, this has 2 issues:

- Release version in `LLamaSharp.csproj` was ignored
- If a release fails (like we've now had 2 times in a row) leaves nuget.org behind, so release versions would go out of sync

This PR also adds 2 guards:

- Check if the version in the csproj is a valid x.y.z (if not, abort)
- Check if the release version in the csproj already exists on nuget (if so, abort)

After this gets merged, there will be one more PR to fix docs that have been failing since 0.26.0 (stuck on 0.25.0). After that, we should probably do another version increment to 0.30.0 and we should be ready to get the release up.