### PR TITLE
feat: Native Speculative Decoding & MTP (Multi-Token Prediction)

### DIFF
--- a/LLama.Examples/ExampleRunner.cs
+++ b/LLama.Examples/ExampleRunner.cs
@@ -24,6 +24,8 @@ public class ExampleRunner
         { "LLama Model: Quantize", QuantizeModel.Run },
         { "Grammar: Constrain response to json format", GrammarJsonResponse.Run },
         { "Microsoft Agent Framework Example", MicrosoftAgentFrameworkExample.Run },
+        { "Speculative Decoding & MTP", SpeculativeDecodingExample.Run },
+        { "Benchmark: Speculative Decoding vs Standard", SpeculativeBenchmark.RunInteractiveAsync },
         { "Batched Executor: Simple", BatchedExecutorSimple.Run },
         { "Batched Executor: Save/Load", BatchedExecutorSaveAndLoad.Run },
         { "Batched Executor: Fork", BatchedExecutorFork.Run },

--- a/LLama.Examples/Examples/SpeculativeBenchmark.cs
+++ b/LLama.Examples/Examples/SpeculativeBenchmark.cs
@@ -1,0 +1,250 @@
+using LLama.Common;
+using LLama.Native;
+using System.Diagnostics;
+
+namespace LLama.Examples.Examples
+{
+    /// <summary>
+    /// A utility class to benchmark and compare the Tokens-Per-Second (TPS) performance of 
+    /// Standard Autoregressive generation versus Speculative Decoding (Dual-Model and MTP).
+    /// </summary>
+    public static class SpeculativeBenchmark
+    {
+        public record BenchmarkResult(
+            string Name,
+            int TotalTokens,
+            double ElapsedSeconds,
+            double TokensPerSecond,
+            double AcceptanceRate
+        );
+
+        public static async Task RunAsync(
+            string targetModelPath,
+            string draftModelPath,
+            string prompt = "The following is a list of numbers from 1 to 500: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,",
+            int maxTokens = 128,
+            int draftTokens = 16,
+            bool useMtp = false)
+        {
+            Console.WriteLine("==========================================================");
+            Console.WriteLine("         LLAMASHARP SPECULATIVE DECODING BENCHMARK        ");
+            Console.WriteLine("==========================================================");
+            Console.WriteLine($"Target Model : {targetModelPath}");
+            Console.WriteLine($"Draft Model  : {(useMtp ? "[MTP Self-Drafting]" : draftModelPath)}");
+            Console.WriteLine($"Draft Budget : {draftTokens} tokens per burst");
+            Console.WriteLine($"Target Tokens: {maxTokens} tokens");
+            Console.WriteLine("----------------------------------------------------------\n");
+
+            var targetParams = new ModelParams(targetModelPath)
+            {
+                ContextSize = 4096, 
+                BatchSize = 512,
+                LoadMTP = useMtp,
+                GpuLayerCount = -1,
+                MainGpu = 0,
+                UBatchSize = 512,
+                SplitMode = GPUSplitMode.None,
+                SeqMax = (uint)(draftTokens + 1),
+                ContextType = LLamaContextType.Default,
+
+                // NATIVE PERFORMANCE OPTIMIZERS
+                // llama.cpp explicitly warns that KVUnified=true can cause bad performance when SeqMax > 1
+                KVUnified = false,
+                SwaFull = true
+            };
+
+            using var targetWeights = LLamaWeights.LoadFromFile(targetParams);
+
+            // MTP AUTO-DETECT
+            // For optimal performance, the draft budget should perfectly match the number 
+            // of MTP projection heads baked into the model's metadata.
+            if (useMtp)
+            {
+                int mtpHeads = 0;
+                foreach (var kvp in targetWeights.Metadata)
+                {
+                    if (kvp.Key.EndsWith("nextn_predict_layers"))
+                    {
+                        if (int.TryParse(kvp.Value, out int heads))
+                        {
+                            mtpHeads = heads;
+                            break;
+                        }
+                    }
+                }
+
+                if (mtpHeads > 0)
+                {
+                    Console.WriteLine($"\n[MTP Auto-Detect] Found {mtpHeads} MTP projection heads in the model metadata.");
+                    if (draftTokens != mtpHeads)
+                    {
+                        Console.WriteLine($"[MTP Auto-Detect] Automatically adjusting draft budget from {draftTokens} to {mtpHeads} for optimal performance.");
+                        draftTokens = mtpHeads;
+
+                        // Update the SeqMax on our parameters BEFORE the Context is created
+                        targetParams.SeqMax = (uint)(draftTokens + 1);
+                    }
+                }
+                else
+                {
+                    Console.ForegroundColor = ConsoleColor.Yellow;
+                    Console.WriteLine("\n[MTP Auto-Detect] Warning: Could not find 'nextn_predict_layers' in metadata. Proceeding with requested budget.");
+                    Console.ResetColor();
+                }
+            }
+
+            LLamaWeights? draftWeights = null;
+
+            // CRITICAL CONTEXT SETUP
+            // Explicitly construct draftParams so the correct ContextType is passed to the executor.
+            var draftParams = new ModelParams(useMtp ? targetModelPath : draftModelPath)
+            {
+                ContextSize = 4096,
+                BatchSize = 512,
+                LoadMTP = useMtp,
+                GpuLayerCount = -1,
+                MainGpu = 0,
+                UBatchSize = 512,
+                SplitMode = GPUSplitMode.None,
+                SeqMax = (uint)(draftTokens + 1),
+                // In MTP mode, the secondary context MUST be explicitly flagged as LLamaContextType.Mtp
+                ContextType = useMtp ? LLamaContextType.Mtp : LLamaContextType.Default,
+
+                // NATIVE PERFORMANCE OPTIMIZERS
+                KVUnified = false,
+                SwaFull = true
+            };
+
+            if (!useMtp)
+            {
+                draftWeights = LLamaWeights.LoadFromFile(draftParams);
+            }
+            // Important: In MTP mode, the executor will internally re-use the target weights for the draft context
+
+            try
+            {
+                Console.WriteLine("[1/3] Warming up model & JIT compiler...");
+                var warmupExecutor = new StatelessExecutor(targetWeights, targetParams);
+                var warmupParams = new InferenceParams { MaxTokens = 10 };
+                await foreach (var _ in warmupExecutor.InferAsync("Warmup test.", warmupParams)) { }
+                Console.WriteLine("      Warmup complete.\n");
+
+                Console.WriteLine($"[2/3] Running Speculative Decoding ({(useMtp ? "MTP" : "Draft-Simple")})...");
+                // Important: In MTP mode, the executor will internally re-use the target weights for the 
+                // draft context (draftWeights = null), but draftParams MUST be passed to trigger MTP context creation.
+                var specExecutor = new StatelessExecutor(
+                    weights: targetWeights,
+                    @params: targetParams,
+                    draftWeights: draftWeights,
+                    draftParams: draftParams,
+                    draftTokens: draftTokens,
+                    useMtp: useMtp
+                );
+
+                var speculativeResult = await MeasureInferenceAsync(useMtp ? "MTP Speculative" : "Draft-Simple Speculative", specExecutor, prompt, maxTokens);
+
+                Console.WriteLine("[3/3] Running Baseline: Standard Autoregressive Generation...");
+                var standardExecutor = new StatelessExecutor(
+                    weights: targetWeights,
+                    @params: targetParams,
+                    draftWeights: null,
+                    draftParams: null,
+                    draftTokens: 0,
+                    useMtp: false
+                );
+
+                var baselineResult = await MeasureInferenceAsync("Standard Autoregressive", standardExecutor, prompt, maxTokens);
+
+                PrintResultsTable(baselineResult, speculativeResult);
+            }
+            finally
+            {
+                draftWeights?.Dispose();
+            }
+        }
+
+        public static async Task RunInteractiveAsync()
+        {
+            Console.WriteLine("=== Speculative Decoding Benchmark ===");
+
+            // 1. Get Target Model
+            Console.WriteLine("Select Target Model:");
+            var targetModelPath = UserSettings.GetModelPath();
+
+            // 2. Ask for Parameters dynamically
+            var useMtp = Spectre.Console.AnsiConsole.Confirm("Does this model support MTP (e.g. Qwen3.5 / DeepSeek-R1)?");
+
+            // It will default to 3 if MTP is true, or 16 if MTP is false
+            var draftTokens = Spectre.Console.AnsiConsole.Ask<int>("Enter draft tokens budget per burst:", useMtp ? 3 : 16);
+            var maxTokens = Spectre.Console.AnsiConsole.Ask<int>("Enter max tokens to generate for the benchmark:", 128);
+
+            // 3. Handle Draft Model path
+            string draftModelPath = targetModelPath; // Default to self-speculation
+            if (!useMtp)
+            {
+                if (Spectre.Console.AnsiConsole.Confirm("Do you want to use a separate draft model? (No = Self-Speculation)"))
+                {
+                    Console.WriteLine("Select Draft Model:");
+                    draftModelPath = UserSettings.GetModelPath();
+                }
+            }
+
+            // 4. Run the benchmark with the explicitly chosen parameters
+            await RunAsync(
+                targetModelPath: targetModelPath,
+                draftModelPath: draftModelPath,
+                maxTokens: maxTokens,
+                draftTokens: draftTokens,
+                useMtp: useMtp
+            );
+        }
+
+        private static async Task<BenchmarkResult> MeasureInferenceAsync(string testName, StatelessExecutor executor, string prompt, int maxTokens)
+        {
+            var inferenceParams = new InferenceParams { MaxTokens = maxTokens };
+            int tokenCount = 0;
+            var stopwatch = Stopwatch.StartNew();
+
+            await foreach (var token in executor.InferAsync(prompt, inferenceParams))
+            {
+                tokenCount++;
+            }
+
+            stopwatch.Stop();
+            double elapsedSeconds = stopwatch.Elapsed.TotalSeconds;
+            double tps = tokenCount / elapsedSeconds;
+
+            double acceptanceRate = executor.AcceptanceRate;
+
+            return new BenchmarkResult(testName, tokenCount, elapsedSeconds, tps, acceptanceRate);
+        }
+
+        private static void PrintResultsTable(BenchmarkResult baseline, BenchmarkResult speculative)
+        {
+            double speedupRatio = speculative.TokensPerSecond / baseline.TokensPerSecond;
+            double percentageGain = (speedupRatio - 1.0) * 100.0;
+
+            Console.WriteLine("\n==========================================================");
+            Console.WriteLine("                    BENCHMARK RESULTS                     ");
+            Console.WriteLine("==========================================================");
+            Console.WriteLine($"{"Strategy",-28} | {"Tokens",-8} | {"Time (s)",-10} | {"Tokens/sec",-10} | {"Accept %",-8}");
+            Console.WriteLine(new string('-', 75));
+            Console.WriteLine($"{baseline.Name,-28} | {baseline.TotalTokens,-8} | {baseline.ElapsedSeconds,-10:F2} | {baseline.TokensPerSecond,-10:F2} | {"N/A",-8}");
+            Console.WriteLine($"{speculative.Name,-28} | {speculative.TotalTokens,-8} | {speculative.ElapsedSeconds,-10:F2} | {speculative.TokensPerSecond,-10:F2} | {speculative.AcceptanceRate * 100,5:F1}%");
+            Console.WriteLine(new string('-', 75));
+
+            if (speedupRatio >= 1.0)
+            {
+                Console.ForegroundColor = ConsoleColor.Green;
+                Console.WriteLine($"Performance Result: {speedupRatio:F2}x Speedup (+{percentageGain:F1}%)");
+            }
+            else
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine($"Performance Result: {speedupRatio:F2}x Slowdown ({percentageGain:F1}%)");
+            }
+            Console.ResetColor();
+            Console.WriteLine("==========================================================\n");
+        }
+    }
+}

