### PR TITLE
Disable SSE4.2 in noavx native builds

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -27,8 +27,10 @@ jobs:
       fail-fast: true
       matrix:
         include:
+          # SSE4.2 stays on unless we disable it; that SIGILLs pre-Nehalem CPUs (#1422).
+          # -march=x86-64 stops gcc from emitting SSE4 via auto-vectorization.
           - build: 'noavx'
-            defines: '-DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF'
+            defines: '-DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF -DGGML_SSE42=OFF -DCMAKE_C_FLAGS=-march=x86-64 -DCMAKE_CXX_FLAGS=-march=x86-64'
             os: ubuntu-22.04
             arch: x64
           - build: 'avx2'
@@ -95,7 +97,7 @@ jobs:
       matrix:
         include:
           - build: 'noavx'
-            defines: '-DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF'
+            defines: '-DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF -DGGML_SSE42=OFF -DCMAKE_C_FLAGS=-march=x86-64 -DCMAKE_CXX_FLAGS=-march=x86-64'
           - build: 'avx2'
             defines: ''
           - build: 'avx'
@@ -160,7 +162,7 @@ jobs:
       matrix:
         include:
           - build: 'noavx'
-            defines: '-DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF'
+            defines: '-DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF -DGGML_SSE42=OFF'
           - build: 'avx2'
             defines: ''
           - build: 'avx'
@@ -535,7 +537,7 @@ jobs:
             defines: '-DCMAKE_OSX_ARCHITECTURES=x86_64 -DGGML_METAL=OFF -DGGML_AVX=ON -DGGML_AVX2=ON'
             targets: '--target ggml ggml-base ggml-cpu ggml-blas llama mtmd'
           - build: 'x64-rosetta2'
-            defines: '-DCMAKE_OSX_ARCHITECTURES=x86_64 -DGGML_METAL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF'
+            defines: '-DCMAKE_OSX_ARCHITECTURES=x86_64 -DGGML_METAL=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF -DGGML_SSE42=OFF -DCMAKE_C_FLAGS=-march=x86-64 -DCMAKE_CXX_FLAGS=-march=x86-64'
             targets: '--target ggml ggml-base ggml-cpu ggml-blas llama mtmd'
     env:
       MACOS_RPATH_DEFINE: "-DCMAKE_INSTALL_RPATH='@loader_path' -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -225,7 +225,9 @@ jobs:
         include:
           - build: 'arm64'
             defines: '-T ClangCL -DCMAKE_GENERATOR_PLATFORM=ARM64 -DGGML_NATIVE=OFF'
-    runs-on: windows-latest
+    # windows-latest is VS 18; ClangCL there rebuilds ggml-cpu with C17 off after a
+    # C17 PCH, so llama.dll is never produced. Pin VS 2022 like compile-cublas.
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -224,9 +224,8 @@ jobs:
       matrix:
         include:
           - build: 'arm64'
-            defines: '-T ClangCL -DCMAKE_GENERATOR_PLATFORM=ARM64 -DGGML_NATIVE=OFF'
-    # windows-latest is VS 18; ClangCL there rebuilds ggml-cpu with C17 off after a
-    # C17 PCH, so llama.dll is never produced. Pin VS 2022 like compile-cublas.
+            # ClangCL + CMake PCH disagrees on C17 for ggml-cpu, so llama.dll is never built.
+            defines: '-T ClangCL -DCMAKE_GENERATOR_PLATFORM=ARM64 -DGGML_NATIVE=OFF -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON'
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v6
@@ -242,6 +241,7 @@ jobs:
           cd build
           cmake .. ${{ env.COMMON_DEFINE }} ${{ matrix.defines }}
           cmake --build . --config Release -j ${env:NUMBER_OF_PROCESSORS} --target ggml ggml-base ggml-cpu llama mtmd
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           tree /f
 
       - name: Upload artifacts (llama)

--- a/LLama/Native/Load/NativeLibraryMetadata.cs
+++ b/LLama/Native/Load/NativeLibraryMetadata.cs
@@ -23,7 +23,7 @@ namespace LLama.Native
     public enum AvxLevel
     {
         /// <summary>
-        /// No AVX
+        /// No AVX or SSE4.2. For x86_64 CPUs that only provide SSSE3 / SSE2.
         /// </summary>
         None,
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -24,6 +24,22 @@ Generally, there are two possible cases for this problem:
 1. The native library (backend) you are using is not compatible with the LLamaSharp version. If you compiled the native library yourself, please make sure you have checkouted llama.cpp to the corresponding commit of LLamaSharp, which could be found at the bottom of README.
 2. The model file you are using is not compatible with the backend. If you are using a GGUF file downloaded from huggingface, please check its publishing time.
 
+### Illegal instruction (core dumped) on an older CPU
+
+`LLamaSharp.Backend.Cpu` ships several x86_64 binaries. The loader picks `noavx` when the CPU has no AVX. Those binaries must also be free of SSE4.2. A CPU that only has SSSE3 (no `sse4_1` / `sse4_2` in `lscpu`) will SIGILL if the `noavx` build still contains SSE4.2 kernels.
+
+Until a backend package built with `-DGGML_SSE42=OFF` is published, compile llama.cpp yourself and load it before any other LLamaSharp call:
+
+```bash
+cmake -B build -DGGML_NATIVE=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF -DGGML_SSE42=OFF -DCMAKE_C_FLAGS=-march=x86-64 -DCMAKE_CXX_FLAGS=-march=x86-64 -DBUILD_SHARED_LIBS=ON
+```
+
+```cs
+NativeLibraryConfig.All.WithLibrary("<path-to-libllama.so-or-llama.dll>", null);
+```
+
+You can also add `NativeLibraryConfig.All.WithLogCallback(...)` at startup to confirm which runtime folder was loaded (`noavx`, `avx`, `avx2`, ...).
+
 
 ## Why my model is generating output infinitely
 


### PR DESCRIPTION
## Summary

- The published `noavx` CPU backend still compiles with `-msse4.2`. ggml turns `GGML_SSE42` on for a normal (non-cross) compile even when `GGML_NATIVE=OFF`.
- That is an illegal instruction on CPUs that stop at SSSE3, which is the crash in #1422. `lscpu` there has no `avx`, `sse4_1`, or `sse4_2`.
- `noavx` jobs on Linux, musl, Windows, and the macOS x64 Rosetta build now pass `-DGGML_SSE42=OFF`. gcc/clang jobs also pin `-march=x86-64` so auto-vectorization cannot put SSE4 back in. MSVC only gets the CMake flag.

## Test plan

- Configure current llama.cpp with the old noavx flags. CMake prints `Adding CPU backend variant ggml-cpu: -msse4.2 GGML_SSE42`.
- Configure with the new flags. CMake prints an empty CPU variant and `GGML_SSE42=OFF`.
- `objdump` of `libggml-cpu.so`: old build contains `pblendvb` / `pinsrd` (SSE4.1). New build does not.
- After the next Update Binaries run and a new `LLamaSharp.Backend.Cpu` publish, #1422 should load without SIGILL. Until then the FAQ notes the self-compile path.