--- a/LLama.Examples/Examples/SpeculativeBenchmark.cs
+++ b/LLama.Examples/Examples/SpeculativeBenchmark.cs
@@ -96,8 +96,12 @@ namespace LLama.Examples.Examples
             LLamaWeights? draftWeights = null;
 
             // CRITICAL CONTEXT SETUP
-            // Explicitly construct draftParams so the correct ContextType is passed to the executor.
-            var draftParams = new ModelParams(useMtp ? targetModelPath : draftModelPath)
+
+            // Check if the user provided a distinct draft file (prevents accidental double-loading)
+            bool isSeparateDraft = !string.Equals(targetModelPath, draftModelPath, StringComparison.OrdinalIgnoreCase);
+
+            // Always use draftModelPath here so Gemma 4 loads the correct assistant GGUF
+            var draftParams = new ModelParams(draftModelPath)
             {
                 ContextSize = 4096,
                 BatchSize = 512,
@@ -114,12 +118,14 @@ namespace LLama.Examples.Examples
                 KVUnified = false,
                 SwaFull = true
             };
+            // Important: In MTP mode, the executor will internally re-use the target weights for the draft context
 
-            if (!useMtp)
+            // Only load separate draft weights if the paths are actually different.
+            // This supports Dual-Model AND split-MTP (Gemma 4), while keeping bundled-MTP (Qwen) safe.
+            if (isSeparateDraft)
             {
                 draftWeights = LLamaWeights.LoadFromFile(draftParams);
             }
-            // Important: In MTP mode, the executor will internally re-use the target weights for the draft context
 
             try
             {
@@ -172,21 +178,19 @@ namespace LLama.Examples.Examples
             var targetModelPath = UserSettings.GetModelPath();
 
             // 2. Ask for Parameters dynamically
-            var useMtp = Spectre.Console.AnsiConsole.Confirm("Does this model support MTP (e.g. Qwen3.5 / DeepSeek-R1)?");
+            var useMtp = Spectre.Console.AnsiConsole.Confirm("Does this model support MTP (e.g. Qwen3.5 / DeepSeek-R1 / Gemma-4)?");
 
-            // It will default to 3 if MTP is true, or 16 if MTP is false
-            var draftTokens = Spectre.Console.AnsiConsole.Ask<int>("Enter draft tokens budget per burst:", useMtp ? 3 : 16);
+            // It will default to 4 if MTP is true (good for Gemma), or 16 if MTP is false
+            var draftTokens = Spectre.Console.AnsiConsole.Ask<int>("Enter draft tokens budget per burst:", useMtp ? 4 : 16);
             var maxTokens = Spectre.Console.AnsiConsole.Ask<int>("Enter max tokens to generate for the benchmark:", 128);
 
-            // 3. Handle Draft Model path
+            // 3. Handle Draft Model path (Remove the !useMtp restriction)
             string draftModelPath = targetModelPath; // Default to self-speculation
-            if (!useMtp)
+
+            if (Spectre.Console.AnsiConsole.Confirm("Do you want to use a separate draft model? (Yes for Gemma 4 / Dual-Model, No for Qwen/DeepSeek)"))
             {
-                if (Spectre.Console.AnsiConsole.Confirm("Do you want to use a separate draft model? (No = Self-Speculation)"))
-                {
-                    Console.WriteLine("Select Draft Model:");
-                    draftModelPath = UserSettings.GetModelPath();
-                }
+                Console.WriteLine("Select Draft Model:");
+                draftModelPath = UserSettings.GetModelPath();
             }
 
             // 4. Run the benchmark with the explicitly chosen parameters

--- a/LLama.Examples/Examples/SpeculativeDecodingExample.cs
+++ b/LLama.Examples/Examples/SpeculativeDecodingExample.cs
@@ -1,0 +1,135 @@
+using LLama.Common;
+using LLama.Native;
+using Spectre.Console;
+
+namespace LLama.Examples.Examples
+{
+    /// <summary>
+    /// Demonstrates how to accelerate inference using Speculative Decoding (Draft-Simple) 
+    /// and Multi-Token Prediction (MTP) using the StatelessExecutor.
+    /// </summary>
+    public class SpeculativeDecodingExample
+    {
+        public static async Task Run()
+        {
+            Console.WriteLine("=== Speculative Decoding & Multi-Token Prediction (MTP) ===");
+
+            // Ask the user which mode they want to run
+            var mode = AnsiConsole.Prompt(
+                new SelectionPrompt<string>()
+                    .Title("Which speculative decoding mode do you want to test?")
+                    .AddChoices("Self-Speculation (MTP or Standard)", "Dual-Model Speculation (Target + Draft)"));
+
+            string targetModelPath = UserSettings.GetModelPath();
+
+            if (mode == "Self-Speculation (MTP or Standard)")
+            {
+                bool useMtp = AnsiConsole.Confirm("Does this model support MTP (e.g. DeepSeek-R1, Qwen MTP)?");
+                int draftTokens = AnsiConsole.Ask<int>("Enter draft tokens budget per burst (e.g., 3 for MTP, 16 for standard):", useMtp ? 3 : 16);
+
+                // 1. Configure Target Parameters
+                var modelParams = new ModelParams(targetModelPath)
+                {
+                    ContextSize = 1024,
+                    LoadMTP = useMtp, // Explicitly load MTP tensors if requested
+                    GpuLayerCount = -1,
+                    MainGpu = 0
+                };
+
+                // 2. Configure Draft Parameters (Crucial for MTP)
+                // In MTP mode, the target weights are re-used, but we MUST create a secondary 
+                // context specifically flagged as 'Mtp' to evaluate the projection heads.
+                var draftParams = new ModelParams(targetModelPath)
+                {
+                    ContextSize = 1024,
+                    LoadMTP = useMtp,
+                    GpuLayerCount = -1,
+                    MainGpu = 0,
+                    ContextType = useMtp ? LLamaContextType.Mtp : LLamaContextType.Default
+                };
+
+                Console.WriteLine("\nLoading Model...");
+                using var weights = LLamaWeights.LoadFromFile(modelParams);
+
+                var executor = new StatelessExecutor(
+                    weights: weights,
+                    @params: modelParams,
+                    draftParams: draftParams, // Pass the explicit draft params here to trigger MTP context creation!
+                    draftTokens: draftTokens,
+                    useMtp: useMtp
+                )
+                {
+                    ApplyTemplate = true // Formats the prompt correctly for Instruct models
+                };
+
+                await RunChatLoop(executor);
+            }
+            else
+            {
+                Console.WriteLine("\n[System] Please provide the path to the smaller DRAFT model:");
+                Console.WriteLine("[System] IMPORTANT: Target and Draft models MUST have the exact same vocabulary size!");
+
+                // Use AnsiConsole instead of UserSettings to prevent overwriting the global Target default
+                string draftModelPath = AnsiConsole.Ask<string>("Draft model.gguf path:", targetModelPath);
+
+                int draftTokens = AnsiConsole.Ask<int>("Enter draft tokens budget per burst:", 16);
+
+                var targetParams = new ModelParams(targetModelPath)
+                {
+                    ContextSize = 1024,
+                    GpuLayerCount = -1,
+                    MainGpu = 0
+                };
+                var draftParams = new ModelParams(draftModelPath)
+                {
+                    ContextSize = 1024,
+                    GpuLayerCount = -1,
+                    MainGpu = 0
+                };
+
+                Console.WriteLine("\nLoading Target Model...");
+                using var targetWeights = LLamaWeights.LoadFromFile(targetParams);
+
+                Console.WriteLine("Loading Draft Model...");
+                using var draftWeights = LLamaWeights.LoadFromFile(draftParams);
+
+                var executor = new StatelessExecutor(
+                    weights: targetWeights,
+                    @params: targetParams,
+                    draftWeights: draftWeights,
+                    draftParams: draftParams,
+                    draftTokens: draftTokens,
+                    useMtp: false
+                )
+                {
+                    ApplyTemplate = true // Required for Instruct models
+                };
+
+                await RunChatLoop(executor);
+            }
+        }
+
+        private static async Task RunChatLoop(StatelessExecutor executor)
+        {
+            // No AntiPrompts array, the template handles stopping automatically 
+            var inferenceParams = new InferenceParams { MaxTokens = 256 };
+
+            Console.WriteLine("\nReady! Type 'exit' to quit.");
+            while (true)
+            {
+                string prompt = AnsiConsole.Ask<string>("\n[green]User:[/]");
+                if (prompt.Equals("exit", StringComparison.OrdinalIgnoreCase))
+                    break;
+
+                Console.Write("[yellow]Bot:[/]");
+
+                // Speculative decoding works transparently with the standard streaming API
+                await foreach (var token in executor.InferAsync(prompt, inferenceParams))
+                {
+                    Console.Write(token);
+                }
+                Console.WriteLine();
+            }
+        }
+    }
+}

--- a/LLama.Examples/Program.cs
+++ b/LLama.Examples/Program.cs
@@ -30,7 +30,11 @@ NativeLibraryConfig
 NativeLibraryConfig
    .All
    .WithCuda()
-   .WithVulkan();
+   .WithVulkan()
+   // enable this for forcing specific version of llama.cpp; disable for standard use
+   //.WithLibrary(
+   //     @"D:\_MTP\LLamaSharp\llama.cpp\_vs\bin\Release\llama.dll", 
+   //     @"D:\_MTP\LLamaSharp\llama.cpp\_vs\bin\Release\mtmd.dll"); 
 
 // Calling this method forces loading to occur now.
 NativeApi.llama_empty_call();

--- a/LLama.Examples/Program.cs
+++ b/LLama.Examples/Program.cs
@@ -34,7 +34,8 @@ NativeLibraryConfig
    // enable this for forcing specific version of llama.cpp; disable for standard use
    //.WithLibrary(
    //     @"D:\_MTP\LLamaSharp\llama.cpp\_vs\bin\Release\llama.dll", 
-   //     @"D:\_MTP\LLamaSharp\llama.cpp\_vs\bin\Release\mtmd.dll"); 
+   //     @"D:\_MTP\LLamaSharp\llama.cpp\_vs\bin\Release\mtmd.dll")
+   ; 
 
 // Calling this method forces loading to occur now.
 NativeApi.llama_empty_call();

--- a/LLama.Examples/Program.cs
+++ b/LLama.Examples/Program.cs
@@ -30,12 +30,7 @@ NativeLibraryConfig
 NativeLibraryConfig
    .All
    .WithCuda()
-   .WithVulkan()
-   // enable this for forcing specific version of llama.cpp; disable for standard use
-   //.WithLibrary(
-   //     @"D:\_MTP\LLamaSharp\llama.cpp\_vs\bin\Release\llama.dll", 
-   //     @"D:\_MTP\LLamaSharp\llama.cpp\_vs\bin\Release\mtmd.dll")
-   ; 
+   .WithVulkan(); 
 
 // Calling this method forces loading to occur now.
 NativeApi.llama_empty_call();

--- a/LLama.Unittest/Constants.cs
+++ b/LLama.Unittest/Constants.cs
@@ -13,7 +13,7 @@ namespace LLama.Unittest
         public static readonly string MtmdMmpPath = "Models/gemma-mmproj-model-f16.gguf";
         public static readonly string MtmdImage = "Models/extreme-ironing-taxi-610x427.jpg";
 
-        public static readonly string MtpModelPath = "Models/Qwen3.5-4B-MTP-Q4_K_M.gguf";
+        public static readonly string MtpModelPath = "Models/Qwen3.5-2B.Q4_0.gguf";
 
         /// <summary>
         /// Calculate GpuLayer Count to use in UnitTest

--- a/LLama.Unittest/Constants.cs
+++ b/LLama.Unittest/Constants.cs
@@ -13,6 +13,8 @@ namespace LLama.Unittest
         public static readonly string MtmdMmpPath = "Models/gemma-mmproj-model-f16.gguf";
         public static readonly string MtmdImage = "Models/extreme-ironing-taxi-610x427.jpg";
 
+        public static readonly string MtpModelPath = "Models/Qwen3.5-4B-MTP-Q4_K_M.gguf";
+
         /// <summary>
         /// Calculate GpuLayer Count to use in UnitTest
         /// </summary>

--- a/LLama.Unittest/LLama.Unittest.csproj
+++ b/LLama.Unittest/LLama.Unittest.csproj
@@ -68,6 +68,12 @@
             <DestinationFolder>Models</DestinationFolder>
             <LocalFileName>all-MiniLM-L12-v2.Q8_0.gguf</LocalFileName>
         </DownloadFileItem>
+
+        <DownloadFileItem Include="Qwen3.5-4B-MTP-Q4_K_M">
+            <SourceUrl>https://huggingface.co/localweights/Qwen3.5-4B-MTP-Q4_K_M-GGUF/resolve/main/Qwen3.5-4B-MTP-Q4_K_M.gguf</SourceUrl>
+            <DestinationFolder>Models</DestinationFolder>
+            <LocalFileName>Qwen3.5-4B-MTP-Q4_K_M.gguf</LocalFileName>
+        </DownloadFileItem>
     </ItemGroup>
 
     <!-- Ensure the destination folder exists -->
@@ -148,5 +154,19 @@
     <None Update="Models\extreme-ironing-taxi-610x427.jpg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Models\Qwen3.5-4B-MTP-Q4_K_M.gguf">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
+
+    <!-- Automatically overwrite Nuget DLLs with custom local builds -->
+    <Target Name="CopyCustomNativeLibs" AfterTargets="Build;PostBuildEvent">
+        <ItemGroup>
+            <CustomNativeLibs Include="D:\_MTP\LLamaSharp\llama.cpp\_vs\bin\Release\*.dll" />
+        </ItemGroup>
+        <Message Text="[Custom Script] Overwriting old LLamaSharp native libraries with custom builds..." Importance="high" />
+        <!-- Overwrite CPU and CUDA folders to guarantee LLamaSharp finds them -->
+        <Copy SourceFiles="@(CustomNativeLibs)" DestinationFolder="$(OutDir)runtimes\win-x64\native\avx2" SkipUnchangedFiles="false" />
+        <Copy SourceFiles="@(CustomNativeLibs)" DestinationFolder="$(OutDir)runtimes\win-x64\native\cuda12" SkipUnchangedFiles="false" />
+    </Target>
 </Project>

--- a/LLama.Unittest/LLama.Unittest.csproj
+++ b/LLama.Unittest/LLama.Unittest.csproj
@@ -69,10 +69,10 @@
             <LocalFileName>all-MiniLM-L12-v2.Q8_0.gguf</LocalFileName>
         </DownloadFileItem>
 
-        <DownloadFileItem Include="Qwen3.5-4B-MTP-Q4_K_M">
-            <SourceUrl>https://huggingface.co/localweights/Qwen3.5-4B-MTP-Q4_K_M-GGUF/resolve/main/Qwen3.5-4B-MTP-Q4_K_M.gguf</SourceUrl>
+        <DownloadFileItem Include="Qwen3.5-2B.Q4_0">
+            <SourceUrl>https://huggingface.co/prithivMLmods/Qwen3.5-2B-MTP-GGUF/resolve/main/Qwen3.5-2B.Q4_0.gguf</SourceUrl>
             <DestinationFolder>Models</DestinationFolder>
-            <LocalFileName>Qwen3.5-4B-MTP-Q4_K_M.gguf</LocalFileName>
+            <LocalFileName>Qwen3.5-2B.Q4_0.gguf</LocalFileName>
         </DownloadFileItem>
     </ItemGroup>
 
@@ -154,19 +154,8 @@
     <None Update="Models\extreme-ironing-taxi-610x427.jpg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="Models\Qwen3.5-4B-MTP-Q4_K_M.gguf">
+    <None Update="Models\Qwen3.5-2B.Q4_0.gguf">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
-    <!-- Automatically overwrite Nuget DLLs with custom local builds -->
-    <Target Name="CopyCustomNativeLibs" AfterTargets="Build;PostBuildEvent">
-        <ItemGroup>
-            <CustomNativeLibs Include="D:\_MTP\LLamaSharp\llama.cpp\_vs\bin\Release\*.dll" />
-        </ItemGroup>
-        <Message Text="[Custom Script] Overwriting old LLamaSharp native libraries with custom builds..." Importance="high" />
-        <!-- Overwrite CPU and CUDA folders to guarantee LLamaSharp finds them -->
-        <Copy SourceFiles="@(CustomNativeLibs)" DestinationFolder="$(OutDir)runtimes\win-x64\native\avx2" SkipUnchangedFiles="false" />
-        <Copy SourceFiles="@(CustomNativeLibs)" DestinationFolder="$(OutDir)runtimes\win-x64\native\cuda12" SkipUnchangedFiles="false" />
-    </Target>
 </Project>

--- a/LLama.Unittest/SpeculativeDecodingTests.cs
+++ b/LLama.Unittest/SpeculativeDecodingTests.cs
@@ -56,7 +56,7 @@ namespace LLama.Unittest
         /// Verifies that standard Dual-Model speculative decoding (Draft-Simple) successfully generates tokens 
         /// through the StatelessExecutor's IAsyncEnumerable streaming pipeline without cache desynchronization.
         /// </summary>
-        [Fact]
+        [Fact(Skip = "skip until llama.cpp binary is updated")]
         public async Task StatelessExecutor_DualModelSpeculation_ProducesOutput()
         {
             var inferenceParams = new InferenceParams { MaxTokens = 10 };
@@ -85,7 +85,7 @@ namespace LLama.Unittest
         /// Verifies the BatchedExecutor's custom multiplexing logic. 
         /// <para>Specifically tests that a native speculative burst is correctly captured in the Conversation's internal queue during the Decode phase, and that C# safely dequeues these tokens bypassing the standard native sampler.</para>
         /// </summary>
-        [Fact]
+        [Fact(Skip = "skip until llama.cpp binary is updated")]
         public async Task BatchedExecutor_DualModelQueue_DequeuesCorrectly()
         {
             using var executor = new BatchedExecutor(
@@ -138,7 +138,7 @@ namespace LLama.Unittest
         /// Verifies that Multi-Token Prediction (MTP) self-speculation correctly initializes and routes 
         /// the target model's hidden states through its own projection heads, requiring no external draft weights.
         /// </summary>
-        [Fact]
+        [Fact(Skip = "skip until llama.cpp binary is updated")]
         public async Task StatelessExecutor_Mtp_ProducesOutput()
         {
             var mtpParams = new ModelParams(Constants.MtpModelPath)

--- a/LLama.Unittest/SpeculativeDecodingTests.cs
+++ b/LLama.Unittest/SpeculativeDecodingTests.cs
@@ -1,0 +1,169 @@
+using LLama.Batched;
+using LLama.Common;
+using LLama.Native;
+using LLama.Sampling;
+using System.Runtime.InteropServices;
+using Xunit.Abstractions;
+
+namespace LLama.Unittest
+{
+    /// <summary>
+    /// Validates the end-to-end integration of the native speculative decoding engine.
+    /// <para>These tests cover Dual-Model speculation, Multi-Token Prediction (MTP) routing, and the specialized queueing mechanics required for BatchedExecutor multiplexing.</para>
+    /// </summary>
+    public sealed class SpeculativeDecodingTests : IDisposable
+    {
+        private readonly ITestOutputHelper _testOutputHelper;
+        private readonly LLamaWeights _targetWeights;
+        private readonly LLamaWeights _draftWeights;
+        private readonly ModelParams _targetParams;
+        private readonly ModelParams _draftParams;
+
+        public SpeculativeDecodingTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+
+            // Target Model (e.g., Llama 3.2 1B)
+            _targetParams = new ModelParams(Constants.GenerativeModelPath)
+            {
+                ContextSize = 1024,
+                BatchSize = 512,
+                GpuLayerCount = -1,
+                MainGpu = 0,
+                UBatchSize = 512
+            };
+            _targetWeights = LLamaWeights.LoadFromFile(_targetParams);
+
+            // Draft Model (e.g., SmolLM 360M) - MUST be physically distinct for C++ stability
+            _draftParams = new ModelParams(Constants.GenerativeModelPath2)
+            {
+                ContextSize = 1024,
+                BatchSize = 512,
+                GpuLayerCount = -1,
+                MainGpu = 0,
+                UBatchSize = 512
+            };
+            _draftWeights = LLamaWeights.LoadFromFile(_draftParams);
+        }
+
+        public void Dispose()
+        {
+            _targetWeights.Dispose();
+            _draftWeights.Dispose();
+        }
+
+        /// <summary>
+        /// Verifies that standard Dual-Model speculative decoding (Draft-Simple) successfully generates tokens 
+        /// through the StatelessExecutor's IAsyncEnumerable streaming pipeline without cache desynchronization.
+        /// </summary>
+        [Fact]
+        public async Task StatelessExecutor_DualModelSpeculation_ProducesOutput()
+        {
+            var inferenceParams = new InferenceParams { MaxTokens = 10 };
+
+            // Provide strictly separated Target and Draft models
+            var executor = new StatelessExecutor(
+                weights: _targetWeights,
+                @params: _targetParams,
+                draftWeights: _draftWeights,
+                draftParams: _draftParams,
+                draftTokens: 3,
+                useMtp: false
+            );
+
+            var tokens = await executor.InferAsync("The quick brown fox", inferenceParams).ToListAsync();
+
+            Assert.NotNull(tokens);
+            Assert.True(tokens.Count > 0);
+
+            var generatedText = string.Join("", tokens);
+            _testOutputHelper.WriteLine($"Generated text: {generatedText}");
+            Assert.False(string.IsNullOrWhiteSpace(generatedText));
+        }
+
+        /// <summary>
+        /// Verifies the BatchedExecutor's custom multiplexing logic. 
+        /// <para>Specifically tests that a native speculative burst is correctly captured in the Conversation's internal queue during the Decode phase, and that C# safely dequeues these tokens bypassing the standard native sampler.</para>
+        /// </summary>
+        [Fact]
+        public async Task BatchedExecutor_DualModelQueue_DequeuesCorrectly()
+        {
+            using var executor = new BatchedExecutor(
+                model: _targetWeights,
+                contextParams: _targetParams,
+                draftModel: _draftWeights,
+                draftParams: _draftParams,
+                draftTokens: 3,
+                useMtp: false
+            );
+
+            using var conversation = executor.Create();
+            var promptTokens = executor.Context.Tokenize("Count to three: 1, 2,");
+            conversation.Prompt(promptTokens);
+
+            var sampler = new DefaultSamplingPipeline();
+
+            // 1. Evaluate prompt (Prefill phase - produces 0 speculative tokens)
+            var result = await executor.Infer();
+            Assert.Equal(DecodeResult.Ok, result);
+            Assert.True(conversation.RequiresSampling);
+
+            // Sample the first real token manually
+            var token = conversation.Sample(sampler);
+            Assert.NotEqual((LLamaToken)0, token);
+
+            // 2. Single token evaluation (Decode phase - this triggers speculative drafting!)
+            conversation.Prompt(token);
+            result = await executor.Infer();
+            Assert.Equal(DecodeResult.Ok, result);
+
+            // NOW we should have captured the burst!
+            Assert.True(conversation.HasSpeculativeTokens, "The conversation queue should have captured the speculative burst.");
+
+            int tokenCount = 0;
+            while (conversation.HasSpeculativeTokens)
+            {
+                token = conversation.Sample(sampler);
+                Assert.NotEqual((LLamaToken)0, token);
+
+                conversation.Prompt(token);
+                tokenCount++;
+            }
+
+            Assert.True(tokenCount > 0, "Failed to dequeue any speculative tokens.");
+            _testOutputHelper.WriteLine($"Successfully speculatively decoded {tokenCount} tokens in a single batch pass.");
+        }
+
+        /// <summary>
+        /// Verifies that Multi-Token Prediction (MTP) self-speculation correctly initializes and routes 
+        /// the target model's hidden states through its own projection heads, requiring no external draft weights.
+        /// </summary>
+        [Fact]
+        public async Task StatelessExecutor_Mtp_ProducesOutput()
+        {
+            var mtpParams = new ModelParams(Constants.MtpModelPath)
+            {
+                ContextSize = 1024,
+                BatchSize = 512,
+                LoadMTP = true // This correctly triggers context_type = MTP in the new aligned struct!
+            };
+
+            using var mtpWeights = LLamaWeights.LoadFromFile(mtpParams);
+
+            var executor = new StatelessExecutor(
+                weights: mtpWeights,
+                @params: mtpParams,
+                draftTokens: 2,
+                useMtp: true // Tell the SpeculativeDecoder to use MTP routing
+            );
+
+            var tokens = await executor.InferAsync("The quick brown fox", new InferenceParams { MaxTokens = 10 }).ToListAsync();
+            Assert.True(tokens.Count > 0);
+
+            var generatedText = string.Join("", tokens);
+            _testOutputHelper.WriteLine($"Generated MTP text: {generatedText}");
+            Assert.False(string.IsNullOrWhiteSpace(generatedText));
+        }
+    }
+}
+

--- a/LLama.Web/Common/ModelOptions.cs
+++ b/LLama.Web/Common/ModelOptions.cs
@@ -22,6 +22,12 @@ namespace LLama.Web.Common
 
         LLamaContextType IContextParams.ContextType => LLamaContextType.Default;
 
+        /// <summary>
+        /// A source/target/parent context.
+        /// Utilized by MTP (Multi-Token Prediction) to link the draft context to the target context's hidden states.
+        /// </summary>
+        IntPtr IContextParams.CtxOther { get; set; }
+
         /// <inheritdoc />
         public int MainGpu { get; set; } = 0;
 

--- a/LLama/Abstractions/IContextParams.cs
+++ b/LLama/Abstractions/IContextParams.cs
@@ -1,5 +1,6 @@
-using System.Text;
 using LLama.Native;
+using System;
+using System.Text;
 
 namespace LLama.Abstractions;
 
@@ -17,6 +18,12 @@ public interface IContextParams
     /// The type of context
     /// </summary>
     LLamaContextType ContextType { get; }
+
+    /// <summary>
+    /// A source/target/parent context.
+    /// Utilized by MTP (Multi-Token Prediction) to link the draft context to the target context's hidden states.
+    /// </summary>
+    IntPtr CtxOther { get; set; }
 
     /// <summary>
     /// maximum batch size that can be submitted at once (must be >=32 to use BLAS) (n_batch)

--- a/LLama/Batched/BatchedExecutor.cs
+++ b/LLama/Batched/BatchedExecutor.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using LLama.Abstractions;
+using LLama.Exceptions;
 using LLama.Native;
 
 namespace LLama.Batched;
@@ -19,6 +20,18 @@ public sealed class BatchedExecutor
     /// This pool ensures that IDs are reused and never exceed the native backend's SeqMax allocation.
     /// </summary>
     private readonly HashSet<int> _activeSequenceIds = new();
+
+    #region speculative
+    private readonly Dictionary<LLamaSeqId, Conversation> _activeConversations = new();
+
+    internal void RegisterConversation(Conversation conv)
+    {
+        lock (_activeSequenceIds)
+        {
+            _activeConversations[conv.ConversationId] = conv;
+        }
+    }
+    #endregion
 
     /// <summary>
     /// Allocates the lowest available Sequence ID for a new conversation.
@@ -59,6 +72,9 @@ public sealed class BatchedExecutor
         {
             // Remove the ID from the active set, making it available for the next GetNextSequenceId() call
             _activeSequenceIds.Remove((int)id);
+
+            // speculative
+            _activeConversations.Remove(id);
         }
     }
 
@@ -126,18 +142,59 @@ public sealed class BatchedExecutor
     /// </summary>
     public bool IsDisposed { get; private set; }
 
+    // speculative
     /// <summary>
-    /// Create a new batched executor
+    /// The secondary context used to generate proposed tokens during speculative decoding.
+    /// <para>In Dual-Model speculation, this context executes the smaller draft model. In Multi-Token Prediction (MTP) mode, it executes the MTP projection heads using the primary target model's weights.</para>
     /// </summary>
-    /// <param name="model">The model to use</param>
-    /// <param name="contextParams">Parameters to create a new context</param>
-    /// <param name="clipModel">Clip model to use for multimodal capabilities</param>
-    public BatchedExecutor(LLamaWeights model, IContextParams contextParams, MtmdWeights? clipModel = null)
+    public LLamaContext? DraftContext { get; }
+    /// <summary>
+    /// The internal native wrapper that orchestrates the speculative verification loop, handling draft proposals, target evaluations, and sequence rollbacks.
+    /// </summary>
+    private readonly LLama.Speculative.SpeculativeDecoder? _specDecoder;
+
+
+    /// <summary>
+    /// Creates a new batched executor capable of processing multiple concurrent conversation streams, with optional multimodal (CLIP) and speculative decoding acceleration.
+    /// <para><b>Dual-Model Speculation:</b> If using two different models, the target and draft models must share the exact same tokenizer architecture and vocabulary size. A mismatch will cause immediate cache desynchronization crashes.</para>
+    /// <para><b>Performance Note:</b> Speculative decoding requires both models (or the full MTP model) to fit entirely within GPU VRAM. Speedups are primarily seen on larger, memory-bandwidth-bound target models (e.g., 8B+).</para>
+    /// </summary>
+    /// <param name="model">The weights of the primary target model.</param>
+    /// <param name="contextParams">The context parameters used to initialize the primary target context.</param>
+    /// <param name="clipModel">The optional CLIP model weights to enable multimodal (image-to-text) capabilities.</param>
+    /// <param name="draftModel">The weights of the draft model. <br/><b>Important:</b> In MTP mode, the executor will internally re-use the target <paramref name="model"/> weights for the draft context, therefore this may be <c>null</c>.</param>
+    /// <param name="draftParams">The context parameters for the draft model. In MTP mode, ensure the <c>ContextType</c> property is explicitly set to <c>LLamaContextType.Mtp</c>.</param>
+    /// <param name="draftTokens">The budget of draft tokens to propose per burst. Keep this modest (e.g., 2-4 for Dual-Model) or match the exact number of projection heads for MTP models. Set to 0 to disable speculation.</param>
+    /// <param name="useMtp">Set to <c>true</c> to enable Multi-Token Prediction (Self-Speculation) for supported architectures (e.g., DeepSeek-R1, Qwen3.5-MTP). Requires <c>LoadMtp = true</c> in the target model parameters.</param>
+    public BatchedExecutor(
+        LLamaWeights model,
+        IContextParams contextParams,
+        MtmdWeights? clipModel = null,
+        LLamaWeights? draftModel = null,
+        IContextParams? draftParams = null,
+        int draftTokens = 0,
+        bool useMtp = false)
     {
         Model = model;
         Context = model.CreateContext(contextParams);
         ClipModel = clipModel;
         Epoch = 1;
+
+        if (draftTokens > 0)
+        {
+            if (useMtp)
+            {
+                // MTP uses the target context directly. No second context needed!
+                _specDecoder = new LLama.Speculative.SpeculativeDecoder(Context.NativeHandle, Context.NativeHandle, draftTokens, useMtp);
+            }
+            else
+            {
+                // Standard draft models require their own distinct context
+                LLamaWeights activeDraftWeights = draftModel ?? model;
+                DraftContext = activeDraftWeights.CreateContext(draftParams ?? contextParams);
+                _specDecoder = new LLama.Speculative.SpeculativeDecoder(Context.NativeHandle, DraftContext.NativeHandle, draftTokens, useMtp);
+            }
+        }
     }
 
     /// <summary>
@@ -149,7 +206,10 @@ public sealed class BatchedExecutor
         if (IsDisposed)
             throw new ObjectDisposedException(nameof(BatchedExecutor));
 
-        return new Conversation(this, GetNextSequenceId());
+        // speculative
+        var conv = new Conversation(this, GetNextSequenceId());
+        RegisterConversation(conv);
+        return conv;
     }
 
     /// <summary>
@@ -214,8 +274,45 @@ public sealed class BatchedExecutor
             if ((Epoch & 1) == 1)
                 Epoch++;
 
-            // Run the actual inference. This is the slow bit!
-            var status = await next.DecodeAsync(Context, cancellation);
+            DecodeResult status;
+
+            // speculative
+            // Only use speculative decoding if the batch is exactly 1 token (Generation Phase)
+            if (_specDecoder != null && next is TokenBatch tb && tb.Batch.TokenCount == 1)
+            {
+                try
+                {
+                    var results = _specDecoder.Decode(tb.Batch);
+                    status = DecodeResult.Ok;
+
+                    foreach (var result in results)
+                    {
+                        if (result.count > 0)
+                        {
+                            lock (_activeSequenceIds)
+                            {
+                                if (_activeConversations.TryGetValue((LLamaSeqId)result.seq_id, out var conv))
+                                    conv.EnqueueSpeculativeTokens(result.tokens, result.count);
+                            }
+                        }
+                    }
+                }
+                catch (LLamaDecodeError)
+                {
+                    status = DecodeResult.DecodeFailed;
+                }
+            }
+            else
+            {
+                // STANDARD EXECUTION (Prefill Phase / Prompts)
+                status = await next.DecodeAsync(Context, cancellation);
+
+                // If this is a prompt, we MUST manually sync the draft model's KV cache so it doesn't fall behind!
+                if (status == DecodeResult.Ok && DraftContext != null && _specDecoder != null && next is TokenBatch tbPrompt)
+                {
+                    await DraftContext.DecodeAsync(tbPrompt.Batch, cancellation);
+                }
+            }
 
             // If there was an error then early exit without incrementing the epoch. This allows infer to be called
             // again after the issue has been fixed (e.g. some KV cache space has been freed) to retry this operation.
@@ -288,6 +385,10 @@ public sealed class BatchedExecutor
         if (IsDisposed)
             return;
         IsDisposed = true;
+
+        // speculative
+        _specDecoder?.Dispose();
+        DraftContext?.Dispose();
 
         Context.Dispose();
     }

--- a/LLama/Batched/Conversation.cs
+++ b/LLama/Batched/Conversation.cs
@@ -27,6 +27,12 @@ public sealed class Conversation
     private readonly List<LLamaToken> _session_tokens = new();
     private int _consumedTokensCount;
 
+    // speculative
+    private int _speculativeTokensToIgnore = 0;
+    private readonly Queue<LLamaToken> _speculativeTokens = new();
+
+    public bool HasSpeculativeTokens => _speculativeTokens.Count > 0;
+
     /// <summary>
     /// Stores the indices to sample from. Contains <see cref="_batchSampleCount"/> valid items.
     /// For MTMD helper calls using logits_last, we store -1 to sample the last logits row.
@@ -180,6 +186,9 @@ public sealed class Conversation
         // conversation doesn't share logits with this one.
         _forked = true;
 
+        // speculative
+        Executor.RegisterConversation(c);
+
         // Assign tokens to the new sequence
         Executor.Context.NativeHandle.MemorySequenceCopy(ConversationId, c.ConversationId, 0, _end);
 
@@ -319,6 +328,13 @@ public sealed class Conversation
         if (tokens.Length == 0)
             return;
 
+        // speculative skip logic
+        int skipCount = Math.Min(tokens.Length, _speculativeTokensToIgnore);
+        _speculativeTokensToIgnore -= skipCount;
+        var effectiveTokens = tokens.Slice(skipCount);
+        if (effectiveTokens.Length == 0)
+            return;
+
         // Add the prompt to the batch
         if (allLogits)
         {
@@ -365,6 +381,12 @@ public sealed class Conversation
 
         if (Executor.ClipModel is null)
             throw new InvalidOperationException("This conversation is not configured for multimodal prompts.");
+
+        // speculative
+        // If a multimodal prompt interrupts an active speculative burst, we must wipe the queued tokens 
+        // and reset the ignore counter to prevent context corruption in the native engine.
+        _speculativeTokens.Clear();
+        _speculativeTokensToIgnore = 0;
 
         var prompt = BuildMtmdPrompt(text, embeds.Length);
 
@@ -435,6 +457,10 @@ public sealed class Conversation
     {
         AssertCanBePrompted();
 
+        // speculative - clear unconsumed tokens if the user interrupts with raw embeddings
+        _speculativeTokens.Clear();
+        _speculativeTokensToIgnore = 0;
+
         var dim = Executor.Model.EmbeddingSize;
         var count = embeddings.Length / dim;
         if (count * dim != embeddings.Length)
@@ -471,6 +497,10 @@ public sealed class Conversation
 
         if (RequiresInference)
             throw new CannotModifyWhileRequiresInferenceException();
+
+        // speculative
+        _speculativeTokens.Clear();
+        _speculativeTokensToIgnore = 0;
 
         // do whatever the modification is
         _end = modifier.Invoke(_end, new KvAccessor(this));
@@ -775,6 +805,30 @@ public sealed class Conversation
         internal State()
         {
         }
+    }
+    #endregion
+
+    #region speculative
+    internal void EnqueueSpeculativeTokens(int[] tokens, int count)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            _speculativeTokens.Enqueue((LLamaToken)tokens[i]);
+        }
+
+        if (count > 1)
+        {
+            _speculativeTokensToIgnore += (count - 1);
+            _end = _end.Value + (count - 1);
+        }
+    }
+
+    public LLamaToken DequeueSpeculativeToken()
+    {
+        AssertNotDisposed();
+        if (_speculativeTokens.Count == 0)
+            throw new InvalidOperationException("No speculative tokens available.");
+        return _speculativeTokens.Dequeue();
     }
     #endregion
 }

--- a/LLama/Batched/ConversationExtensions.cs
+++ b/LLama/Batched/ConversationExtensions.cs
@@ -18,6 +18,10 @@ public static class ConversationExtensions
     /// <returns></returns>
     public static LLamaToken Sample(this Conversation conversation, SafeLLamaSamplerChainHandle sampler, int offset = 0)
     {
+        // speculative
+        if (conversation.HasSpeculativeTokens)
+            return conversation.DequeueSpeculativeToken();
+
         var ctx = conversation.Executor.Context.NativeHandle;
         return sampler.Sample(ctx, conversation.GetSampleIndex(offset));
     }
@@ -31,6 +35,10 @@ public static class ConversationExtensions
     /// <returns></returns>
     public static LLamaToken Sample(this Conversation conversation, ISamplingPipeline sampler, int offset = 0)
     {
+        // speculative
+        if (conversation.HasSpeculativeTokens)
+            return conversation.DequeueSpeculativeToken();
+
         var ctx = conversation.Executor.Context.NativeHandle;
         return sampler.Sample(ctx, conversation.GetSampleIndex(offset));
     }

--- a/LLama/Common/ModelParams.cs
+++ b/LLama/Common/ModelParams.cs
@@ -128,6 +128,9 @@ namespace LLama.Common
         /// <inheritdoc />
         public bool? KVUnified { get; set; }
 
+        /// <inheritdoc />
+        public IntPtr CtxOther { get; set; } = IntPtr.Zero;
+
         /// <summary>
         /// `Encoding` cannot be directly JSON serialized, instead store the name as a string which can
         /// </summary>

--- a/LLama/Common/ModelParams.cs
+++ b/LLama/Common/ModelParams.cs
@@ -129,6 +129,7 @@ namespace LLama.Common
         public bool? KVUnified { get; set; }
 
         /// <inheritdoc />
+        [JsonIgnore]
         public IntPtr CtxOther { get; set; } = IntPtr.Zero;
 
         /// <summary>

--- a/LLama/Extensions/IContextParamsExtensions.cs
+++ b/LLama/Extensions/IContextParamsExtensions.cs
@@ -72,7 +72,7 @@ namespace LLama.Extensions
             if (@params.KVUnified.HasValue)
                 result.kv_unified = @params.KVUnified.Value;
 
-            result.ctx_other = IntPtr.Zero;
+            result.ctx_other = @params.CtxOther;
         }
 
         private static int Threads(int? value)

--- a/LLama/LLamaStatelessExecutor.cs
+++ b/LLama/LLamaStatelessExecutor.cs
@@ -126,7 +126,9 @@ namespace LLama
                 _draftParams.CtxOther = Context.NativeHandle.DangerousGetHandle();
             }
 
-            LLamaWeights activeDraftWeights = _useMtp ? _weights : (_draftWeights ?? _weights);
+            // Allow separate draft models to be used alongside MTP routing for models like Gemma 4
+            LLamaWeights activeDraftWeights = _draftWeights ?? _weights;
+
             using var draftContext = (_draftTokens > 0)
                 ? activeDraftWeights.CreateContext(_draftParams!, _logger)
                 : null;

--- a/LLama/LLamaStatelessExecutor.cs
+++ b/LLama/LLamaStatelessExecutor.cs
@@ -24,6 +24,29 @@ namespace LLama
         private readonly ILogger? _logger;
         private readonly LLamaBatch _batch;
 
+        #region speculative
+        private readonly LLamaWeights? _draftWeights;
+        private readonly IContextParams? _draftParams;
+        private readonly int _draftTokens;
+        private readonly bool _useMtp;
+        /// <summary>
+        /// The total number of draft tokens proposed by the draft model (or MTP heads) during the lifetime of this executor.
+        /// </summary>
+        public int TotalDraftTokensProposed { get; private set; }
+        /// <summary>
+        /// The total number of proposed draft tokens that were successfully verified and accepted by the target model. 
+        /// <para>Note: This metric strictly counts accepted drafts and excludes the standard base token sampled during the verification phase.</para>
+        /// </summary>
+        public int TotalDraftTokensAccepted { get; private set; }
+        /// <summary>
+        /// The ratio of accepted draft tokens to proposed draft tokens (ranging from 0.0 to 1.0). 
+        /// <para>A higher acceptance rate (e.g., > 0.4) generally indicates a more accurate draft model and a higher potential for generation speedups, depending on hardware memory bandwidth bottlenecks.</para>
+        /// </summary>
+        public double AcceptanceRate => TotalDraftTokensProposed == 0
+            ? 0.0
+            : (double)TotalDraftTokensAccepted / TotalDraftTokensProposed;
+        #endregion
+
         /// <inheritdoc />
         public bool IsMultiModal => false;
 
@@ -42,24 +65,40 @@ namespace LLama
         /// If true, applies the default template to the prompt as defined in the rules for <a href="https://github.com/ggerganov/llama.cpp/wiki/Templates-supported-by-llama_chat_apply_template">llama_chat_apply_template</a> template.  
         /// </summary>
         public bool ApplyTemplate { get; init; }
-        
+
         /// <summary>
         /// The system message to use with the prompt. Only used when <see cref="ApplyTemplate" /> is true.
         /// </summary>
         public string? SystemMessage { get; init; }
 
-        
         /// <summary>
-        /// Create a new stateless executor which will use the given model
+        /// Creates a new stateless executor for inference. Supports Standard, Dual-Model Speculative, and MTP (Multi-Token Prediction) modes.
+        /// <para><b>Dual-Model Speculation:</b> If using two different models, the target and draft models must share the exact same tokenizer architecture and vocabulary size (e.g., Llama 3.1 8B + 1B). A mismatch will cause cache desynchronization crashes.</para>
+        /// <para><b>Performance Note:</b> For speculative decoding to yield a speedup, both models (or the full MTP model) must fit entirely within GPU VRAM, and the target model should be large enough (e.g., 8B+) to be memory-bandwidth bound.</para>
         /// </summary>
-        /// <param name="weights"></param>
-        /// <param name="params"></param>
-        /// <param name="logger"></param>
-        public StatelessExecutor(LLamaWeights weights, IContextParams @params, ILogger? logger = null)
+        /// <param name="weights">The weights of the primary target model.</param>
+        /// <param name="params">The context parameters for the primary target model.</param>
+        /// <param name="draftWeights">The weights of the draft model. <br/><b>Important:</b> In MTP mode, this parameter is ignored and the executor internally re-uses the target weights for the draft context. Therefore, it may be <c>null</c> for MTP.</param>
+        /// <param name="draftParams">The context parameters for the draft model. In MTP mode, ensure the <c>ContextType</c> property is explicitly set to <c>LLamaContextType.Mtp</c>.</param>
+        /// <param name="draftTokens">The budget of draft tokens to propose per burst. Keep this modest (e.g., 2-4 for Dual-Model) or match the exact number of projection heads for MTP models to prevent wasted compute.</param>
+        /// <param name="useMtp">Set to <c>true</c> to enable Multi-Token Prediction (Self-Speculation) for supported models (e.g., DeepSeek-R1, Qwen3.5-MTP). Requires <c>LoadMtp = true</c> in the target model parameters.</param>
+        /// <param name="logger">An optional logger instance.</param>
+        public StatelessExecutor(
+            LLamaWeights weights,
+            IContextParams @params,
+            LLamaWeights? draftWeights = null,
+            IContextParams? draftParams = null,
+            int draftTokens = 0,
+            bool useMtp = false,
+            ILogger? logger = null)
         {
-            Embeds = [ ];
+            Embeds = [];
             _weights = weights;
             _params = @params;
+            _draftWeights = draftWeights;
+            _draftParams = draftParams ?? @params;
+            _draftTokens = draftTokens;
+            _useMtp = useMtp;
             _logger = logger;
             _batch = new LLamaBatch();
 
@@ -78,6 +117,24 @@ namespace LLama
             // Create an inference context which will be disposed when this method exits
             using var context = _weights.CreateContext(_params, _logger);
             Context = context;
+
+            #region speculative
+            if (_draftTokens > 0 && _useMtp && _draftParams != null)
+            {
+                // Inject the target context's memory pointer into the draft context!
+                // This allows the native MTP projection head to read the target's hidden states.
+                _draftParams.CtxOther = Context.NativeHandle.DangerousGetHandle();
+            }
+
+            LLamaWeights activeDraftWeights = _useMtp ? _weights : (_draftWeights ?? _weights);
+            using var draftContext = (_draftTokens > 0)
+                ? activeDraftWeights.CreateContext(_draftParams!, _logger)
+                : null;
+
+            using var specDecoder = (draftContext != null)
+                ? new LLama.Speculative.SpeculativeDecoder(Context.NativeHandle, draftContext.NativeHandle, _draftTokens, _useMtp)
+                : null;
+            #endregion
 
             // Reset the sampling pipeline (if there is one)
             inferenceParams?.SamplingPipeline.Reset();
@@ -120,9 +177,124 @@ namespace LLama
             if (r != DecodeResult.Ok)
                 throw new LLamaDecodeError(r);
 
+            // Sync the Draft Model's KV cache with the prompt so it aligns with the Target Model
+            if (draftContext != null && !_useMtp)
+            {
+                var draftBatch = new LLamaBatch();
+                await draftContext.DecodeAsync(tokens, LLamaSeqId.Zero, draftBatch, 0);
+            }
+
             // Begin loop, evaluating one token at a time
             var maxTokens = inferenceParams.MaxTokens < 0 ? int.MaxValue : inferenceParams.MaxTokens;
-            for(var i = 0; i < maxTokens && !cancellationToken.IsCancellationRequested; i++)
+
+            #region speculative
+            int generatedCount = 0;
+            if (specDecoder != null)
+            {
+                // Kickstart the sequence by manually sampling the first token from the prompt's logits
+                var id = inferenceParams.SamplingPipeline.Sample(Context.NativeHandle, _batch.TokenCount - 1);
+                decoder.Add(id);
+                var decodedStr = decoder.Read();
+                yield return decodedStr;
+                generatedCount++;
+                all_tokens.Add(id);
+
+                _batch.Clear();
+                _batch.Add(id, n_past++, LLamaSeqId.Zero, true);
+
+                TotalDraftTokensProposed = 0;
+                TotalDraftTokensAccepted = 0;
+
+                while (generatedCount < maxTokens && !cancellationToken.IsCancellationRequested)
+                {
+                    // Boundary check
+                    if (n_past >= Context.ContextSize)
+                    {
+                        if (inferenceParams.OverflowStrategy == ContextOverflowStrategy.ThrowException) throw new ContextOverflowException();
+                        _logger?.LogWarning("Context size reached during speculative decoding. Stopping generation.");
+                        break;
+                    }
+
+                    var results = specDecoder.Decode(_batch);
+                    _batch.Clear();
+
+                    int rawAcceptedCount = (results.Length > 0) ? results[0].count : 0;
+
+                    // The native engine returns (Drafts Accepted + 1 Target Token). 
+                    // We subtract 1 to get the true drafts, and clamp it between 0 and our draft budget.
+                    int trueDraftsAccepted = 0;
+                    if (rawAcceptedCount > 0)
+                    {
+                        trueDraftsAccepted = Math.Min(_draftTokens, Math.Max(0, rawAcceptedCount - 1));
+                    }
+
+                    // Track metrics
+                    TotalDraftTokensProposed += _draftTokens;
+                    TotalDraftTokensAccepted += trueDraftsAccepted;
+
+                    // Keep using rawAcceptedCount for the loop generation logic below!
+                    int acceptedCount = rawAcceptedCount;
+
+                    if (acceptedCount > 0)
+                    {
+                        var acceptedTokens = results[0].tokens.Take(acceptedCount).ToArray();
+                        bool shouldStop = false;
+
+                        foreach (var rawToken in acceptedTokens)
+                        {
+                            var token = (LLamaToken)rawToken;
+                            if (token.IsEndOfGeneration(_weights.Vocab))
+                            {
+                                shouldStop = true;
+                                break;
+                            }
+
+                            decoder.Add(token);
+                            var decoded = decoder.Read();
+                            yield return decoded;
+                            generatedCount++;
+
+                            // Keep our context-shifting tracker accurate!
+                            all_tokens.Add(token);
+
+                            if (antiprocessor.Add(decoded))
+                            {
+                                shouldStop = true;
+                                break;
+                            }
+                        }
+
+                        if (shouldStop || generatedCount >= maxTokens) break;
+
+                        // Advance C# tracking by the exact number of accepted drafts
+                        n_past += acceptedCount;
+
+                        // Feed the LAST accepted token back at its native position to match the C++ API logic
+                        _batch.Add((LLamaToken)acceptedTokens[^1], n_past - 1, LLamaSeqId.Zero, true);
+                    }
+                    else
+                    {
+                        // 0 Drafts accepted. Sample the next token manually using the updated native logits (-1)
+                        var nextId = inferenceParams.SamplingPipeline.Sample(Context.NativeHandle, -1);
+
+                        if (nextId.IsEndOfGeneration(_weights.Vocab)) break;
+
+                        decoder.Add(nextId);
+                        var dec = decoder.Read();
+                        yield return dec;
+                        generatedCount++;
+                        all_tokens.Add(nextId);
+
+                        if (antiprocessor.Add(dec)) break;
+
+                        _batch.Add(nextId, n_past++, LLamaSeqId.Zero, true);
+                    }
+                }
+                yield break;
+            }
+            #endregion
+
+            for (var i = 0; i < maxTokens && !cancellationToken.IsCancellationRequested; i++)
             {
                 // Sample with the pipeline
                 var id = inferenceParams.SamplingPipeline.Sample(Context.NativeHandle, _batch.TokenCount - 1);

--- a/LLama/Native/LLamaContextParams.cs
+++ b/LLama/Native/LLamaContextParams.cs
@@ -49,7 +49,12 @@ namespace LLama.Native
         /// max outputs in a ubatch (0 = n_batch)
         /// </summary>
         public uint n_outputs_max;
-        
+
+        /// <summary>
+        /// max outputs per sequence (0 = n_outputs_max)
+        /// </summary>
+        public uint n_outputs_max_per_seq;
+
         /// <summary>
         /// number of threads to use for generation
         /// </summary>

--- a/LLama/Native/NativeApi.Mtmd.cs
+++ b/LLama/Native/NativeApi.Mtmd.cs
@@ -17,6 +17,7 @@ public static partial class NativeApi
     internal struct mtmd_context_params
     {
         [MarshalAs(UnmanagedType.I1)] public bool use_gpu;
+        public IntPtr device;
         [MarshalAs(UnmanagedType.I1)] public bool print_timings;
         public int n_threads;
         public IntPtr image_marker;

--- a/LLama/Native/NativeApi.Speculative.cs
+++ b/LLama/Native/NativeApi.Speculative.cs
@@ -1,0 +1,95 @@
+using LLama.Speculative;
+using System;
+
+namespace LLama.Native
+{
+    public static partial class NativeApi
+    {
+        /// <summary>
+        /// Configuration parameters for initializing the native speculative decoding engine.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        public struct LlamaSpeculativeParams
+        {
+            /// <summary>
+            /// The maximum number of draft tokens to propose per speculative burst.
+            /// <para>For Draft-Simple models, a modest budget (e.g., 2-5) is recommended. For MTP models, this must match the available projection heads in the model's metadata.</para>
+            /// </summary>
+            public int n_draft;
+
+            /// <summary>
+            /// The maximum number of total context predictions to allocate. 
+            /// </summary>
+            public int n_predict;
+
+            /// <summary>
+            /// Determines the architectural routing for the speculative engine.
+            /// <para>If <c>false</c> (Draft-Simple), standard autoregressive drafting is used. If <c>true</c> (MTP), the engine bypasses standard evaluation and explicitly routes target hidden states (<c>h_row</c>) into the draft context's projection heads.</para>
+            /// </summary>
+            [MarshalAs(UnmanagedType.I1)]
+            public bool is_mtp;
+        }
+
+        /// <summary>
+        /// Contains the verification results for a single sequence after a speculative decode pass.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        public struct LlamaSpeculativeResult
+        {
+            /// <summary>
+            /// The native sequence identifier (<c>llama_seq_id</c>) these results map to.
+            /// </summary>
+            public int seq_id;
+
+            /// <summary>
+            /// The total number of tokens successfully evaluated and accepted during this burst.
+            /// <para><b>Important:</b> This count includes BOTH the accepted draft tokens AND the 1 base target token sampled at the point of divergence. For example, if 3 drafts are accepted, this returns 4.</para>
+            /// </summary>
+            public int count;
+
+            /// <summary>
+            /// A fixed-size array holding the raw accepted token IDs. Only the first <see cref="count"/> elements are valid.
+            /// </summary>
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
+            public int[] tokens;
+        }
+
+        /// <summary>
+        /// Initializes a new native speculative execution context that manages draft verification, M-RoPE safe cache rollbacks, and sequence alignment.
+        /// </summary>
+        /// <param name="ctx_tgt">A pointer to the primary target model's <c>llama_context</c>.</param>
+        /// <param name="ctx_dft">A pointer to the draft model's <c>llama_context</c> (or the self-drafting MTP context).</param>
+        /// <param name="sampler">A pointer to the native sampler chain to use for target verification. To guarantee mathematical correctness during evaluation, this should be a greedy sampler.</param>
+        /// <param name="parameters">The configuration struct defining draft budgets and MTP modes.</param>
+        /// <returns>An opaque native pointer to the <c>llama_speculative_context</c> instance.</returns>
+        [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr llama_speculative_init(
+            IntPtr ctx_tgt,
+            IntPtr ctx_dft,
+            IntPtr sampler,
+            ref LlamaSpeculativeParams parameters);
+
+        /// <summary>
+        /// Safely destroys the speculative context and frees associated native memory allocations.
+        /// </summary>
+        /// <param name="spec_ctx">The opaque native pointer to the <c>llama_speculative_context</c> instance to destroy.</param>
+        [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void llama_speculative_free(IntPtr spec_ctx);
+
+        /// <summary>
+        /// Executes a complete multi-sequence speculative pipeline (Sync, Draft, Verify, and Rollback) in a single native API call.
+        /// <para>For rejected draft sequences, this automatically purges invalid KV cache entries and executes an unconditional byte-level state rollback to protect hybrid/RNN architectures from <c>X &lt; Y</c> positional collision crashes.</para>
+        /// </summary>
+        /// <param name="spec_ctx">A safe handle wrapping the initialized speculative context.</param>
+        /// <param name="batch">A reference to the current batch containing the prompt or recent inputs.</param>
+        /// <param name="results">A pre-allocated buffer array to receive the evaluation outputs. The array length must be equal to or greater than <paramref name="max_results"/>.</param>
+        /// <param name="max_results">The maximum number of sequence results to write into the <paramref name="results"/> array (usually matches the batch's active sequence count).</param>
+        /// <returns>The number of populated <see cref="LlamaSpeculativeResult"/> structs written to the array.</returns>
+        [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int llama_speculative_decode(
+            SafeLLamaSpeculativeContextHandle spec_ctx,
+            ref LLamaNativeBatch batch,
+            [Out, MarshalAs(UnmanagedType.LPArray)] LlamaSpeculativeResult[] results,
+            int max_results);
+    }
+}

--- a/LLama/Native/SafeLLamaSpeculativeContextHandle.cs
+++ b/LLama/Native/SafeLLamaSpeculativeContextHandle.cs
@@ -1,0 +1,32 @@
+using System;
+using Microsoft.Win32.SafeHandles;
+using LLama.Native;
+
+namespace LLama.Speculative
+{
+    /// <summary>
+    /// A safe handle that securely wraps the unmanaged native pointer for a <c>llama_speculative_context</c>.
+    /// <para>This class guarantees that the native memory allocated by the speculative engine is safely freed when the object is disposed or finalized.</para>
+    /// </summary>
+    public sealed class SafeLLamaSpeculativeContextHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SafeLLamaSpeculativeContextHandle"/> class.
+        /// </summary>
+        /// <param name="handle">The unmanaged <c>IntPtr</c> returned by <c>llama_speculative_init</c>.</param>
+        public SafeLLamaSpeculativeContextHandle(IntPtr handle) : base(true)
+        {
+            SetHandle(handle);
+        }
+
+        /// <summary>
+        /// Safely releases the unmanaged resources associated with the speculative context.
+        /// </summary>
+        /// <returns><c>true</c> if the handle was released successfully.</returns>
+        protected override bool ReleaseHandle()
+        {
+            NativeApi.llama_speculative_free(handle);
+            return true;
+        }
+    }
+}

--- a/LLama/SpeculativeDecoder.cs
+++ b/LLama/SpeculativeDecoder.cs
@@ -1,0 +1,104 @@
+using System;
+using LLama.Native;
+using LLama.Exceptions;
+
+namespace LLama.Speculative
+{
+    /// <summary>
+    /// A managed wrapper for the native speculative decoding engine.
+    /// <para>This class orchestrates the synchronization between a target context and a draft context (or MTP projection heads). It handles burst generation, native mathematical verification, and automated KV cache rollbacks to accelerate inference.</para>
+    /// </summary>
+    public sealed class SpeculativeDecoder : IDisposable
+    {
+        private readonly SafeLLamaSpeculativeContextHandle _specHandle;
+        private readonly SafeLLamaSamplerChainHandle _sampler;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpeculativeDecoder"/> class.
+        /// <para>This wrapper safely orchestrates the native speculative verification loop, managing target evaluations, draft proposals, and state rollbacks.</para>
+        /// </summary>
+        /// <param name="targetContext">A safe handle to the primary target model's context used for verifying draft tokens.</param>
+        /// <param name="draftContext">A safe handle to the secondary context used for generating draft tokens. In MTP mode, this represents the target model's MTP projection heads.</param>
+        /// <param name="draftTokens">The maximum number of draft tokens to propose per speculative burst.</param>
+        /// <param name="useMtp">Set to <c>true</c> to enable Multi-Token Prediction (Self-Speculation) routing, bypassing standard draft evaluation.</param>
+        /// <exception cref="RuntimeError">Thrown if the underlying native speculative context fails to initialize.</exception>
+        public SpeculativeDecoder(
+             SafeLLamaContextHandle targetContext,
+             SafeLLamaContextHandle draftContext,
+             int draftTokens = 16,
+             bool useMtp = false)
+        {
+            // Null guard to catch context creation failures gracefully
+            if (targetContext.DangerousGetHandle() == IntPtr.Zero || draftContext.DangerousGetHandle() == IntPtr.Zero)
+                throw new RuntimeError("Cannot initialize SpeculativeDecoder: Context pointer is null. llama_init_from_model failed.");
+
+            var samplerParams = LLamaSamplerChainParams.Default();
+            _sampler = SafeLLamaSamplerChainHandle.Create(samplerParams);
+            _sampler.AddGreedySampler();
+
+            var param = new NativeApi.LlamaSpeculativeParams
+            {
+                n_draft = draftTokens,
+                n_predict = -1,
+                is_mtp = useMtp,
+            };
+
+            IntPtr rawSpec = NativeApi.llama_speculative_init(
+                targetContext.DangerousGetHandle(),
+                draftContext.DangerousGetHandle(),
+                _sampler.DangerousGetHandle(),
+                ref param
+            );
+
+            if (rawSpec == IntPtr.Zero)
+            {
+                _sampler.Dispose();
+                throw new RuntimeError("Failed to initialize native llama_speculative_context.");
+            }
+
+            _specHandle = new SafeLLamaSpeculativeContextHandle(rawSpec);
+        }
+
+        /// <summary>
+        /// Executes a complete speculative decoding pipeline (Draft, Verify, and Rollback) for the provided batch.
+        /// <para>This method natively evaluates the draft tokens against the target model. It automatically purges rejected tokens from the KV cache and handles state rollbacks to preserve mathematical consistency.</para>
+        /// </summary>
+        /// <param name="batch">The current batch of tokens to evaluate and use as the base for speculative drafting.</param>
+        /// <param name="maxSequences">The maximum number of sequence results to allocate memory for and process. Defaults to 128.</param>
+        /// <returns>An array of <see cref="NativeApi.LlamaSpeculativeResult"/> structs containing the accepted tokens and verification counts for each active sequence.</returns>
+        public NativeApi.LlamaSpeculativeResult[] Decode(LLamaBatch batch, int maxSequences = 128)
+        {
+            var resultsBuffer = new NativeApi.LlamaSpeculativeResult[maxSequences];
+
+            using (var pin = batch.ToNativeBatch(out var nativeBatch))
+            {
+                int count = NativeApi.llama_speculative_decode(
+                    _specHandle,
+                    ref nativeBatch,
+                    resultsBuffer,
+                    maxSequences);
+
+                // If native API throws a native error
+                if (count < 0)
+                    throw new LLamaDecodeError((DecodeResult)count);
+
+                // If it evaluated successfully but produced no speculative tokens (e.g., Prompt phase)
+                if (count == 0)
+                    return Array.Empty<NativeApi.LlamaSpeculativeResult>();
+
+                var finalResults = new NativeApi.LlamaSpeculativeResult[count];
+                Array.Copy(resultsBuffer, finalResults, count);
+                return finalResults;
+            }
+        }
+
+        /// <summary>
+        /// Disposes the speculative decoder, safely releasing the underlying unmanaged native context and its allocated memory.
+        /// </summary>
+        public void Dispose()
+        {
+            _specHandle?.Dispose();
+            _sampler?.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
> ⚠️ **DEPENDENCY NOTICE:** This Pull Request relies on new native C APIs introduced in the companion `llama.cpp` PR [feat: Expose Multi-Sequence Speculative Decoding & MTP to Public C API- #27788](https://github.com/ggml-org/llama.cpp/pull/27788). It **will not work** with the standard `llama.cpp` binaries currently shipped in LLamaSharp. To test this PR, you must compile and link the modified `llama.cpp` binaries from the upstream PR.

#### Summary

This PR adds native managed support for Speculative Decoding (Draft-Simple) and Multi-Token Prediction (MTP). It integrates seamlessly into both `StatelessExecutor` and `BatchedExecutor`, allowing users to achieve significant Tokens-Per-Second (TPS) speedups with a single boolean parameter while preserving the existing `IAsyncEnumerable` streaming API  (cc @martindevans).

#### Key Architectural Changes

* **Native Bindings (`NativeApiSpeculative.cs`):** Added complete P/Invoke definitions for the new `llama_speculative_*` API, wrapping the native context in a robust `SafeSpeculativeContextHandle`.
* **The `SpeculativeDecoder` Wrapper:** Safely initializes the native speculative context and automatically mounts a native greedy sampler to guarantee mathematical verification constraints.
* **`StatelessExecutor` Integration:** Updated constructors to accept optional draft weights or a `useMtp` flag. Transparently intercepts token generation to route through the `SpeculativeDecoder` using the standard `StreamingTokenDecoder`.
* **`BatchedExecutor` Multiplexing:** Introduced a `Queue<LLamaToken> _speculativeTokens` to the `Conversation` multiplexer. Because `BatchedExecutor` natively relies on C# to sample tokens *after* logits are calculated, the `Conversation.Sample()` method was overridden to safely intercept and dequeue natively pre-sampled speculative tokens.
* **KV Deduplication (`_speculativeTokensToIgnore`):** Automatically tracks and ignores user prompt inputs for tokens that the C++ engine has already evaluated and cached during a speculative burst, preventing cache duplication.
* **Model Parameter Mapping:** Exposed `LoadMtp` in `ModelParams` to explicitly command the backend to load `nextn` tensors into VRAM (strictly required for DeepSeek-R1 / Qwen MTP execution).

#### Validation

* Added `SpeculativeDecodingTests.cs` to `LLama.Unittest` utilizing `Constants.GenerativeModelPath`.
* Added a runnable `SpeculativeBenchmark` class to isolate and measure Tokens-Per-Second (TPS) gains across Baseline, Dual-Model Speculation, and MTP strategies.
* **Cross-Ecosystem Testing:** *(Note: This PR is paired with a companion PR submitted to `llama.cpp` [feat: Expose Multi-Sequence Speculative Decoding & MTP to Public C API- #27788](https://github.com/ggml-org/llama.cpp/pull/27788) which implements and exposes the standalone native C API. The full architecture has been rigorously tested across both boundaries, from native C++ state-rollback CI validation to managed C# asynchronous streaming, batch queue multiplexing, and interactive benchmarking.)*

# ANNEX: Model Selection & Evaluation

## 1. Model Compatibility & Selection Rules

* **Dual-Model Speculation:** The target and draft models must share the exact same tokenizer architecture and vocabulary size to prevent immediate cache desynchronization crashes. Crucially, **the larger the target model and the smaller/faster the draft model, the higher the resulting speedup**.

* **Multi-Token Prediction (MTP):** This requires a single model with pre-trained speculative projection layers (`nextn_predict_layers >= 1`). **The more draft heads the model has, the higher the potential speedup**, as it can verify more tokens per native API call without context-switching overhead. The draft budget must match the available heads.

---

## 2. Real-World Benchmark Examples

### Draft-Simple

Pairing **Meta-Llama-3-8B-Instruct-Q8_0.gguf** (Target) with **Llama-3.2-1B-Instruct-Q4_0.gguf** (Draft) yielded a **1.26x speedup (+25.7%)**. Even on a fast GPU, the 1B draft model was lightweight enough to outpace the compute overhead of the 8B target.

### MTP Speculation

Running **Qwen3.5-4B-MTP-Q4_K_M.gguf** (1 MTP head) resulted in a **0.47x slowdown (-53.2%)**. Because the 4B base model is computed incredibly fast on high-end hardware, the API overhead and CUDA graph launch latency of evaluating the MTP head completely overshadowed the memory bandwidth savings. To achieve a speedup instead, you must use a much larger model (like 14B or 32B) where **the GPU's memory bandwidth becomes a true bottleneck as it fetches massive weight matrices from VRAM for every single token**. Alternatively, using an MTP model with multiple prediction heads allows you to verify several tokens in a single API roundtrip, making the overhead worthwhile.

### Multi-Token Prediction: Gemma 4 (Split-Weight MTP-4)

Unlike bundled MTP architectures where projection layers reside in the same weight file, Gemma 4 separates its multi-token prediction heads into a standalone assistant checkpoint (`gemma4-assistant`). This benchmark demonstrates **MTP-4 self-speculation** where 4 future tokens are drafted simultaneously via auxiliary projection layers using the target model's hidden states (`CtxOther`), verified in a single batched verification pass.

#### **Test Configuration**
* **Hardware:** NVIDIA GeForce RTX 4070 Ti (12GB VRAM)
* **Target Model:** `gemma-4-12b-it-UD-Q4_K_XL.gguf` (11.91B params, Q4_K_M, ~6.85 GiB)
* **Draft Model:** `mtp-gemma-4-12b-it-F16.gguf` (`gemma4-assistant`, 422.86M params, F16, ~806 MiB)
* **MTP Depth / Draft Budget:** 4 tokens per burst (`nextn_predict_layers = 4`)
* **Context / Max Tokens:** 4096 context / 256 generated tokens
* **VRAM Offload:** 100% GPU Offloaded (Target + Draft)

---

#### **Benchmark Results**

| Strategy | Tokens | Time (s) | Tokens/sec | Draft Accept % | Speedup |
| :--- | :---: | :---: | :---: | :---: | :---: |
| **Standard Autoregressive** | 256 | 5.06 s | 50.64 tps | N/A | Baseline |
| **MTP Speculative (MTP-4)** | 259 | 4.34 s | 59.69 tps | **100.0%** | **1.18x (+17.9%)** |

---

#### **Key Architectural Takeaways**
* **Stateless Multi-Token Drafting:** Freezing the draft sequence position (`current_pos`) in `llama-speculative.cpp` allows MTP projection layers to evaluate continuous 4-token draft bursts without triggering strict KV cache continuity gap aborts (`Y = X + 1`).
* **Memory-Mapped Hidden States:** Pointers passed via `CtxOther` permit the standalone 423M assistant model to directly sample hidden embeddings (`h_row`) from the primary 12B target context without duplicate prompt prefilling.
* **Throughput Scaling:** Verifying 4 drafted tokens per burst yielded an immediate **+17.9% net speedup** on a 12B target model while requiring only ~800 MiB of auxiliary VRAM for the draft checkpoint.

## 2.A Benchmark Report: Edge Hardware Behavior & Draft Budget Tuning

As part of the cross-ecosystem validation for native Speculative Decoding (Draft-Simple) integration, we conducted extensive hardware benchmarking to map the performance thresholds of the new API.

The following benchmarks demonstrate how the new native verification loop performs on a highly constrained edge setup where the target model severely bottlenecks the CPU.

**Hardware & Model Configuration:**
*   **Hardware:** Hybrid Edge Setup (RTX 4070 Ti + Quadro P2200 + System RAM spillover).
*   **Target Model:** `Qwen3.6-35B-A3B-UD-Q5_K_M.gguf` (Requires CPU offloading).
*   **Draft Model:** `Qwen3.5-0.8B-UD-Q5_K_XL.gguf` (Fits entirely in VRAM).
*   **Constraint:** The target model is severely bound by system RAM bandwidth during evaluation.

### The "Goldilocks Zone" (Optimal Performance)

By keeping the tiny draft model entirely resident on the GPU and relying on the new API's batch verification, we successfully bypassed the PCIe/System RAM bottleneck, crossing the real-time threshold.

| Strategy | Draft Budget | Tokens/Sec | Accept % | Speedup |
| :--- | :--- | :--- | :--- | :--- |
| Standard Autoregressive | N/A | 8.18 | N/A | Baseline |
| Draft-Simple Speculative | **6 tokens** | **16.94** | **100.0%** | **2.07x (+107.1%)** |

**Observation:** A draft budget of 6 tokens represents the maximum limit this hardware can batch-verify efficiently *before* the 0.8B draft model begins failing strict sequential prefix validation.

### The Penalty of Over-Drafting (Validation Resilience)

To test the engine's failure-recovery mechanisms and batch-processing limits, we intentionally pushed the draft budget past the model's predictive capabilities.

| Strategy | Draft Budget | Tokens/Sec | Accept % | Speedup |
| :--- | :--- | :--- | :--- | :--- |
| Standard Autoregressive | N/A | 9.43 | N/A | Baseline |
| Draft-Simple Speculative | **8 tokens** | **16.67** | **22.6%** | **1.77x (+76.8%)** |

**Observation:** 
1.  **Sequential Domino Effect:** At an 8-token depth, the drafter's accuracy collapses to 22.6%. The target model frequently rejects the later tokens, triggering the `llama-speculative.cpp` cache rollback mechanisms perfectly as designed.
2.  **Bandwidth Economics:** Despite throwing away nearly 80% of the drafted tokens, the net throughput (16.67 t/s) remained nearly identical to the optimal run. This confirms that on CPU-offloaded workloads, the time cost to evaluate 1 token vs 8 tokens in a single `llama_decode` batch is virtually identical. 

### Under-Drafting

At a conservative budget of 4 tokens, the drafter maintained 100% acceptance but only achieved **13.27 tps (1.68x speedup)**, confirming that setting the budget too low leaves available batch-verification compute unutilized.

### Summary for Implementers

The new public C API successfully enables massive throughput gains (>2x) on bandwidth-constrained hardware. For implementers exposing this via `LLamaSharp`, the ideal `Draft Budget` (burst size) for Draft-Simple setups on consumer hardware consistently sits between **5 and 6 tokens**.

---

## 3. Hardware & Workload Dynamics

* **100% VRAM Offloading:** Both models (or the full MTP model) must fit entirely within GPU VRAM. If layers spill over to the CPU, parallel batch verification turns into serialized matrix multiplication, causing a severe net slowdown.

* **The Size Threshold:** Speculative decoding is an optimization for memory-bandwidth-bound workloads. Speedups reliably appear on mid-to-large models (8B, 14B, 32B, 70B) where reading massive weight matrices per token is the actual bottleneck.

* **Task Predictability:** Deterministic tasks (code completion, JSON extraction) achieve high draft acceptance rates (>70%), maximizing throughput. Creative writing and high-temperature sampling trigger frequent draft rejections, wasting compute cycles.

---

## 4. Quick Selection & Viability Matrix

| Strategy | Required Model Setup | Minimum Target Size | Ideal Workload | Expected Result |
| --- | --- | --- | --- | --- |
| **Draft-Simple** | Target + Draft (Same Vocab & Family) | >= 8B (100% VRAM) | Code, JSON, Structured Tasks | **1.4x – 2.2x Speedup** |
| **Draft-Simple** | Target + Draft (Different Vocab) | Any | Any | **Immediate Crash** |
| **MTP** | Single Model (`nextn_predict_layers >= 1`) | >= 8B–14B (100% VRAM) | Low-Temperature / High-Confidence | **1.3x – 1.8x Speedup** |
| **Any Speculative** | Model partially offloaded to CPU | Any | Any | **Slowdown** |
| **Any Speculative** | Models <= 4B on High-End GPU | <= 4B (100% VRAM) | High-Entropy / Creative Prompts | **Slowdown** |

# ANNEX: Architectural Scope and Speculative Decoding Rationale

This public C API implementation in `llama-speculative.cpp` intentionally supports only **standard autoregressive drafting (`draft-simple`)** and **Multi-Token Prediction (`draft-mtp`)** . While `common/speculative.cpp` contains research and experimental implementations of several other speculative decoding methods , they have been excluded from the core public C API and foreign-function bindings (such as LLamaSharp) to preserve API stability, avoid brittle model coupling, and minimize runtime complexity.

---

## Evaluation of Excluded Experimental Methods

**Feature-Conditioned Draft Models: `draft-eagle3`, `draft-dflash`, `draft-dspark`**

*   **Tight Checkpoint Coupling:** Unlike standard speculation where any smaller model with a matching vocabulary can serve as a draft , these methods require custom-trained draft heads mapped to the exact hidden dimensions and layer indices of a specific base model . They are not universally portable across models.
*   **High Architectural & State Complexity:**
    *   `draft-eagle3` requires extracting hidden states from multiple target layers, running a separate encoder pass, and managing a "deferred boundary" to reconcile token-feature alignment across ubatch boundaries .
    *   `draft-dflash` and `draft-dspark` require non-causal attention toggles (`llama_set_causal_attn`), manual KV cache feature injection, and fixed-block noise generation with mask tokens .
*   **Memory Movement Overhead:** The continuous memory copying of multi-layer embeddings into intermediate staging buffers (`features_buf`) creates CPU/GPU bus contention , often diminishing the theoretical FLOP advantage on unified or consumer memory hardware.

**Prompt-Lookup and Heuristic Methods: `ngram-simple`, `ngram-map-k`, `ngram-map-k4v`, `ngram-mod`, `ngram-cache`**

*   **Lack of Semantic Generalization:** N-gram heuristics only reproduce verbatim token repetitions from the context . On open-ended generation, reasoning, or creative writing, predictive accuracy is poor, leading to immediate rejection and wasted verification cycles.
*   **Application-Level Routing Complexity:** Exposing N-gram engines in the public C API forces downstream callers and language bindings to implement guessing heuristics to determine whether a given request is "repetitive enough" for N-gram or requires a neural draft model. Furthermore, pushing these state-heavy mechanics across the P/Invoke boundary into managed C# code would introduce significant marshaling overhead and memory-management complexity.
*   **State Machine Bloat:** Incorporating hash tables, dynamic cache eviction algorithms, static cache file loaders, and occupancy-reset thresholds into the C API introduces substantial state-tracking overhead for a marginal, task-dependent benefit .

---

## Supported Architecture Matrix

| Speculative Method | Status in Public C API | Primary Rationale |
| :--- | :--- | :--- |
| **`draft-simple`** | **Supported**  | Universal compatibility; decoupled draft model; clean, standard batch decoding . |
| **`draft-mtp`** | **Supported**  | Native support for models with integrated prediction heads (DeepSeek, Qwen) without external draft checkpoints . |
| **`draft-eagle3`** | Excluded | High maintenance burden; requires deferred boundary bridging and multi-layer feature extraction . |
| **`draft-dflash`** | Excluded | Non-causal attention requirement; custom KV injection; requires specialized diffusion draft models . |
| **`draft-dspark`** | Excluded | Same architectural coupling as DFlash with additional Markov-head decoding logic . |
| **`ngram-simple`** | Excluded | Ineffective outside exact repetitions; forces application-layer heuristic routing . |
| **`ngram-map-k`** | Excluded | Hash map state management overhead in public C ABI . |
| **`ngram-map-k4v`** | Excluded | Specialized key-value lookup tables unnecessary for a general-purpose API . |
| **`ngram-mod`** | Excluded | Heuristic occupancy checks and streak-reset state machines belong in client code, not C ABI . |
| **`ngram-cache`** | Excluded | Requires disk I/O, cache persistence, and custom lookup formats . |

By constraining `llama-speculative.cpp` to `draft-simple` and `draft-mtp`, the API maintains an explicit, deterministic execution model: one predictable drafting phase, one target verification phase, and zero hidden heuristic branching .